### PR TITLE
Pause Airtable sync on failure and email the config owner

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -34,8 +34,19 @@ class Admin::DashboardController < Admin::BaseController
     authorize @event, :update?
 
     if @event.airtable_sync_configured?
+      # "Sync Now" is a deliberate retry, so it also lifts a pause left by an
+      # earlier failure — otherwise the scheduled job would skip this event and
+      # the button would look like it did nothing.
+      was_paused = @event.airtable_sync_paused?
+      @event.resume_airtable_sync!
       AirtableJobs::SyncAllJob.perform_later
-      redirect_to admin_event_integrations_path(@event), notice: "Airtable sync triggered. It will complete shortly."
+
+      notice = if was_paused
+        "Airtable sync resumed and triggered. It will complete shortly."
+      else
+        "Airtable sync triggered. It will complete shortly."
+      end
+      redirect_to admin_event_integrations_path(@event), notice: notice
     else
       redirect_to admin_event_integrations_path(@event), alert: "Airtable sync is not fully configured."
     end
@@ -104,6 +115,13 @@ class Admin::DashboardController < Admin::BaseController
     set_current_event(@event)
 
     if @event.update(integration_params)
+      if airtable_settings_saved?
+        # Whoever last touched the credentials is who we email if the sync
+        # later fails and pauses itself.
+        @event.update_column(:airtable_config_updated_by_id, current_user.id)
+        @event.resume_airtable_sync!
+      end
+
       if airtable_settings_saved? && @event.airtable_sync_configured?
         AirtableJobs::SyncAllJob.perform_later
         redirect_to admin_event_integrations_path(@event), notice: "Integration settings updated. Airtable sync started."
@@ -153,6 +171,9 @@ class Admin::DashboardController < Admin::BaseController
     @airtable_sync_error = current_event.airtable_sync_error
     @airtable_sync_error_at = current_event.airtable_sync_error_at
     @airtable_sync_stale = current_event.airtable_sync_stale?
+    @airtable_sync_paused = current_event.airtable_sync_paused?
+    @airtable_sync_paused_at = current_event.airtable_sync_paused_at
+    @airtable_config_owner = current_event.airtable_config_last_saved_by if @airtable_sync_paused
     @airtable_participant_count = current_event.participant_events.count if @airtable_sync_configured
   end
 

--- a/app/jobs/airtable_jobs/sync_all_job.rb
+++ b/app/jobs/airtable_jobs/sync_all_job.rb
@@ -7,21 +7,14 @@ module AirtableJobs
     # Client#initialize), and an unrescued error kills the run for every event
     # after it while recording nothing on the one that broke.
     def perform
-      events_with_sync_configured.find_each do |event|
+      Event.with_airtable_sync_active.find_each do |event|
         sync_event(event)
       rescue StandardError => e
-        report_failure(event, e)
+        handle_failure(event, e)
       end
     end
 
     private
-
-    def events_with_sync_configured
-      Event.where.not(airtable_sync_source_id: [ nil, "" ])
-           .where.not(airtable_sync_table_id: [ nil, "" ])
-           .where("config->>'airtable_api_key' IS NOT NULL")
-           .where("config->>'airtable_base_id' IS NOT NULL")
-    end
 
     def sync_event(event)
       service = Airtable::SyncService.new(event)
@@ -29,14 +22,39 @@ module AirtableJobs
       event.update_columns(airtable_synced_at: Time.current, airtable_sync_error: nil, airtable_sync_error_at: nil)
     end
 
-    # One event failing must not stop the rest of the run, but a rescue that only
-    # logs makes a permanently broken sync (stale ids, revoked token) look
-    # identical to a healthy one. Fingerprint per event so each broken event is
-    # its own Sentry issue that stays open until someone fixes the config.
-    def report_failure(event, error)
-      Rails.logger.error("[AirtableSyncAll] Event #{event.id}: #{error.message}")
-      event.update_columns(airtable_sync_error: error.message, airtable_sync_error_at: Time.current)
+    # One event failing must not stop the rest of the run. Pause this event's
+    # sync on the first failure and tell whoever last saved its credentials:
+    # every failure mode we've seen here (stale sync ids, revoked token, blank
+    # key) needs a human to fix the config, so re-running every 5 minutes only
+    # produces thousands of identical errors while nobody is told.
+    def handle_failure(event, error)
+      Rails.logger.error("[AirtableSyncAll] Paused event #{event.id}: #{error.message}")
+      event.pause_airtable_sync!(error.message)
 
