### PR TITLE
Let's not report development errors to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,7 +2,7 @@ Sentry.init do |config|
   config.dsn = Rails.application.credentials.dig(:sentry, :dsn)
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
 
-  config.enabled_environments = %w[production staging development]
+  config.enabled_environments = %w[production staging]
 
   config.send_default_pii = false
 


### PR DESCRIPTION
enabled_environments on sentry's config included development, so every local error was being sent to Sentry. Let's limit it to production and staging lol.