### PR TITLE
Drop the flipper tables left over from the open-source cutover

### DIFF
--- a/db/migrate/20260813120000_drop_flipper_tables.rb
+++ b/db/migrate/20260813120000_drop_flipper_tables.rb
@@ -1,0 +1,14 @@
+class DropFlipperTables < ActiveRecord::Migration[8.1]
+  # Leftovers from a dev-only feature flag that never shipped: the tables reached
+  # schema.rb during the open-source cutover, so a fresh `db:schema:load` created
+  # them even though nothing in the app has ever referenced flipper. `if_exists`
+  # keeps this a no-op on databases that never had them.
+  def up
+    drop_table :flipper_gates, if_exists: true
+    drop_table :flipper_features, if_exists: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_12_142500) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -436,22 +436,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_12_142500) do
     t.index ["created_by_id"], name: "index_export_templates_on_created_by_id"
     t.index ["event_id", "name"], name: "index_export_templates_on_event_id_and_name", unique: true
     t.index ["event_id"], name: "index_export_templates_on_event_id"
-  end
-
-  create_table "flipper_features", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "key", null: false
-    t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_flipper_features_on_key", unique: true
-  end
-
-  create_table "flipper_gates", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "feature_key", null: false
-    t.string "key", null: false
-    t.datetime "updated_at", null: false
-    t.text "value"
-    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "global_api_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
`flipper_features` and `flipper_gates` have been sitting in committed `db/schema.rb` since the 2026-08-12 open-source cutover. They came from a dev-only feature flag that was never committed, and nothing in the app has ever referenced flipper — it's absent from the Gemfile, Gemfile.lock, `app/`, `config/` and `lib/`, and no migration ever created the tables. A fresh clone running `db:schema:load` was creating them anyway.

## Why a migration and not just a schema.rb edit

Deleting the two `create_table` blocks alone fixes fresh clones but strands anyone who **already** ran `db:schema:load` — the tables stay in their database, and their next `bin/rails db:migrate` dumps both blocks straight back into `schema.rb`. That phantom diff then rides along in whatever unrelated PR they happen to be working on. The repo went public a day ago with contribution docs, so that's a growing population.

`drop_table ..., if_exists: true` cleans up those databases and no-ops everywhere the tables were never created. It matters that it no-ops rather than raises: `db:prepare` runs per-pod in the entrypoint, so a migration that raised on a database lacking the tables would crash-loop the deploy.

The migration is `up`-only and irreversible by design — a `down` would have to recreate tables backing no gem and no code.

## Verification

Tested all three database states:

| state | result |
|---|---|
| dev DB (has the tables) | dropped both, exit 0 |
| fresh `db:schema:load` | no flipper tables; migration auto-marked applied via `assume_migrated_upto_version`, so `db:migrate` won't re-run it |
| DB without the tables, migration unrun (production-shaped) | clean no-op, exit 0, no raise |

The fresh-load test doubles as a check on the schema diff: running `db:migrate` against that clean scratch database re-dumped `schema.rb` byte-identically to what's committed here. So this file is provably what a clean database produces, not a hand-edit that happens to look right.

Rubocop clean.

## Note for whoever runs db:migrate next

Unrelated to this PR, the shared dev database also carries an `index_consents_on_docuseal_envelope_id` index that no migration creates and that isn't in `schema.rb`, so it shows up as a phantom `+ t.index [...]` hunk on every dump. It's deliberately **not** included here. Tracked separately.