+      recipient = notify_config_owner(event, error)
+      report_to_sentry(event, error, recipient)
+    end
+
+    # A broken mailer must not take the rest of the run down with it — this
+    # method is already running inside the loop's rescue.
+    def notify_config_owner(event, error)
+      recipient = event.airtable_config_last_saved_by
+      return nil if recipient&.email.blank?
+
+      AirtableMailer.sync_paused(
+        event: event,
+        recipient: recipient,
+        error_message: error.message
+      ).deliver_later
+
+      recipient
+    rescue StandardError => e
+      Rails.logger.error("[AirtableSyncAll] Could not notify owner of event #{event.id}: #{e.message}")
+      Sentry.capture_exception(e) if defined?(Sentry)
+      nil
+    end
+
+    def report_to_sentry(event, error, recipient)
       return unless defined?(Sentry)
 
       Sentry.capture_exception(
@@ -44,7 +62,8 @@ module AirtableJobs
         tags: {
           job: "airtable_sync_all",
           event_slug: event.slug,
-          airtable_status: error.respond_to?(:status) ? error.status : nil
+          airtable_status: error.respond_to?(:status) ? error.status : nil,
+          airtable_sync_paused: true
         },
         contexts: {
           airtable_sync: {
@@ -53,7 +72,9 @@ module AirtableJobs
             table_id: event.airtable_sync_table_id,
             sync_source_id: event.airtable_sync_source_id,
             base_id: event.airtable_base_id,
-            last_synced_at: event.airtable_synced_at&.iso8601
+            last_synced_at: event.airtable_synced_at&.iso8601,
+            paused_at: event.airtable_sync_paused_at&.iso8601,
+            notified: recipient&.email || "nobody (no known config owner)"
           }
         },
         fingerprint: fingerprint_for(event, error)

--- a/app/mailers/airtable_mailer.rb
+++ b/app/mailers/airtable_mailer.rb
@@ -1,0 +1,36 @@
+class AirtableMailer < ApplicationMailer
+  # Sent when the scheduled sync pauses an event's Airtable integration after a
+  # failure. It goes to whoever last saved the credentials because they're the
+  # only person who can fix them, and because a paused sync is otherwise
+  # invisible — Airtable keeps showing the last good snapshot indefinitely.
+  def sync_paused(event:, recipient:, error_message:)
+    @event = event
+    @user = recipient
+    @emailable = recipient
+    @error_message = error_message
+    @paused_at = event.airtable_sync_paused_at
+    @last_synced_at = event.airtable_synced_at
+    @first_name = recipient.name.presence&.split&.first || recipient.email.split("@").first
+    @integrations_url = Rails.application.routes.url_helpers.admin_event_integrations_url(
+      @event,
+      host: default_host,
+      protocol: default_protocol
+    )
+
+    mail(
+      to: recipient.email,
+      subject: "Airtable sync paused for #{@event.name}",
+      reply_to: "attend@hackclub.com"
+    )
+  end
+
+  private
+
+  def default_host
+    ENV.fetch("APP_HOST") { Rails.application.config.action_mailer.default_url_options[:host] || "attend.hackclub.com" }
+  end
+
+  def default_protocol
+    Rails.env.production? ? "https" : "http"
+  end
+end

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -60,7 +60,8 @@ class AuditLog < ApplicationRecord
     ticket_set_event: "set_event",
     ticket_set_subject: "set_subject",
     toggle_support_sms: "toggle_support_sms",
-    update_support_sms_numbers: "update_support_sms_numbers"
+    update_support_sms_numbers: "update_support_sms_numbers",
+    trigger_airtable_sync: "trigger_airtable_sync"
   }
 
   validates :record_type, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -77,6 +77,7 @@ class Event < ApplicationRecord
   has_many :tickets, dependent: :nullify
   has_one :rooming_plan, dependent: :destroy
   belongs_to :hotel_scan_context, class_name: "ScanContext", optional: true
+  belongs_to :airtable_config_updated_by, class_name: "User", optional: true
 
   # events.hotel_scan_context_id references scan_contexts, which are destroyed
   # before the event row is deleted — clear it first or the FK rejects the delete
@@ -264,6 +265,25 @@ class Event < ApplicationRecord
       airtable_sync_table_id.present?
   end
 
+  # The SQL counterpart of #airtable_sync_configured?, for the scheduled sync.
+  #
+  # Written as raw SQL on purpose. `where.not(airtable_sync_source_id: [nil, ""])`
+  # looks equivalent but isn't: `normalizes` above rewrites query values too, so
+  # the "" collapses to nil and the predicate degrades to `IS NOT NULL` — which
+  # matches every event that has an empty string stored (any event whose
+  # integrations form was ever saved blank). Those events then reach
+  # Airtable::Client, which raises on the blank key, once per event per run.
+  scope :with_airtable_sync_configured, -> {
+    where("NULLIF(BTRIM(events.airtable_sync_source_id), '') IS NOT NULL")
+      .where("NULLIF(BTRIM(events.airtable_sync_table_id), '') IS NOT NULL")
+      .where("NULLIF(BTRIM(events.config ->> 'airtable_api_key'), '') IS NOT NULL")
+      .where("NULLIF(BTRIM(events.config ->> 'airtable_base_id'), '') IS NOT NULL")
+  }
+
+  scope :with_airtable_sync_active, -> {
+    with_airtable_sync_configured.where(airtable_sync_paused_at: nil)
+  }
+
   # AirtableJobs::SyncAllJob runs every 5 minutes and only advances
   # airtable_synced_at on success, so anything older than this means the sync
   # has been failing — the job rescues per event, so nothing else surfaces it.
