### PR TITLE
Add leowilkin as codeowner for all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @leowilkin


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file assigning @leowilkin as code owner for the entire repo, so i'm automatically requested for review on all PRs.