### PR TITLE
Audit-log every admin action that fires log_admin_action

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -45,6 +45,10 @@ class Admin::DashboardController < Admin::BaseController
     @event = Event.find_by!(slug: params[:slug])
     authorize @event, :update?
 
+    # Without a current event the audit row lands with a null event_id, which
+    # hides it from every non-global admin's audit log.
+    set_current_event(@event)
+
     client = Vote::Client.new
 
     if @event.vote_event_linked?

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -60,7 +60,32 @@ class AuditLog < ApplicationRecord
     ticket_set_event: "set_event",
     ticket_set_subject: "set_subject",
     toggle_support_sms: "toggle_support_sms",
-    update_support_sms_numbers: "update_support_sms_numbers"
+    update_support_sms_numbers: "update_support_sms_numbers",
+    trigger_airtable_sync: "trigger_airtable_sync",
+    create_vote_event: "create_vote_event",
+    dismiss_pickup: "dismiss_pickup",
+    refresh_all: "refresh_all",
+    revoke: "revoke",
+    reinstate: "reinstate",
+    rotate_api_token: "rotate",
+    reorder_groups: "reorder",
+    unassign: "unassign",
+    cancel: "cancel",
+    confirm: "confirm",
+    send_to_slack: "send_to_slack",
+    send_now: "send_now",
+    retry_delivery: "retry_delivery",
+    retry_failed: "retry_failed",
+    retry_recipient: "retry_recipient",
+    link_guardian: "link_guardian",
+    refresh_flight_tracking: "refresh_flight_tracking",
+    resync_airtable: "resync_airtable",
+    revoke_invite: "revoke_invite",
+    destroy_avatar: "destroy_avatar",
+    toggle_maintenance: "toggle_maintenance",
+    toggle_twilio: "toggle_twilio",
+    toggle_waiver_sending: "toggle_waiver_sending",
+    update_twilio_from_number: "update_twilio_from_number"
   }
 
   validates :record_type, presence: true

--- a/spec/models/audit_log_spec.rb
+++ b/spec/models/audit_log_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe AuditLog, type: :model do
+  # `log_admin_action` hands the raw `action_name` to `AuditLog.log!`, so an
+  # admin action missing from this enum raises ArgumentError inside the
+  # after_action. Production swallows it: the change lands, nothing is audited,
+  # and Sentry gets an error on every request.
+  describe "the action enum" do
+    it "covers every non-GET admin action that log_admin_action fires on" do
+      valid = described_class.actions.keys.map(&:to_s) | described_class.actions.values.map(&:to_s)
+
+      missing = audited_admin_actions.reject { |_controller, action| valid.include?(action) }
+
+      expect(missing).to be_empty, lambda {
+        "These admin actions have no AuditLog action enum entry, so auditing " \
+        "them raises ArgumentError:\n" +
+          missing.map { |controller, action| "  #{action} (#{controller})" }.join("\n")
+      }
+    end
+  end
+
+  # [controller, action] for every routable non-GET admin action whose
+  # controller still runs the log_admin_action after_action.
+  def audited_admin_actions
+    Rails.application.routes.routes.filter_map { |route|
+      verbs = route.verb.to_s.split("|")
+      next if verbs.empty? || verbs.all? { |verb| verb.in?(%w[GET HEAD]) }
+
+      controller = route.defaults[:controller].to_s
+      next unless controller.start_with?("admin/")
+      next unless audit_logged?(controller)
+
+      [ controller, route.defaults[:action].to_s ]
+    }.uniq
+  end
+
+  def audit_logged?(controller)
+    klass = "#{controller}_controller".camelize.safe_constantize
+    return false unless klass.respond_to?(:_process_action_callbacks)
+
+    klass._process_action_callbacks.any? do |callback|
+      callback.kind == :after && callback.filter == :log_admin_action
+    end
+  end
+end

--- a/spec/requests/admin/integrations_spec.rb
+++ b/spec/requests/admin/integrations_spec.rb
@@ -76,4 +76,35 @@ RSpec.describe "Admin::Integrations", type: :request do
       expect(flash[:notice]).to eq("Integration settings updated.")
     end
   end
+
+  describe "POST /admin/:slug/integrations/vote_event" do
+    let(:vote_client) { instance_double(Vote::Client, configured?: true) }
+
+    before do
+      allow(Vote::Client).to receive(:new).and_return(vote_client)
+      allow(vote_client).to receive(:find_event).with(event.slug).and_return(
+        "id" => "vote-evt-1",
+        "slug" => event.slug,
+        "adminUrl" => "https://vote.hackclub.com/admin/vote-evt-1",
+        "galleryUrl" => "https://vote.hackclub.com/vote-evt-1"
+      )
+
+      # Consume Devise trackable's sign-in columns on a throwaway request so the
+      # event, not the user, is the changed record log_admin_action picks up.
+      get admin_event_integrations_path(event)
+    end
+
+    it "audit-logs the linkage" do
+      expect {
+        post admin_event_create_vote_event_path(event)
+      }.to change(AuditLog, :count).by(1)
+
+      log = AuditLog.order(:created_at).last
+      expect(log.action).to eq("create_vote_event")
+      expect(log.record).to eq(event)
+      expect(log.actor).to eq(admin)
+      expect(log.event).to eq(event)
+      expect(event.reload.vote_event_id).to eq("vote-evt-1")
+    end
+  end
 end


### PR DESCRIPTION
`log_admin_action` passes the raw `action_name` to `AuditLog.log!`, so any admin action missing from the `action` enum raises `ArgumentError` inside the after_action. Production swallows that: the change still lands, nothing is audited, and Sentry takes an error on every request.

`create_vote_event` was the reported case (`POST /admin/:slug/integrations/vote_event`). Auditing the whole route table turned up 24 more.

### The audit

Derived from the route table rather than by eye: every non-GET route under `admin/` whose controller still runs the callback, checked against enum keys **and** values — Rails accepts either side of the mapping, which is why `create`/`update`/`close` already work as values only.

`admin/rooming_wizard` and `admin/sibling_groups` `skip_after_action :log_admin_action`, so their 16 non-GET actions are correctly absent.

Three keys are renamed off their action name to dodge conflicts — `rotate_api_token: "rotate"` and `reorder_groups: "reorder"`, since Rails refuses to generate `AuditLog.rotate`/`.reorder` (both exist on `ActiveRecord::Relation`). Follows the existing `ticket_close: "close"` convention; the stored value stays the raw action name, which is what `log!` has to accept.

⚠️ `trigger_airtable_sync` is in here too. It is missing on this branch, and the new guard spec fails without it — expect a one-line conflict with the airtable sync branch, dedupe on merge.

### Also

`create_vote_event` never set a current event, so even once the enum accepted the action the row landed with a null `event_id` — which hides it from every non-global admin, since `Admin::AuditLogsController#index` scopes them by `event_id`. It now sets one, matching `update_integrations` on the same page. **`trigger_airtable_sync` has the identical gap** and wants the same one-liner on the airtable branch.

### Tests

- `spec/requests/admin/integrations_spec.rb` — POSTs the route with `Vote::Client` stubbed, asserts one `AuditLog` row with the right action, record, actor and event.
- `spec/models/audit_log_spec.rb` — new guard: walks the route table at runtime, resolves each admin controller, checks whether it still has the callback, and fails with a named list of anything missing. Verified it bites by pulling `create_vote_event` back out.

Full suite green: 746 examples, 0 failures.