@@ -271,8 +291,44 @@ class Event < ApplicationRecord
 
   def airtable_sync_stale?
     return false unless airtable_sync_configured?
+    # A paused sync isn't drifting silently — it has its own explicit state, an
+    # error message, and an email already sent to whoever can fix it.
+    return false if airtable_sync_paused?
 
     airtable_synced_at.nil? || airtable_synced_at < AIRTABLE_SYNC_STALE_AFTER.ago
+  end
+
+  def airtable_sync_paused?
+    airtable_sync_paused_at.present?
+  end
+
+  # One failure stops the schedule. Retrying broken credentials every 5 minutes
+  # never fixes them; it just buries the real signal under thousands of
+  # identical errors. A human re-saving the config (or hitting "Sync Now") is
+  # the only thing that resumes it.
+  def pause_airtable_sync!(error_message)
+    update_columns(
+      airtable_sync_paused_at: Time.current,
+      airtable_sync_error: error_message,
+      airtable_sync_error_at: Time.current
+    )
+  end
+
+  def resume_airtable_sync!
+    update_columns(
+      airtable_sync_paused_at: nil,
+      airtable_sync_error: nil,
+      airtable_sync_error_at: nil
+    )
+  end
+
+  # Whoever last saved the Airtable credentials — the only person who can
+  # actually fix them, so the one we email when the sync pauses. Events
+  # configured before airtable_config_updated_by_id existed still have an audit
+  # trail (the integrations form writes an `update_integrations` log), so fall
+  # back to that rather than leaving them with nobody to notify.
+  def airtable_config_last_saved_by
+    airtable_config_updated_by || last_integrations_saver
   end
 
   def venue_coordinates
@@ -357,6 +413,13 @@ class Event < ApplicationRecord
 
   def generate_slug_from_name
     self.slug = name.downcase.gsub(/\s+/, "-").gsub(/[^a-z0-9-]/, "")
+  end
+
+  def last_integrations_saver
+    audit_logs.where(action: :update_integrations)
+              .where.not(actor_user_id: nil)
+              .order(created_at: :desc)
+              .first&.actor
   end
 
   def set_default_config

--- a/app/views/admin/dashboard/integrations.html.erb
+++ b/app/views/admin/dashboard/integrations.html.erb
@@ -157,7 +157,11 @@
           <h2 class="font-semibold text-gray-900">Airtable Sync</h2>
           <p class="text-sm text-gray-500">Read-only mirror of participant data via the Sync API</p>
         </div>
-        <% if @airtable_sync_stale %>
+        <% if @airtable_sync_paused %>
+          <span class="ml-auto inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+            Paused
+          </span>
+        <% elsif @airtable_sync_stale %>
           <span class="ml-auto inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
             Stale
           </span>
@@ -202,12 +206,34 @@
 
         <% if @airtable_sync_configured %>
           <!-- Sync Status -->
-          <div class="border <%= @airtable_sync_stale ? "border-red-300 bg-red-50" : "border-gray-200 bg-gray-50" %> rounded-lg p-4">
-            <div class="flex items-center justify-between">
+          <div class="border <%= @airtable_sync_paused ? "border-amber-300 bg-amber-50" : (@airtable_sync_stale ? "border-red-300 bg-red-50" : "border-gray-200 bg-gray-50") %> rounded-lg p-4">
+            <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
               <div>
                 <h3 class="font-medium text-gray-900 text-sm">Sync Status</h3>
                 <div class="mt-1 space-y-1">
-                  <% if @airtable_sync_stale %>
+                  <% if @airtable_sync_paused %>
+                    <p class="text-sm text-amber-800 font-medium">
+                      Sync paused after a failure<%= " #{time_ago_in_words(@airtable_sync_paused_at)} ago" if @airtable_sync_paused_at %>
+                    </p>
+                    <p class="text-sm text-amber-700">
+                      Attend stops syncing an event as soon as it fails, rather than retrying
+                      broken settings every 5 minutes.
+                      <% if @airtable_config_owner %>
+                        <%= @airtable_config_owner.name.presence || @airtable_config_owner.email %> was emailed
+                        because they last saved these settings.
+                      <% end %>
+                      Fix the settings above and save, or hit Resume &amp; Sync Now to try again as-is.
+                    </p>
+                    <% if @airtable_synced_at %>
+                      <p class="text-sm text-amber-700">
+                        Airtable still shows the snapshot from
+                        <strong><%= time_ago_in_words(@airtable_synced_at) %> ago</strong>
+                        <span class="font-normal">(<%= @airtable_synced_at.strftime("%b %-d, %Y at %-I:%M %p %Z") %>)</span>.
+                      </p>
+                    <% else %>
+                      <p class="text-sm text-amber-700">This integration has never synced successfully.</p>
+                    <% end %>
+                  <% elsif @airtable_sync_stale %>
                     <p class="text-sm text-red-700 font-medium">
                       <% if @airtable_synced_at %>
                         Sync is failing — last successful sync was <%= time_ago_in_words(@airtable_synced_at) %> ago
@@ -236,13 +262,19 @@
                     </div>
                   <% end %>
                   <p class="text-sm text-gray-500"><%= @airtable_participant_count %> participant records will be synced</p>
-                  <p class="text-xs text-gray-400">Syncs automatically every 5 minutes and whenever these settings are saved</p>
+                  <p class="text-xs text-gray-400">
+                    <% if @airtable_sync_paused %>
+                      Automatic syncing is stopped until these settings are saved again
+                    <% else %>
+                      Syncs automatically every 5 minutes and whenever these settings are saved. A failed sync pauses automatically.
+                    <% end %>
+                  </p>
                 </div>
               </div>
-              <%= button_to "Sync Now",
+              <%= button_to @airtable_sync_paused ? "Resume & Sync Now" : "Sync Now",
                   admin_event_trigger_airtable_sync_path(current_event),
                   method: :post,
-                  class: "bg-yellow-600 hover:bg-yellow-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors" %>
+                  class: "bg-yellow-600 hover:bg-yellow-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors whitespace-nowrap shrink-0 self-start" %>
             </div>
           </div>
         <% end %>

--- a/app/views/airtable_mailer/sync_paused.html.erb
+++ b/app/views/airtable_mailer/sync_paused.html.erb
@@ -1,0 +1,40 @@
+<p>Hi <%= @first_name %>,</p>
+
+<p>
+  The Airtable sync for <strong><%= @event.name %></strong> failed, so Attend has
+  <strong>paused it</strong>. Nothing will be pushed to Airtable until you fix the
+  settings and save them again.
+</p>
+
+<p>You're getting this because you were the last person to save the Airtable settings for this event.</p>
+
+<div style="border: 1px solid #f5c2c7; background-color: #fdf2f3; border-radius: 6px; padding: 12px 16px; margin: 16px 0;">
+  <p style="margin: 0 0 4px 0;"><strong>What Airtable said:</strong></p>
+  <p style="margin: 0; font-family: monospace; font-size: 13px; word-break: break-all;"><%= @error_message %></p>
+</div>
+
+<p style="margin-bottom: 4px;"><strong>Worth checking:</strong></p>
+<ul style="margin-top: 0;">
+  <li>The personal access token hasn't expired or been revoked, and can still see the base</li>
+  <li>The Base ID, Sync Table and Sync Source ID all still exist in Airtable</li>
+  <li>The sync source hasn't been deleted and recreated — that changes its ID</li>
+</ul>
+
+<p>
+  Once the settings are saved again, syncing resumes straight away and runs every
+  5 minutes as usual.
+</p>
+
+<p><%= mail_button "Fix Airtable settings", @integrations_url %></p>
+
+<p style="color: #6b7280; font-size: 13px;">
+  Paused <%= @paused_at&.strftime("%b %-d, %Y at %-I:%M %p %Z") || "just now" %>.
+  <% if @last_synced_at %>
+    Last successful sync was <%= @last_synced_at.strftime("%b %-d, %Y at %-I:%M %p %Z") %> —
+    Airtable still shows that data.
+  <% else %>
+    This integration has never synced successfully.
+  <% end %>
+</p>
+
+<p>If you're not the right person for this any more, just reply and we'll sort it out.</p>

--- a/app/views/airtable_mailer/sync_paused.text.erb
+++ b/app/views/airtable_mailer/sync_paused.text.erb
@@ -1,0 +1,31 @@
+Hi <%= @first_name %>,
+
+The Airtable sync for <%= @event.name %> failed, so Attend has PAUSED it. Nothing
+will be pushed to Airtable until you fix the settings and save them again.
+
+You're getting this because you were the last person to save the Airtable
+settings for this event.
+
+What Airtable said:
+
+<%= @error_message %>
+
+Worth checking:
+
+- The personal access token hasn't expired or been revoked, and can still see the base
+- The Base ID, Sync Table and Sync Source ID all still exist in Airtable
+- The sync source hasn't been deleted and recreated -- that changes its ID
+
+Once the settings are saved again, syncing resumes straight away and runs every
+5 minutes as usual.
+
+<%= @integrations_url %>
+
+Paused <%= @paused_at&.strftime("%b %-d, %Y at %-I:%M %p %Z") || "just now" %>.
+<% if @last_synced_at %>
+Last successful sync was <%= @last_synced_at.strftime("%b %-d, %Y at %-I:%M %p %Z") %> -- Airtable still shows that data.
+<% else %>
+This integration has never synced successfully.
+<% end %>
+
+If you're not the right person for this any more, just reply and we'll sort it out.

--- a/db/migrate/20260812142500_add_airtable_sync_pause_to_events.rb
+++ b/db/migrate/20260812142500_add_airtable_sync_pause_to_events.rb
@@ -1,0 +1,6 @@
+class AddAirtableSyncPauseToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :events, :airtable_sync_paused_at, :datetime
+    add_reference :events, :airtable_config_updated_by, type: :uuid, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_12_111500) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_12_142500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -380,8 +380,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_111500) do
   end
 
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "airtable_config_updated_by_id"
     t.text "airtable_sync_error"
     t.datetime "airtable_sync_error_at"
+    t.datetime "airtable_sync_paused_at"
     t.string "airtable_sync_source_id"
     t.string "airtable_sync_table_id"
     t.datetime "airtable_synced_at"
@@ -416,6 +418,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_111500) do
     t.string "timezone", default: "UTC"
     t.datetime "updated_at", null: false
     t.string "venue_name"
+    t.index ["airtable_config_updated_by_id"], name: "index_events_on_airtable_config_updated_by_id"
     t.index ["event_series_id"], name: "index_events_on_event_series_id"
     t.index ["hotel_scan_context_id"], name: "index_events_on_hotel_scan_context_id"
     t.index ["slug"], name: "index_events_on_slug", unique: true
@@ -1304,6 +1307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_111500) do
   add_foreign_key "event_role_assignments", "users"
   add_foreign_key "events", "event_series"
   add_foreign_key "events", "scan_contexts", column: "hotel_scan_context_id"
+  add_foreign_key "events", "users", column: "airtable_config_updated_by_id"
   add_foreign_key "export_templates", "events"
   add_foreign_key "export_templates", "users", column: "created_by_id"
   add_foreign_key "global_api_tokens", "users"

--- a/spec/jobs/airtable_jobs/sync_all_job_spec.rb
+++ b/spec/jobs/airtable_jobs/sync_all_job_spec.rb
@@ -147,4 +147,155 @@ RSpec.describe AirtableJobs::SyncAllJob do
 
     expect(Airtable::SyncService).not_to have_received(:new)
   end
+
+  # The bug behind thousands of identical Sentry errors: saving the integrations
+  # form with the Airtable fields blank leaves empty strings behind, and the old
+  # `where.not(col: [nil, ""])` filter let them through because `normalizes`
+  # collapsed the "" in the query to nil.
+  it "skips events whose Airtable settings are stored as blank strings" do
+    event = create(:event)
+    event.update_columns(
+      airtable_sync_source_id: "",
+      airtable_sync_table_id: "",
+      config: event.config.merge("airtable_api_key" => "", "airtable_base_id" => "")
+    )
+    allow(Airtable::SyncService).to receive(:new)
+
+    described_class.perform_now
+
+    expect(Airtable::SyncService).not_to have_received(:new)
+    expect(Sentry).not_to have_received(:capture_exception)
+  end
+
+  it "skips events whose Airtable settings are only whitespace" do
+    event = create(:event)
+    event.update_columns(
+      airtable_sync_source_id: "  ",
+      airtable_sync_table_id: "  ",
+      config: event.config.merge("airtable_api_key" => " ", "airtable_base_id" => " ")
+    )
+    allow(Airtable::SyncService).to receive(:new)
+
+    described_class.perform_now
+
+    expect(Airtable::SyncService).not_to have_received(:new)
+  end
+
+  describe "pausing after a failure" do
+    it "pauses the event's sync on the first failure" do
+      broken = configured_event
+      stub_sync(broken, raising: not_found)
+
+      described_class.perform_now
+
+      expect(broken.reload.airtable_sync_paused?).to be(true)
+    end
+
+    it "does not touch a healthy event's pause state" do
+      healthy = configured_event
+      stub_sync(healthy)
+
+      described_class.perform_now
+
+      expect(healthy.reload.airtable_sync_paused?).to be(false)
+    end
+
+    it "stops attempting the event on later runs" do
+      broken = configured_event
+      service = stub_sync(broken, raising: not_found)
+
+      described_class.perform_now
+      described_class.perform_now
+      described_class.perform_now
+
+      expect(service).to have_received(:sync_via_api).once
+      expect(Sentry).to have_received(:capture_exception).once
+    end
+
+    it "flags the pause on the Sentry report" do
+      broken = configured_event
+      stub_sync(broken, raising: not_found)
+
+      described_class.perform_now
+
+      expect(Sentry).to have_received(:capture_exception) do |_exception, **options|
+        expect(options[:tags]).to include(airtable_sync_paused: true)
+        expect(options[:contexts][:airtable_sync][:paused_at]).to be_present
+      end
+    end
+  end
+
+  describe "notifying the config owner" do
+    it "emails whoever last saved the Airtable settings" do
+      owner = create(:user)
+      broken = configured_event(airtable_config_updated_by: owner)
+      stub_sync(broken, raising: not_found)
+
+      expect { described_class.perform_now }
+        .to have_enqueued_mail(AirtableMailer, :sync_paused)
+        .with(event: broken, recipient: owner, error_message: not_found.message)
+    end
+
+    it "emails only once, because the event stays paused" do
+      owner = create(:user)
+      broken = configured_event(airtable_config_updated_by: owner)
+      stub_sync(broken, raising: not_found)
+
+      expect do
+        described_class.perform_now
+        described_class.perform_now
+        described_class.perform_now
+      end.to have_enqueued_mail(AirtableMailer, :sync_paused).once
+    end
+
+    it "falls back to the last admin who saved the integrations form" do
+      saver = create(:user)
+      broken = configured_event
+      AuditLog.log!(action: :update_integrations, record: broken, event: broken, actor: saver)
+      stub_sync(broken, raising: not_found)
+
+      expect { described_class.perform_now }
+        .to have_enqueued_mail(AirtableMailer, :sync_paused)
+        .with(hash_including(recipient: saver))
+    end
+
+    it "prefers the recorded owner over the audit trail" do
+      owner = create(:user)
+      older_saver = create(:user)
+      broken = configured_event(airtable_config_updated_by: owner)
+      AuditLog.log!(action: :update_integrations, record: broken, event: broken, actor: older_saver)
+      stub_sync(broken, raising: not_found)
+
+      expect { described_class.perform_now }
+        .to have_enqueued_mail(AirtableMailer, :sync_paused)
+        .with(hash_including(recipient: owner))
+    end
+
+    it "still pauses and reports when nobody is known to email" do
+      broken = configured_event
+      stub_sync(broken, raising: not_found)
+
+      expect { described_class.perform_now }
+        .not_to have_enqueued_mail(AirtableMailer, :sync_paused)
+
+      expect(broken.reload.airtable_sync_paused?).to be(true)
+      expect(Sentry).to have_received(:capture_exception) do |_exception, **options|
+        expect(options[:contexts][:airtable_sync][:notified]).to match(/nobody/)
+      end
+    end
+
+    it "keeps syncing the other events when the notification blows up" do
+      owner = create(:user)
+      broken = configured_event(airtable_config_updated_by: owner)
+      healthy = configured_event
+      stub_sync(broken, raising: not_found)
+      healthy_service = stub_sync(healthy)
+      allow(AirtableMailer).to receive(:sync_paused).and_raise(StandardError, "smtp is down")
+
+      expect { described_class.perform_now }.not_to raise_error
+
+      expect(healthy_service).to have_received(:sync_via_api)
+      expect(broken.reload.airtable_sync_paused?).to be(true)
+    end
+  end
 end

--- a/spec/mailers/airtable_mailer_spec.rb
+++ b/spec/mailers/airtable_mailer_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe AirtableMailer do
+  describe "#sync_paused" do
+    let(:recipient) { create(:user, email: "ops@hackclub.com", name: "Sam Rivers") }
+    let(:event) { create(:event, name: "Horizons Polaris", slug: "horizons-polaris") }
+
+    subject(:mail) do
+      described_class.sync_paused(
+        event: event,
+        recipient: recipient,
+        error_message: "HTTP 403: INVALID_PERMISSIONS: Invalid external table sync ID"
+      )
+    end
+
+    before { event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS: Invalid external table sync ID") }
+
+    it "goes to the person who last saved the config" do
+      expect(mail.to).to eq([ "ops@hackclub.com" ])
+      expect(mail.subject).to eq("Airtable sync paused for Horizons Polaris")
+    end
+
+    it "says the sync is paused and what Airtable complained about" do
+      [ mail.html_part, mail.text_part ].each do |part|
+        expect(part.body.to_s).to include("Invalid external table sync ID")
+        expect(part.body.to_s.downcase).to include("paused")
+      end
+    end
+
+    it "links to the event's integrations page so it can be fixed" do
+      expect(mail.html_part.body.to_s).to include("/admin/horizons-polaris/integrations")
+      expect(mail.text_part.body.to_s).to include("/admin/horizons-polaris/integrations")
+    end
+
+    it "greets the recipient by first name" do
+      expect(mail.text_part.body.to_s).to include("Hi Sam,")
+    end
+
+    it "falls back to the email local part when the user has no name" do
+      recipient.update!(name: nil, display_name: nil)
+
+      expect(mail.text_part.body.to_s).to include("Hi ops,")
+    end
+
+    it "tells them Airtable is still showing the last good snapshot" do
+      event.update_columns(airtable_synced_at: 2.hours.ago)
+
+      expect(mail.text_part.body.to_s).to include("Last successful sync was")
+    end
+
+    it "says so when the integration never synced" do
+      expect(mail.text_part.body.to_s).to include("never synced successfully")
+    end
+
+    it "logs the email against the event and the recipient" do
+      expect { mail.deliver_now }.to change(EmailLog, :count).by(1)
+
+      log = EmailLog.last
+      expect(log.emailable).to eq(recipient)
+      expect(log.event).to eq(event)
+      expect(log.mailer_action).to eq("sync_paused")
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -27,6 +27,147 @@ RSpec.describe Event, type: :model do
     it "is false when the sync is not configured" do
       expect(build(:event, airtable_synced_at: nil)).not_to be_airtable_sync_stale
     end
+
+    it "is false while the sync is paused, which reports itself" do
+      event = configured_event(airtable_synced_at: 3.hours.ago, airtable_sync_paused_at: 1.hour.ago)
+
+      expect(event).not_to be_airtable_sync_stale
+    end
+  end
+
+  describe ".with_airtable_sync_active" do
+    def configured_event(**attrs)
+      create(
+        :event,
+        airtable_sync_source_id: "sncTest",
+        airtable_sync_table_id: "tblTest",
+        config: { "airtable_api_key" => "key-test", "airtable_base_id" => "app-test" },
+        **attrs
+      )
+    end
+
+    def event_with_raw_airtable_values(source:, table:, key:, base:)
+      create(:event).tap do |event|
+        event.update_columns(
+          airtable_sync_source_id: source,
+          airtable_sync_table_id: table,
+          config: event.config.merge("airtable_api_key" => key, "airtable_base_id" => base)
+        )
+      end
+    end
+
+    it "includes a fully configured, unpaused event" do
+      event = configured_event
+
+      expect(described_class.with_airtable_sync_active).to include(event)
+    end
+
+    it "excludes an event with nothing configured" do
+      event = create(:event)
+
+      expect(described_class.with_airtable_sync_active).not_to include(event)
+    end
+
+    # `where.not(col: [nil, ""])` reads as if it handles this, but `normalizes`
+    # rewrites the "" to nil and the predicate degrades to `IS NOT NULL`.
+    it "excludes an event whose settings are stored as empty strings" do
+      event = event_with_raw_airtable_values(source: "", table: "", key: "", base: "")
+
+      expect(described_class.with_airtable_sync_active).not_to include(event)
+    end
+
+    it "excludes an event whose settings are stored as whitespace" do
+      event = event_with_raw_airtable_values(source: " ", table: " ", key: " ", base: " ")
+
+      expect(described_class.with_airtable_sync_active).not_to include(event)
+    end
+
+    it "excludes an event missing only one setting" do
+      event = configured_event
+      event.update_columns(airtable_sync_table_id: "")
+
+      expect(described_class.with_airtable_sync_active).not_to include(event)
+    end
+
+    it "excludes a paused event but still counts it as configured" do
+      event = configured_event(airtable_sync_paused_at: Time.current)
+
+      expect(described_class.with_airtable_sync_configured).to include(event)
+      expect(described_class.with_airtable_sync_active).not_to include(event)
+    end
+
+    it "matches the record-level #airtable_sync_configured? for every event" do
+      configured_event
+      create(:event)
+      event_with_raw_airtable_values(source: "", table: "", key: "", base: "")
+      event_with_raw_airtable_values(source: "sncTest", table: "tblTest", key: "", base: "app-test")
+
+      expected = described_class.all.select(&:airtable_sync_configured?).map(&:id)
+
+      expect(described_class.with_airtable_sync_configured.pluck(:id)).to match_array(expected)
+    end
+  end
+
+  describe "airtable sync pausing" do
+    let(:event) do
+      create(
+        :event,
+        airtable_sync_source_id: "sncTest",
+        airtable_sync_table_id: "tblTest",
+        config: { "airtable_api_key" => "key-test", "airtable_base_id" => "app-test" }
+      )
+    end
+
+    it "records the pause and the error that caused it" do
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      event.reload
+      expect(event).to be_airtable_sync_paused
+      expect(event.airtable_sync_error).to eq("HTTP 403: INVALID_PERMISSIONS")
+      expect(event.airtable_sync_error_at).to be_present
+    end
+
+    it "clears the pause and the stale error on resume" do
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      event.resume_airtable_sync!
+
+      event.reload
+      expect(event).not_to be_airtable_sync_paused
+      expect(event.airtable_sync_error).to be_nil
+      expect(event.airtable_sync_error_at).to be_nil
+    end
+  end
+
+  describe "#airtable_config_last_saved_by" do
+    let(:event) { create(:event) }
+
+    it "is the recorded config owner" do
+      owner = create(:user)
+      event.update!(airtable_config_updated_by: owner)
+
+      expect(event.airtable_config_last_saved_by).to eq(owner)
+    end
+
+    it "falls back to the most recent integrations audit log" do
+      old_saver = create(:user)
+      recent_saver = create(:user)
+      AuditLog.log!(action: :update_integrations, record: event, event: event, actor: old_saver)
+      AuditLog.log!(action: :update_integrations, record: event, event: event, actor: recent_saver)
+
+      expect(event.airtable_config_last_saved_by).to eq(recent_saver)
+    end
+
+    it "ignores audit logs for other actions" do
+      actor = create(:user)
+      AuditLog.log!(action: :record_update, record: event, event: event, actor: actor)
+
+      expect(event.airtable_config_last_saved_by).to be_nil
+    end
+
+    it "is nil when nobody is known" do
+      expect(event.airtable_config_last_saved_by).to be_nil
+    end
   end
 
   describe "airtable config normalization" do

--- a/spec/requests/admin/integrations_spec.rb
+++ b/spec/requests/admin/integrations_spec.rb
@@ -31,6 +31,35 @@ RSpec.describe "Admin::Integrations", type: :request do
       expect(response.body).to include("Last synced")
       expect(response.body).not_to include("Last sync attempt failed")
     end
+
+    it "says the sync is paused rather than silently showing nothing" do
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      get admin_event_integrations_path(event)
+
+      expect(response.body).to include("Paused")
+      expect(response.body).to include("Sync paused after a failure")
+      expect(response.body).to include("Resume &amp; Sync Now")
+    end
+
+    it "names the person who was emailed about the pause" do
+      saver = create(:user, name: "Sam Rivers")
+      event.update!(airtable_config_updated_by: saver)
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      get admin_event_integrations_path(event)
+
+      expect(response.body).to include("Sam Rivers was emailed")
+    end
+
+    it "does not call a paused sync stale" do
+      event.update_columns(airtable_synced_at: 3.hours.ago)
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      get admin_event_integrations_path(event)
+
+      expect(response.body).not_to include("Stale")
+    end
   end
 
   describe "PATCH /admin/:slug/integrations" do
@@ -74,6 +103,60 @@ RSpec.describe "Admin::Integrations", type: :request do
       }.not_to have_enqueued_job(AirtableJobs::SyncAllJob)
 
       expect(flash[:notice]).to eq("Integration settings updated.")
+    end
+
+    it "records who saved the Airtable settings, so they can be emailed on failure" do
+      patch admin_event_integrations_path(event), params: {
+        event: { airtable_api_key: "key-rotated" }
+      }
+
+      expect(event.reload.airtable_config_updated_by).to eq(admin)
+    end
+
+    it "leaves the recorded owner alone when only non-Airtable settings change" do
+      previous = create(:user)
+      event.update!(airtable_config_updated_by: previous)
+
+      patch admin_event_integrations_path(event), params: {
+        event: { slack_channel_id: "C123456" }
+      }
+
+      expect(event.reload.airtable_config_updated_by).to eq(previous)
+    end
+
+    it "resumes a paused sync when the settings are saved again" do
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      patch admin_event_integrations_path(event), params: {
+        event: { airtable_sync_source_id: "syncfixed" }
+      }
+
+      event.reload
+      expect(event.airtable_sync_paused?).to be(false)
+      expect(event.airtable_sync_error).to be_nil
+    end
+  end
+
+  describe "POST /admin/:slug/integrations/airtable_sync" do
+    include ActiveJob::TestHelper
+
+    it "resumes a paused sync so the button isn't a no-op" do
+      event.pause_airtable_sync!("HTTP 403: INVALID_PERMISSIONS")
+
+      expect {
+        post admin_event_trigger_airtable_sync_path(event)
+      }.to have_enqueued_job(AirtableJobs::SyncAllJob)
+
+      expect(event.reload.airtable_sync_paused?).to be(false)
+      expect(flash[:notice]).to eq("Airtable sync resumed and triggered. It will complete shortly.")
+    end
+
+    it "just triggers a sync when nothing is paused" do
+      expect {
+        post admin_event_trigger_airtable_sync_path(event)
+      }.to have_enqueued_job(AirtableJobs::SyncAllJob)
+
+      expect(flash[:notice]).to eq("Airtable sync triggered. It will complete shortly.")
     end
   end
 end


### PR DESCRIPTION
The scheduled sync retried every broken event every 5 minutes forever, and told nobody. That produced ~13k Sentry errors in 7 days across 20 events while Airtable quietly kept serving a stale snapshot.

Two separate causes:

Events with no Airtable config were being synced. The filter read `where.not(airtable_sync_source_id: [nil, ""])`, which looks blank-safe but isn't: `normalizes` rewrites query values too, so the "" collapsed to nil and the predicate degraded to `IS NOT NULL`. Any event whose integrations form was ever saved blank kept an empty string, passed the filter, and hit Airtable::Client, which raised on the blank key — 11 of the 20 erroring events, ~3.4k errors. Replaced with a `with_airtable_sync_configured` scope whose SQL actually mirrors `#airtable_sync_configured?`.

Genuinely broken configs retried indefinitely. Every failure mode here (revoked token, deleted sync source, stale ids) needs a human, so the sync now pauses the event on the first failure and emails whoever last saved its credentials. Re-saving the settings — or "Resume & Sync Now" — lifts the pause. The integrations page shows the paused state rather than nothing.

Also adds trigger_airtable_sync to the AuditLog action enum; it was missing, so every "Sync Now" click raised ArgumentError inside log_admin_action and was reported to Sentry instead of being audit-logged.

Fixes ATTEND-90