### PR TITLE
Fix white-on-red contrast: deepen the button fill to #d42f46

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,276 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-13T16:43:40Z",
+  "title": "Design System: Attend",
+  "extensions": {
+    "colorMeta": {
+      "accent": {
+        "role": "primary",
+        "displayName": "Hack Club Red",
+        "canonical": "#ec3750",
+        "note": "Contrast vs white is 4.02:1 — below WCAG AA for normal text, and below the 18.66px-bold threshold for the large-text exemption. Never carries white text; see The Deepened Red Rule.",
+        "tonalRamp": ["#2e0a10", "#5c1420", "#8a1e30", "#b82840", "#ec3750", "#f2707f", "#f8a8b1", "#fde9ec"]
+      },
+      "accent-strong": {
+        "role": "primary",
+        "displayName": "Deepened Red",
+        "canonical": "#d42f46",
+        "note": "4.89:1 on white — the resting fill of every red surface that carries white text.",
+        "tonalRamp": ["#2a0910", "#54121f", "#7e1b2f", "#a8243e", "#d42f46", "#e26a7b", "#eda5b0", "#f9e0e4"]
+      },
+      "accent-deep": {
+        "role": "primary",
+        "displayName": "Pressed Red",
+        "canonical": "#b82840",
+        "note": "Hover and pressed state under Deepened Red.",
+        "tonalRamp": ["#240811", "#491021", "#6d1832", "#922042", "#b82840", "#cd6377", "#e19fab", "#f6dce1"]
+      },
+      "bg-app": {
+        "role": "neutral",
+        "displayName": "Paper",
+        "canonical": "#f9fafc",
+        "tonalRamp": ["#191b1f", "#31353d", "#4a4f5c", "#62697a", "#7b8399", "#a3a9b8", "#cbcfd8", "#f9fafc"]
+      },
+      "bg-elev": {
+        "role": "neutral",
+        "displayName": "Card White",
+        "canonical": "#ffffff",
+        "tonalRamp": ["#1a1a1a", "#333333", "#4d4d4d", "#666666", "#808080", "#aaaaaa", "#d5d5d5", "#ffffff"]
+      },
+      "bg-sunken": {
+        "role": "neutral",
+        "displayName": "Sunken Grey",
+        "canonical": "#e6e6ea",
+        "tonalRamp": ["#171718", "#2e2e31", "#454549", "#5c5c62", "#73737a", "#9a9aa1", "#c0c0c6", "#e6e6ea"]
+      },
+      "text-strong": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "#1f2d3d",
+        "tonalRamp": ["#0a0f14", "#141d28", "#1f2d3d", "#33485f", "#4c6883", "#7f97ac", "#b3c2d0", "#e6ebf0"]
+      },
+      "text": {
+        "role": "neutral",
+        "displayName": "Slate",
+        "canonical": "#3c4858",
+        "tonalRamp": ["#0c0f12", "#181e24", "#252d36", "#313b48", "#3c4858", "#6c7c92", "#a3aebc", "#dae0e7"]
+      },
+      "text-muted": {
+        "role": "neutral",
+        "displayName": "Muted Steel",
+        "canonical": "#8492a6",
+        "tonalRamp": ["#1a1e24", "#343b47", "#4e586b", "#68758e", "#8492a6", "#a6b1c0", "#c8d0da", "#eaeef3"]
+      },
+      "border": {
+        "role": "neutral",
+        "displayName": "Hairline",
+        "canonical": "#e5e7eb",
+        "tonalRamp": ["#171718", "#2e2f31", "#454749", "#5c5f62", "#74777b", "#9b9ea3", "#c0c3c7", "#e5e7eb"]
+      },
+      "success": {
+        "role": "tertiary",
+        "displayName": "Mint",
+        "canonical": "#33d6a6",
+        "tonalRamp": ["#0a2b21", "#125542", "#1b8063", "#24aa84", "#33d6a6", "#68e2bd", "#9dedd4", "#e6faf3"]
+      },
+      "warning": {
+        "role": "tertiary",
+        "displayName": "Amber",
+        "canonical": "#ff8c37",
+        "tonalRamp": ["#33190a", "#663214", "#994b1e", "#cc6428", "#ff8c37", "#ffab6d", "#ffc9a3", "#ffeede"]
+      },
+      "info": {
+        "role": "tertiary",
+        "displayName": "Sky",
+        "canonical": "#338eda",
+        "tonalRamp": ["#0a1c2c", "#143857", "#1e5583", "#2871ae", "#338eda", "#6cade5", "#a5ccef", "#e4f0fa"]
+      },
+      "text-link": {
+        "role": "tertiary",
+        "displayName": "Link Blue",
+        "canonical": "#2563eb",
+        "tonalRamp": ["#07142f", "#0f285e", "#163c8d", "#1e50bc", "#2563eb", "#5d8bf1", "#95b3f6", "#e0e9fd"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Page titles on marketing-adjacent surfaces — home, public profiles, docs. Rare." },
+      "headline": { "displayName": "Headline", "purpose": "The title of a screen or major panel. The normal top of a page inside the app." },
+      "title": { "displayName": "Title", "purpose": "Card and section headings. Also the minimum size for white text on a red fill." },
+      "body": { "displayName": "Body", "purpose": "The workhorse at 14px/500 — form labels, table cells, button text, nav items." },
+      "label": { "displayName": "Label", "purpose": "Status badges, helper text, metadata, timestamps." },
+      "eyebrow": { "displayName": "Eyebrow", "purpose": "Uppercase sidebar section headers only." }
+    },
+    "shadows": [
+      { "name": "hairline-lift", "value": "0 1px 2px rgba(0, 0, 0, 0.06)", "purpose": "Sticky headers and the app bar, where a border alone disappears against a scrolling surface." },
+      { "name": "overlay", "value": "0 8px 24px rgba(15, 23, 42, 0.10)", "purpose": "Dropdowns, command palette, modals, mobile drawers — things that genuinely float." },
+      { "name": "card-lift", "value": "0 4px 8px rgba(0, 0, 0, 0.125)", "purpose": "The legacy Hack Club card and pill button only; part of the brand component, not the layout system." },
+      { "name": "card-elevated", "value": "0 1px 2px rgba(0, 0, 0, 0.0625), 0 8px 12px rgba(0, 0, 0, 0.125)", "purpose": "Hover state of the Hack Club interactive card and pill button." },
+      { "name": "overlay-dark", "value": "0 12px 32px rgba(0, 0, 0, 0.6)", "purpose": "The overlay role under dark themes; light-theme opacity vanishes on #0f1115." }
+    ],
+    "motion": [
+      { "name": "state-transition", "value": "150ms ease", "purpose": "The default. transition-colors on buttons, nav items, inputs, icon buttons." },
+      { "name": "brand-lift", "value": "125ms ease-in-out", "purpose": "The Hack Club pill button and interactive card scale(1.0625) lift. The only scaling motion in the system." }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px", "purpose": "The dominant breakpoint — where full-width mobile actions shrink to auto width." },
+      { "name": "md", "value": "768px", "purpose": "Participant header expands from hamburger to inline nav." },
+      { "name": "lg", "value": "1024px", "purpose": "Admin sidebar becomes a persistent 256px column instead of an overlay drawer." }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The one red action per screen. Filled with the deepened red so white text clears WCAG AA at 14px.",
+      "html": "<button class=\"ds-btn-primary\">Continue</button>",
+      "css": ".ds-btn-primary { background: var(--accent-strong, #d42f46); color: var(--accent-on, #fff); font-size: 0.875rem; font-weight: 600; line-height: 1.5; padding: 8px 16px; border: none; border-radius: 6px; cursor: pointer; transition: background-color 150ms ease; } .ds-btn-primary:hover { background: #b82840; } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent, #ec3750) 30%, transparent); } .ds-btn-primary:active { transform: translateY(1px); }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Back, Cancel, and the second action in any pair. Hairline border, no fill until hover.",
+      "html": "<button class=\"ds-btn-secondary\">Back</button>",
+      "css": ".ds-btn-secondary { background: var(--bg-elev, #fff); color: var(--text, #3c4858); font-size: 0.875rem; font-weight: 500; line-height: 1.5; padding: 8px 16px; border: 1px solid var(--border-strong, #d1d5db); border-radius: 6px; cursor: pointer; transition: background-color 150ms ease, color 150ms ease; } .ds-btn-secondary:hover { background: var(--bg-elev-3, #f3f4f6); color: var(--text-strong, #1f2d3d); } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent, #ec3750) 30%, transparent); }"
+    },
+    {
+      "name": "Hack Club Pill Button",
+      "kind": "button",
+      "refersTo": "button-hc-pill",
+      "description": "The brand call to action. Full-round, bold, and the only component allowed to scale on hover.",
+      "html": "<button class=\"ds-btn-pill\">Get started</button>",
+      "css": ".ds-btn-pill { background: var(--accent-strong, #d42f46); color: #fff; font-size: 1rem; font-weight: 700; padding: 12px 24px; border: none; border-radius: 99999px; cursor: pointer; box-shadow: 0 4px 8px rgba(0,0,0,0.125); display: inline-flex; align-items: center; justify-content: center; transition: transform 125ms ease-in-out, box-shadow 125ms ease-in-out; } .ds-btn-pill:hover, .ds-btn-pill:focus-visible { outline: none; transform: scale(1.0625); box-shadow: 0 1px 2px rgba(0,0,0,0.0625), 0 8px 12px rgba(0,0,0,0.125); }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input-field",
+      "description": "Every form field in the onboarding wizard and guardian portal. The focus ring is the only focus indicator.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Legal first name\" />",
+      "css": ".ds-input { width: 100%; background: var(--bg-elev, #fff); color: var(--text-strong, #1f2d3d); font-size: 0.875rem; font-weight: 500; line-height: 1.5; padding: 8px 12px; border: 1px solid var(--border-strong, #d1d5db); border-radius: 6px; transition: border-color 150ms ease, box-shadow 150ms ease; } .ds-input::placeholder { color: var(--text-faint, #9ca3af); } .ds-input:focus { outline: none; border-color: var(--accent, #ec3750); box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent, #ec3750) 30%, transparent); } .ds-input:disabled { background: var(--bg-elev-2, #f7f7f9); color: var(--text-faint, #9ca3af); cursor: not-allowed; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "The default container. Flat at rest — a hairline border and a tonal step do the work a shadow would.",
+      "html": "<div class=\"ds-card\"><h3 class=\"ds-card-title\">Travel</h3><p class=\"ds-card-body\">Inbound flight confirmed. Outbound leg still needs a booking reference.</p></div>",
+      "css": ".ds-card { background: var(--bg-elev, #fff); border: 1px solid var(--border-card, #e0e6ed); border-radius: 8px; padding: 24px; } .ds-card-title { margin: 0 0 8px; font-size: 1.125rem; font-weight: 600; line-height: 1.4; color: var(--text-strong, #1f2d3d); } .ds-card-body { margin: 0; font-size: 0.875rem; font-weight: 500; line-height: 1.5; color: var(--text, #3c4858); }"
+    },
+    {
+      "name": "Interactive Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "A card that is itself a link. Lifts and scales on hover — reserved for cards that navigate.",
+      "html": "<a class=\"ds-card-interactive\" href=\"#\"><h3 class=\"ds-card-interactive-title\">Hack Club Summit 2026</h3><p class=\"ds-card-interactive-meta\">12–15 August · Vermont</p></a>",
+      "css": ".ds-card-interactive { display: block; text-decoration: none; background: var(--bg-elev, #fff); border-radius: 12px; padding: 24px; overflow: hidden; box-shadow: 0 4px 8px rgba(0,0,0,0.125); transition: transform 125ms ease-in-out, box-shadow 125ms ease-in-out; } .ds-card-interactive:hover, .ds-card-interactive:focus-visible { outline: none; transform: scale(1.0625); box-shadow: 0 1px 2px rgba(0,0,0,0.0625), 0 8px 12px rgba(0,0,0,0.125); } .ds-card-interactive-title { margin: 0 0 4px; font-size: 1.125rem; font-weight: 600; color: var(--text-strong, #1f2d3d); } .ds-card-interactive-meta { margin: 0; font-size: 0.75rem; font-weight: 600; color: var(--text-muted, #8492a6); }"
+    },
+    {
+      "name": "Status Badge",
+      "kind": "chip",
+      "refersTo": "badge-status",
+      "description": "Attend's signature pattern. Tinted pill with same-hue dark text — the tint is never the only signal.",
+      "html": "<span class=\"ds-badge ds-badge-complete\">Complete</span> <span class=\"ds-badge ds-badge-awaiting-parent\">Awaiting Parent</span> <span class=\"ds-badge ds-badge-withdrawn\">Withdrawn</span>",
+      "css": ".ds-badge { display: inline-flex; align-items: center; padding: 2px 10px; font-size: 0.75rem; font-weight: 600; line-height: 1.4; border-radius: 99999px; } .ds-badge-complete { background: #dcfce7; color: #166534; } .ds-badge-awaiting-participant { background: #dbeafe; color: #1e40af; } .ds-badge-awaiting-parent { background: #fef3c7; color: #92400e; } .ds-badge-withdrawn { background: #fee2e2; color: #991b1b; }"
+    },
+    {
+      "name": "Sidebar Nav Item",
+      "kind": "nav",
+      "refersTo": "nav-item",
+      "description": "The admin sidebar row at 13px/500 with a muted 20px icon; active state deepens to the sunken grey.",
+      "html": "<nav class=\"ds-nav\"><a class=\"ds-nav-item\" href=\"#\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3\"/></svg>Overview</a><a class=\"ds-nav-item ds-nav-item-active\" href=\"#\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z\"/></svg>Participants</a></nav>",
+      "css": ".ds-nav { display: flex; flex-direction: column; gap: 2px; width: 256px; padding: 8px; background: var(--bg-elev-2, #f7f7f9); } .ds-nav-item { display: flex; align-items: center; padding: 6px 10px; font-size: 0.8125rem; font-weight: 500; line-height: 1.4; border-radius: 6px; color: var(--text, #3c4858); text-decoration: none; transition: background-color 150ms ease, color 150ms ease; } .ds-nav-item svg { width: 20px; height: 20px; margin-right: 10px; flex-shrink: 0; color: var(--text-muted, #6b7280); } .ds-nav-item:hover { background: rgba(0,0,0,0.04); color: var(--text-strong, #1f2d3d); } .ds-nav-item-active { background: var(--bg-sunken, #e6e6ea); color: var(--text-strong, #1f2d3d); font-weight: 600; } .ds-nav-item-active svg { color: var(--text-strong, #1f2d3d); }"
+    },
+    {
+      "name": "Search Trigger",
+      "kind": "custom",
+      "refersTo": "input-field",
+      "description": "A faux input in the admin header that opens the command palette. Looks like a field, behaves like a button.",
+      "html": "<button class=\"ds-search-trigger\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z\"/></svg>Search participants, events…<kbd>⌘K</kbd></button>",
+      "css": ".ds-search-trigger { display: flex; align-items: center; gap: 8px; min-width: 240px; padding: 6px 12px; font-size: 0.875rem; color: var(--text-faint, #9ca3af); background: var(--bg-elev-2, #f9fafb); border: 1px solid var(--border, #e5e7eb); border-radius: 8px; cursor: pointer; transition: border-color 150ms ease, box-shadow 150ms ease; } .ds-search-trigger svg { width: 16px; height: 16px; flex-shrink: 0; } .ds-search-trigger:hover { border-color: var(--border-strong, #d1d5db); box-shadow: 0 1px 2px rgba(0,0,0,0.05); } .ds-search-trigger kbd { margin-left: auto; padding: 2px 6px; font-size: 0.6875rem; font-weight: 500; color: var(--text-faint, #9ca3af); background: var(--border, #e5e7eb); border-radius: 4px; }"
+    },
+    {
+      "name": "Sidebar Selector Pill",
+      "kind": "custom",
+      "refersTo": "nav-item",
+      "description": "The user and event selectors at the top of the admin sidebar. Full-round because it carries identity, not action.",
+      "html": "<button class=\"ds-sidebar-pill\"><span class=\"ds-sidebar-pill-avatar\">LW</span><span class=\"ds-sidebar-pill-label\">Summit 2026</span><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M19 9l-7 7-7-7\"/></svg></button>",
+      "css": ".ds-sidebar-pill { display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 10px 6px 6px; background: var(--bg-elev, #fff); border: 1px solid var(--border, #e5e7eb); border-radius: 9999px; cursor: pointer; text-align: left; transition: border-color 150ms ease, box-shadow 150ms ease; } .ds-sidebar-pill:hover { border-color: var(--border-strong, #d1d5db); box-shadow: 0 1px 2px rgba(0,0,0,0.04); } .ds-sidebar-pill-avatar { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 9999px; background: var(--accent, #ec3750); color: #fff; font-size: 0.6875rem; font-weight: 700; flex-shrink: 0; } .ds-sidebar-pill-label { font-size: 0.8125rem; font-weight: 500; color: var(--text-strong, #1f2d3d); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; } .ds-sidebar-pill svg { width: 14px; height: 14px; margin-left: auto; flex-shrink: 0; color: var(--text-muted, #8492a6); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Clipboard",
+    "overview": "Attend is the binder a good event organiser carries: tabbed, legible at arm's length, nothing on it that isn't doing a job. Every surface is a checklist in some form — an onboarding step, a consent form, a participant row, a rooming plan — and the interface's whole job is to make the state of that checklist unmistakable. Structure comes from hairline rules and tonal surfaces, not from decoration. The page is mostly quiet greys and whites; Hack Club red appears where something is actionable or wrong, and nowhere else.\n\nThe density is deliberately administrative. Body copy runs at 14px and labels at 12px because most screens carry more information than they carry prose, and the people reading them are scanning for one changed value. Type does the hierarchy work — five weights of grey across a small size range — so the layout never needs a colour to explain itself. Components are tactile where touching them matters: buttons deepen on hover, interactive cards lift and scale slightly, and the Hack Club pill button keeps its bouncy scale(1.0625) because a teenager pressing \"Continue\" on their onboarding should feel it respond.\n\nThe system carries eight themes on one semantic palette. Every colour resolves through a CSS custom property (--accent, --text-strong, --bg-elev), and Tailwind's own --color-* tokens are remapped inside each theme scope so ordinary utilities re-skin for free. That indirection is the system's spine: a hardcoded hex is not a shortcut, it's a theme that breaks.\n\nTwo things Attend must not look like. Not a generic Tailwind starter — undifferentiated blue-600 buttons, indigo gradients, default shadow-lg cards, the look of no decision having been made. And not a consumer event app — gradients, hero imagery, and marketing energy inside a tool people use to do a job.",
+    "keyCharacteristics": [
+      "Flat surfaces, hairline borders, tonal layering instead of shadows",
+      "One loud colour (Hack Club red) held to actions, alerts, and active state",
+      "Dense administrative type scale: 14px body, 12px labels, weight over size for hierarchy",
+      "Every colour semantic and themed; eight themes on one palette contract",
+      "Mobile-first single column that widens into a 256px-sidebar shell on lg",
+      "Motion is confined to transition-colors at ~150ms, plus a small lift on genuinely interactive cards"
+    ],
+    "rules": [
+      {
+        "name": "The One Voice Rule",
+        "body": "Hack Club red covers ≤10% of any screen. If two things on a page are red, at most one of them is a button. Its rarity is what makes a red thing mean \"act on me\".",
+        "section": "colors"
+      },
+      {
+        "name": "The No Literal Hex Rule",
+        "body": "Every colour resolves through a semantic custom property or a Tailwind token remapped in themes.css. A raw hex in a template is a theme bug: it renders correctly in light and wrong in the other seven. New work uses var(--accent), not #ec3750.",
+        "section": "colors"
+      },
+      {
+        "name": "The Deepened Red Rule",
+        "body": "#ec3750 on white measures 4.02:1 — below WCAG AA's 4.5:1 for normal text. WCAG's large-text exemption (3:1) starts at 18.66px bold or 24px regular, which no button in Attend reaches, so the type cannot buy its way out. The colour moves instead: wherever white text sits on red, the fill is #d42f46 (4.89:1), hovering to #b82840. #ec3750 keeps every use that carries no text on it — dots, bars, icon fills, borders, tints, and the progress bar. The two reds are one perceptual step apart; nobody sees the difference, and every white label clears AA.",
+        "section": "colors"
+      },
+      {
+        "name": "The Weight-Before-Size Rule",
+        "body": "Hierarchy is built by moving 500 → 600 → 700 at the same size before reaching for a larger size. Attend has more levels of meaning than it has room for type sizes.",
+        "section": "typography"
+      },
+      {
+        "name": "The Fourteen Rule",
+        "body": "Body copy is 14px, not 16px, everywhere inside the app shell — including on red fills, which is why The Deepened Red Rule moves the colour rather than the type. The one exception is long-form prose on the docs and public-profile surfaces, which may run at 16px with a 65–75ch measure.",
+        "section": "typography"
+      },
+      {
+        "name": "The Full-Width-Then-Auto Rule",
+        "body": "Every primary action is w-full sm:w-auto. On a phone a button is a full-width target; on a desktop it shrinks to its content. This pattern appears on essentially every form in the app and is not optional on guardian or participant surfaces.",
+        "section": "layout"
+      },
+      {
+        "name": "The Flat-By-Default Rule",
+        "body": "A surface is flat at rest. If you reach for a shadow, first ask whether the element actually floats. If it doesn't, it gets a border and a tonal step instead.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Two-Radius Rule",
+        "body": "6px for controls, 8px for containers, full for state and identity. A third value needs a reason.",
+        "section": "shapes"
+      }
+    ],
+    "dos": [
+      "Do resolve every colour through a semantic custom property (var(--accent), var(--text-strong)) or a Tailwind token that themes.css remaps. There are eight themes; a literal hex serves one.",
+      "Do fill any red surface that carries white text with accent-strong (#d42f46), not accent (#ec3750). The Deepened Red Rule is an accessibility floor, not a preference, and no type size in Attend is large enough to opt out of it.",
+      "Do make every primary action w-full sm:w-auto. Guardians and participants are on phones.",
+      "Do build depth from tonal surfaces and 1px hairlines. Reach for a shadow only when the element genuinely floats.",
+      "Do pair every status colour with its word. A green pill without \"Complete\" in it is a colour-only signal.",
+      "Do verify new UI in a dark theme as well as light — themes.css overrides bare input, select, and textarea elements, and remaps --color-white away from white.",
+      "Do rebuild Tailwind before judging any visual change; the compiled CSS is the thing the browser sees.",
+      "Do add cursor-pointer to every button and clickable element."
+    ],
+    "donts": [
+      "Don't add new bg-blue-600 buttons or ring-blue-500 focus rings. The blue running through the onboarding wizard and guardian portal (35 blue fills, 277 blue rings) is drift from a Tailwind default, not a decision. Red is the accent everywhere; converge on it when touching those files.",
+      "Don't let Hack Club red occupy area. It fills buttons, badges, and 1px borders. Large red panels, red page headers, and red backgrounds behind body copy are out — use accent-soft if a red-tinted region is genuinely needed.",
+      "Don't ship gradients, hero imagery, or marketing motion inside the app shell. Attend is a tool someone uses to do a job, not a consumer event app.",
+      "Don't introduce a webfont. The system stack is a deliberate performance choice for guardians on slow connections and old phones.",
+      "Don't add a third container radius. 6px controls, 8px containers, full for state and identity.",
+      "Don't use rounded-full on a plain action button. A pill in Attend means state or identity; the Hack Club brand pill is the one sanctioned exception.",
+      "Don't suppress the focus ring. focus:outline-none is only acceptable when a focus:ring-2 replaces it in the same class list.",
+      "Don't use text-faint for anything a user has to read. It is for placeholders and disabled states only."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,311 @@
+---
+name: Attend
+description: Safeguarding-grade event onboarding for under-18 Hack Club events — flat, bordered, and quiet until it needs to speak.
+colors:
+  accent: "#ec3750"
+  accent-strong: "#d42f46"
+  accent-deep: "#b82840"
+  accent-soft: "rgba(236, 55, 80, 0.10)"
+  accent-on: "#ffffff"
+  bg-app: "#f9fafc"
+  bg-elev: "#ffffff"
+  bg-elev-2: "#f7f7f9"
+  bg-elev-3: "#f3f4f6"
+  bg-sunken: "#e6e6ea"
+  bg-dark: "#17171d"
+  bg-darker: "#1f2d3d"
+  text-strong: "#1f2d3d"
+  text: "#3c4858"
+  text-soft: "#5a6473"
+  text-muted: "#8492a6"
+  text-faint: "#9ca3af"
+  text-link: "#2563eb"
+  border-soft: "#f3f4f6"
+  border: "#e5e7eb"
+  border-strong: "#d1d5db"
+  border-card: "#e0e6ed"
+  success: "#33d6a6"
+  success-strong: "#2ab890"
+  warning: "#ff8c37"
+  warning-strong: "#f97316"
+  danger: "#ec3750"
+  info: "#338eda"
+typography:
+  display:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "1.875rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  headline:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 700
+    lineHeight: 1.25
+  title:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 600
+    lineHeight: 1.4
+  body:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.5
+  label:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 600
+    lineHeight: 1.4
+  eyebrow:
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    fontSize: "0.6875rem"
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: "0.05em"
+rounded:
+  sm: "4px"
+  md: "6px"
+  lg: "8px"
+  xl: "12px"
+  full: "9999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+  "2xl": "32px"
+components:
+  button-primary:
+    backgroundColor: "{colors.accent-strong}"
+    textColor: "{colors.accent-on}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  button-primary-hover:
+    backgroundColor: "{colors.accent-deep}"
+    textColor: "{colors.accent-on}"
+  button-secondary:
+    backgroundColor: "{colors.bg-elev}"
+    textColor: "{colors.text}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "8px 16px"
+  button-secondary-hover:
+    backgroundColor: "{colors.bg-elev-3}"
+    textColor: "{colors.text-strong}"
+  button-hc-pill:
+    backgroundColor: "{colors.accent-strong}"
+    textColor: "{colors.accent-on}"
+    typography: "{typography.title}"
+    rounded: "{rounded.full}"
+    padding: "12px 24px"
+  input-field:
+    backgroundColor: "{colors.bg-elev}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.body}"
+    rounded: "{rounded.md}"
+    padding: "8px 12px"
+  card:
+    backgroundColor: "{colors.bg-elev}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.lg}"
+    padding: "24px"
+  badge-status:
+    backgroundColor: "{colors.bg-elev-3}"
+    textColor: "{colors.text-strong}"
+    typography: "{typography.label}"
+    rounded: "{rounded.full}"
+    padding: "2px 10px"
+  nav-item:
+    backgroundColor: "transparent"
+    textColor: "{colors.text}"
+    rounded: "{rounded.md}"
+    padding: "6px 10px"
+    height: "28px"
+  nav-item-active:
+    backgroundColor: "{colors.bg-sunken}"
+    textColor: "{colors.text-strong}"
+    rounded: "{rounded.md}"
+    padding: "6px 10px"
+---
+
+# Design System: Attend
+
+## Overview
+
+**Creative North Star: "The Clipboard"**
+
+Attend is the binder a good event organiser carries: tabbed, legible at arm's length, nothing on it that isn't doing a job. Every surface is a checklist in some form — an onboarding step, a consent form, a participant row, a rooming plan — and the interface's whole job is to make the state of that checklist unmistakable. Structure comes from hairline rules and tonal surfaces, not from decoration. The page is mostly quiet greys and whites; Hack Club red appears where something is actionable or wrong, and nowhere else.
+
+The density is deliberately administrative. Body copy runs at 14px and labels at 12px because most screens carry more information than they carry prose, and the people reading them are scanning for one changed value. Type does the hierarchy work — five weights of grey across a small size range — so the layout never needs a colour to explain itself. Components are tactile where touching them matters: buttons deepen on hover, interactive cards lift and scale slightly, and the Hack Club pill button keeps its bouncy `scale(1.0625)` because a teenager pressing "Continue" on their onboarding should feel it respond.
+
+The system carries eight themes on one semantic palette. Every colour resolves through a CSS custom property (`--accent`, `--text-strong`, `--bg-elev`), and Tailwind's own `--color-*` tokens are remapped inside each theme scope so ordinary utilities re-skin for free. That indirection is the system's spine: a hardcoded hex is not a shortcut, it's a theme that breaks.
+
+Two things Attend must not look like. Not a **generic Tailwind starter** — undifferentiated `blue-600` buttons, indigo gradients, default `shadow-lg` cards, the look of no decision having been made. And not a **consumer event app** — gradients, hero imagery, and marketing energy inside a tool people use to do a job.
+
+**Key Characteristics:**
+- Flat surfaces, hairline borders, tonal layering instead of shadows
+- One loud colour (Hack Club red) held to actions, alerts, and active state
+- Dense administrative type scale: 14px body, 12px labels, weight over size for hierarchy
+- Every colour semantic and themed; eight themes on one palette contract
+- Mobile-first single column that widens into a 256px-sidebar shell on `lg`
+- Motion is confined to `transition-colors` at ~150ms, plus a small lift on genuinely interactive cards
+
+## Colors
+
+A near-neutral system — cool greys and near-blacks carrying almost every pixel — with a single saturated Hack Club red that earns its rarity, and a small semantic set for state.
+
+### Primary
+- **Hack Club Red** (`{colors.accent}`): the one loud voice, and the brand's own value. Active navigation tint, unread dots, the Turbo progress bar, left-border accents on alert rows, icon fills, and any red that carries no text on it. Never used as a decorative fill or a background for a large region.
+- **Deepened Red** (`{colors.accent-strong}`): the resting fill of every button, badge, or surface that carries white text — see **The Deepened Red Rule**. Visually indistinguishable from the brand red at a glance; measurably different to a contrast checker.
+- **Pressed Red** (`{colors.accent-deep}`): the hover and pressed state under Deepened Red.
+- **Red Wash** (`{colors.accent-soft}`): a 10% tint used for the active-tab background in the participant header and for soft alert panels. It is the only way red is allowed to occupy area.
+
+### Secondary
+No second accent. Blue appears in the codebase (`bg-blue-600` buttons, `ring-blue-500` focus rings across the onboarding wizard and guardian portal) but it is **drift, not design** — see Do's and Don'ts.
+
+### Neutral
+- **Paper** (`{colors.bg-app}`): the app canvas behind everything. Never used for a card.
+- **Card White** (`{colors.bg-elev}`): the surface every card, panel, dropdown, and input sits on. The single most common background in the system.
+- **Rest Grey** (`{colors.bg-elev-2}`): sunken panels, the admin sidebar column, secondary-button hover.
+- **Press Grey** (`{colors.bg-elev-3}`): hover fills on icon buttons and dropdown items.
+- **Sunken Grey** (`{colors.bg-sunken}`): the active navigation item's background — the deepest neutral before you're into ink.
+- **Ink** (`{colors.text-strong}`): headings, active nav labels, primary values in a table. The darkest text.
+- **Slate** (`{colors.text}`): body copy default.
+- **Soft Slate** (`{colors.text-soft}`) and **Muted Steel** (`{colors.text-muted}`): secondary values, helper text, timestamps.
+- **Faint** (`{colors.text-faint}`): placeholders and disabled labels only. Not a text colour for anything a user must read.
+- **Hairline** (`{colors.border}`) / **Card Hairline** (`{colors.border-card}`) / **Strong Hairline** (`{colors.border-strong}`): the borders that do the structural work shadows would otherwise do.
+
+### Tertiary
+State colours, used as badge tints and status dots, never as brand:
+- **Mint** (`{colors.success}`) — complete, checked in, confirmed.
+- **Amber** (`{colors.warning}`) — awaiting the guardian, pending action, impersonation banner.
+- **Sky** (`{colors.info}`) — informational, awaiting participant.
+
+### Named Rules
+
+**The One Voice Rule.** Hack Club red covers ≤10% of any screen. If two things on a page are red, at most one of them is a button. Its rarity is what makes a red thing mean "act on me".
+
+**The No Literal Hex Rule.** Every colour resolves through a semantic custom property or a Tailwind token remapped in `themes.css`. A raw hex in a template is a theme bug: it renders correctly in light and wrong in the other seven. New work uses `var(--accent)`, not `#ec3750`.
+
+**The Deepened Red Rule.** `{colors.accent}` on white measures **4.02:1** — below WCAG AA's 4.5:1 for normal text. WCAG's large-text exemption (3:1) starts at 18.66px bold or 24px regular, which no button in Attend reaches, so the type cannot buy its way out. The colour moves instead: **wherever white text sits on red, the fill is `{colors.accent-strong}` (4.89:1)**, hovering to `{colors.accent-deep}`. `{colors.accent}` keeps every use that carries no text on it — dots, bars, icon fills, borders, tints, and the progress bar. The two reds are one perceptual step apart; nobody sees the difference, and every white label clears AA.
+
+## Typography
+
+**Display Font:** the system UI stack (`ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto`) — Tailwind's default, adopted deliberately. There is no webfont; a guardian on a slow connection gets text on first paint.
+**Body Font:** the same stack. One family, differentiated entirely by weight and size.
+**Label/Mono Font:** none distinct. `<kbd>` in the search trigger is the only monospace-adjacent treatment and it uses the same stack at 11px.
+
+**Character:** neutral, native, and unbranded on purpose. The type carries no personality of its own so the density can be high without becoming tiring, and so an eleven-line participant record reads as data rather than as design.
+
+### Hierarchy
+- **Display** (700, 1.875rem / `text-3xl`, 1.2): page titles on the few marketing-adjacent surfaces — home, public profiles, docs. Rare (30 uses).
+- **Headline** (700, 1.5rem / `text-2xl`, 1.25): the title of a screen or a major panel. The normal top of a page inside the app.
+- **Title** (600, 1.125rem / `text-lg`, 1.4): card headings, section headings within a form step, and the required size for text on a red fill.
+- **Body** (500, 0.875rem / `text-sm`, 1.5): the workhorse — by a factor of three the most common size in the codebase. Form labels, table cells, button text, nav items. `font-medium` is the default weight, not `font-normal`; the small size needs the extra stem.
+- **Label** (600, 0.75rem / `text-xs`, 1.4): status badges, helper text, metadata, timestamps.
+- **Eyebrow** (600, 0.6875rem, uppercase, 0.05em): sidebar section headers only.
+
+### Named Rules
+
+**The Weight-Before-Size Rule.** Hierarchy is built by moving 500 → 600 → 700 at the same size before reaching for a larger size. Attend has more levels of meaning than it has room for type sizes.
+
+**The Fourteen Rule.** Body copy is 14px, not 16px, everywhere inside the app shell — including on red fills, which is why **The Deepened Red Rule** moves the colour rather than the type. The one exception is long-form prose on the docs and public-profile surfaces, which may run at 16px with a 65–75ch measure.
+
+## Layout
+
+A single mobile-first column that becomes a shell at the large breakpoint. Participant and guardian surfaces use `container mx-auto px-4 sm:px-6 lg:px-8 py-8` with a content cap between `max-w-2xl` and `max-w-4xl` — forms stay narrow enough to read in one eye-line. Admin surfaces use a fixed **256px** (`w-64`) left sidebar that appears at `lg` and collapses to an overlay drawer below it, with content filling the remainder unconstrained; tables need the width.
+
+The breakpoint weighting tells the truth about the audience: `sm:` outnumbers `md:` more than three to one and `xl:` is essentially unused. Design for a phone, then for a laptop; there is no third case.
+
+Spacing runs on a 4px base with 8/12/16/24 doing nearly all the work. Card interiors are 24px (`p-6`) on desktop and 16px on mobile; stacked form fields sit 16px apart; related controls sit 8px apart. Buttons are `py-2 px-4` at rest.
+
+**The Full-Width-Then-Auto Rule.** Every primary action is `w-full sm:w-auto`. On a phone a button is a full-width target; on a desktop it shrinks to its content. This pattern appears on essentially every form in the app and is not optional on guardian or participant surfaces.
+
+## Elevation & Depth
+
+Attend is **flat by default, and borders do the work.** Depth is expressed as a tonal stack — `--bg-app` behind `--bg-elev` behind `--bg-elev-2`/`--bg-elev-3` — plus a 1px hairline. This is why `border-gray-300` appears 651 times and `shadow-sm` only 34: the border is the structure, not a shadow.
+
+Shadows are reserved for things that genuinely float above the document and need to break the plane.
+
+### Shadow Vocabulary
+- **Hairline lift** (`box-shadow: var(--shadow-sm)` → `0 1px 2px rgba(0,0,0,0.06)`): sticky headers and the app bar, where a border alone would disappear against a scrolling surface.
+- **Overlay** (`box-shadow: var(--shadow-lg)` → `0 8px 24px rgba(15,23,42,0.10)`): dropdowns, the command palette, modals, mobile drawers.
+- **Card lift** (`box-shadow: var(--hc-shadow-card)` → `0 4px 8px rgba(0,0,0,0.125)`): the legacy Hack Club card and pill button only, where it is part of the brand component rather than the layout system.
+
+Dark themes scale the same three roles up in opacity (0.4 / 0.5 / 0.6) because a shadow that reads on white vanishes on `#0f1115`.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** A surface is flat at rest. If you reach for a shadow, first ask whether the element actually floats. If it doesn't, it gets a border and a tonal step instead.
+
+## Shapes
+
+Two radii carry the system: **6px** (`rounded-md`, 702 uses) for anything interactive and rectangular — buttons, inputs, nav items, icon buttons — and **8px** (`rounded-lg`, 569 uses) for containers and cards. 12px (`rounded-xl`) appears only on floating overlays; 16px+ is essentially absent and should stay that way.
+
+**Full-round** (`rounded-full`, 296 uses) is the system's one piece of personality and it is strictly typed: status badges, avatars, count bubbles, sidebar selector pills, and the Hack Club pill button. A pill in Attend means "this is a piece of state or an identity", never "this is a generic button".
+
+Borders are always 1px, always a hairline neutral, never coloured except to signal state — a red left border on an alert row, an amber dashed border on the admin escape hatch in the participant header. The dashed border is meaningful: it marks a control that isn't part of the normal user's world.
+
+**The Two-Radius Rule.** 6px for controls, 8px for containers, full for state and identity. A third value needs a reason.
+
+## Components
+
+Components are **tactile and confident**: they respond when touched, and the response is proportional to how much the action matters.
+
+### Buttons
+- **Shape:** softly rounded (6px / `rounded-md`); the Hack Club variant is a full pill (9999px).
+- **Primary:** `{colors.accent-strong}` fill per **The Deepened Red Rule**, white text at 14px/500–600, `py-2 px-4`, `w-full sm:w-auto`.
+- **Hover / Focus:** fill deepens to `{colors.accent-deep}` over `transition-colors` (~150ms). Focus shows a 2px ring in `{colors.accent}` at 30% — never `ring-blue-500`.
+- **Secondary:** white fill, `{colors.text}` label, 1px hairline border, hover fills to `{colors.bg-elev-3}`. Used for "Back", "Cancel", and any second action in a pair.
+- **Hack Club pill:** `{colors.accent-strong}` fill, 700 weight, full radius, card shadow, and a `scale(1.0625)` lift on hover over 125ms. Reserved for the single most important call to action on marketing and first-run surfaces. It is the only component allowed to scale.
+- **Every button carries `cursor-pointer`** — Tailwind v4 no longer sets it on `<button>`, and a `<button>` that doesn't change the cursor reads as broken.
+
+### Cards / Containers
+- **Corner Style:** 8px (`rounded-lg`).
+- **Background:** `{colors.bg-elev}` on the `{colors.bg-app}` canvas.
+- **Shadow Strategy:** none at rest — see **The Flat-By-Default Rule**.
+- **Border:** 1px `{colors.border-card}`.
+- **Internal Padding:** 24px desktop, 16px mobile.
+- **Interactive variant:** when a whole card is a link, it lifts and scales on hover (`scale(1.0625)`, `--hc-shadow-elevated`). Only cards that navigate somewhere get this.
+
+### Inputs / Fields
+- **Style:** white fill, 1px hairline border, 6px radius, `px-3 py-2`, 14px/500 text.
+- **Focus:** outline removed, replaced by a 2px ring in `{colors.accent}` at 30% opacity plus a border shift to `{colors.accent}`. The ring is the only focus indicator, so it must never be suppressed.
+- **Placeholder:** `{colors.text-faint}` — placeholder text is decoration, never the label.
+- **Error:** red border and a 12px `{colors.danger}` message below the field, not a tooltip.
+- **Theming caveat:** `themes.css` sets `background-color` and `color` on bare `input, select, textarea` under every non-light theme. That rule beats Tailwind's utilities on specificity ties; new input styling must be verified in a dark theme, not only in light.
+
+### Status Badges
+Attend's most-repeated pattern and the closest thing it has to a signature. A full-round pill, 12px/600, `px-2.5 py-0.5`, tinted background with same-hue dark text: green for Complete, sky for Awaiting Participant, amber for Awaiting Parent, red for Withdrawn and Rejected, grey as the fallback. The tint carries the meaning at a glance and the word carries it precisely — **never the tint alone**, since colour is not an accessible signal on its own.
+
+### Navigation
+- **Participant header:** 64px tall, white, hairline bottom border. Links are 14px/500 in `{colors.text}`, 6px radius, and the active item takes an `{colors.accent-soft}` background with `{colors.accent}` text. Collapses to a hamburger below `md`.
+- **Admin sidebar:** 256px, `{colors.bg-elev-2}`, items at 13px/500 with a 20px icon in `{colors.text-muted}`; hover is a 4% black wash, active is `{colors.bg-sunken}` with `{colors.text-strong}` at 600 and the icon darkening to match. Section headers are uppercase 11px eyebrows. Sidebar selector pills (user, event) are full-round with a hairline border that darkens on hover.
+
+### Search Trigger
+A Stripe-style faux input in the admin header: 240px minimum, `{colors.bg-elev-2}` fill, hairline border, 8px radius, muted placeholder text, and a `<kbd>` shortcut hint pushed to the right edge. It looks like an input and behaves like a button that opens the command palette.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** resolve every colour through a semantic custom property (`var(--accent)`, `var(--text-strong)`) or a Tailwind token that `themes.css` remaps. There are eight themes; a literal hex serves one.
+- **Do** fill any red surface that carries white text with `{colors.accent-strong}`, not `{colors.accent}`. **The Deepened Red Rule** is an accessibility floor, not a preference, and no type size in Attend is large enough to opt out of it.
+- **Do** make every primary action `w-full sm:w-auto`. Guardians and participants are on phones.
+- **Do** build depth from tonal surfaces and 1px hairlines. Reach for a shadow only when the element genuinely floats.
+- **Do** pair every status colour with its word. A green pill without "Complete" in it is a colour-only signal.
+- **Do** verify new UI in a dark theme as well as light — `themes.css` overrides bare `input`, `select`, and `textarea` elements, and remaps `--color-white` away from white.
+- **Do** rebuild Tailwind before judging any visual change; the compiled CSS is the thing the browser sees.
+- **Do** add `cursor-pointer` to every button and clickable element.
+
+### Don't:
+- **Don't** add new `bg-blue-600` buttons or `ring-blue-500` focus rings. The blue running through the onboarding wizard and guardian portal (35 blue fills, 277 blue rings) is **drift from a Tailwind default, not a decision**. Red is the accent everywhere; converge on it when touching those files.
+- **Don't** let Hack Club red occupy area. It fills buttons, badges, and 1px borders. Large red panels, red page headers, and red backgrounds behind body copy are out — use `{colors.accent-soft}` if a red-tinted region is genuinely needed.
+- **Don't** ship gradients, hero imagery, or marketing motion inside the app shell. Attend is a tool someone uses to do a job, not a consumer event app.
+- **Don't** introduce a webfont. The system stack is a deliberate performance choice for guardians on slow connections and old phones.
+- **Don't** add a third container radius. 6px controls, 8px containers, full for state and identity.
+- **Don't** use `rounded-full` on a plain action button. A pill in Attend means state or identity; the Hack Club brand pill is the one sanctioned exception.
+- **Don't** suppress the focus ring. `focus:outline-none` is only acceptable when a `focus:ring-2` replaces it in the same class list.
+- **Don't** use `{colors.text-faint}` for anything a user has to read. It is for placeholders and disabled states only.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,68 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Three distinct audiences, each with its own surfaces. When their needs conflict, **each surface is designed for its own audience** — there is no global tiebreaker.
+
+- **Participants** — under-18 attendees of in-person Hack Club events. They pass through the multi-step onboarding wizard once (profile, travel, accommodation, health, guardian info), then live in a lightweight dashboard: their status, ticket/wallet pass, travel details, messages, documents to sign. Mostly on phones.
+- **Guardians** — parents or legal guardians, typically non-technical, arriving via a magic link (email or SMS) for a one-shot visit to complete consent forms, waivers, and emergency contact details. The hardest audience to convert; often on an old phone. A guardian portal center (`/guardian/portals`) lets them find their own portals by code.
+- **Staff** — Global Admin, Event Admin, Ops Staff, and Safeguarding Lead. They live in `/admin` for the length of an event cycle: dashboards, participant tables, rooming plans, travel ops, messaging blasts, incidents, audit logs, integrations. Density and speed matter more here than expression.
+
+## Product Purpose
+
+Attend onboards under-18 participants for in-person Hack Club events, collecting everything needed for safeguarding, travel, accommodation, and on-site operations in one system. Success is a participant who arrives at an event fully cleared — consent signed by a guardian, travel and rooming known, medical and accessibility needs recorded and access-controlled — without the organisers chasing anyone through spreadsheets.
+
+## Positioning
+
+- **The whole journey in one place.** Replaces the sprawl of forms, spreadsheets, and email chains: onboarding, guardian consent, travel legs, rooming, check-in scanning, messaging, and incident reporting live in a single system with one status per participant.
+- **Built for how Hack Club actually runs events.** Shaped around real HC event operations — Hack Club Auth, Slack, Twilio/Signal messaging, Apple and Google Wallet passes, QR check-in at the venue — rather than a generic event platform bent to fit.
+
+Not positioned as a general self-hostable product for other youth organisations, even though the code is public at `hackclub/attend`.
+
+## Operating Context
+
+- **Event cycle**: an event is created and configured by admins → participants are invited or apply → onboarding wizard → guardian magic-link consent (DocuSeal e-signature, plus physically-signed documents with photo upload) → ops fill in travel, rooming, dietary → wallet pass issued → QR scan check-in on site → incidents and notes logged during the event.
+- **Multi-event and series**: several events run concurrently, grouped into series; role assignments are scoped per event or per series.
+- **Off-screen materials**: signed waivers, excuse letters for school, printed/scanned physical documents, wallet passes on a phone at a venue door.
+- **Sideband channels**: email, SMS, and Slack all carry participants and guardians into the app; a link that 404s or a page that fails on an old phone is a dropped participant.
+- **PWA**: installable, with service worker and manifest.
+
+## Capabilities and Constraints
+
+- Rails 8.1 / Ruby 3.4, PostgreSQL with UUID primary keys, Hotwire (Turbo + Stimulus), Tailwind CSS, Propshaft + Importmap. No React/Vue build step — design work happens in ERB, Tailwind, and Stimulus controllers.
+- `app/assets/stylesheets/themes.css` carries the theme layer and, in places, overrides Tailwind (notably form inputs and `text-white`). Tailwind must be rebuilt before visual verification.
+- Devise + OmniAuth (Hack Club Auth) for identity; Pundit for authorization. Six roles: Participant, Guardian, Global Admin, Event Admin, Ops Staff, Safeguarding Lead.
+- Medical, accessibility, safeguarding, incident, and note records are encrypted at rest; access is role-scoped and every admin action is audit-logged (PaperTrail + console1984 + an `AuditLog` model).
+- Integrations: DocuSeal (consent), Airtable sync, Slack (OAuth + blasts), Twilio/Signal (SMS), Apple/Google Wallet, S3/Cloudflare R2 via Active Storage, an MCP server (toolchest), and a public JSON API with per-event and global tokens.
+- Public opt-in participant profiles at `/p/:slug` with deliberately conservative privacy defaults (checked-in past events only, noindex, photo opt-in).
+- Background work runs on Solid Queue; caching on Solid Cache; real-time on Solid Cable.
+
+## Brand Commitments
+
+Hack Club's visual identity is binding — existing HC colours, logo, and voice. Attend does not get a separate brand of its own.
+
+## Evidence on Hand
+
+- Real product surfaces exist and are the incumbent design authority: onboarding wizard, guardian portal, participant dashboard, admin dashboards and tables, public profiles, docs page, incident report form.
+- No testimonials, customer logos, pricing, benchmarks, or press exist. Do not fabricate them.
+- Seed data and development test accounts exist for local verification (see README).
+
+## Product Principles
+
+1. **Design each surface for the person on it.** The guardian portal and the ops dashboard are different products wearing one brand; don't average them.
+2. **A dropped guardian is a dropped participant.** Every guardian-facing path must survive an old phone, a bad connection, and a single visit with no second chance.
+3. **Sensitive data is shown only to the role that needs it.** Medical, safeguarding, and incident information is never made ambient for the sake of a nicer layout.
+4. **One status, everywhere.** A participant's readiness is a single truth surfaced consistently across participant, guardian, and staff views.
+5. **Real event operations beat abstraction.** When a design choice and the way an event actually runs disagree, the event wins.
+
+## Accessibility & Inclusion
+
+- WCAG 2.1 AA is the floor on every surface. Participants disclose real accessibility needs through this product; the product itself must not be the barrier.
+- Light and dark themes are both first-class — every surface must work in both, with `themes.css` as authority.
+- Mobile-first for participant and guardian surfaces; staff surfaces may assume a larger screen but must not break on one.

--- a/app/assets/stylesheets/themes.css
+++ b/app/assets/stylesheets/themes.css
@@ -561,6 +561,9 @@
   .bg-\[\#1a1d21\] { background-color: var(--bg-elev-2); }
   .bg-\[\#4A154B\] { background-color: var(--bg-darker); }
   .bg-\[\#ec3750\] { background-color: var(--accent); }
+  /* the resting fill under white text — #d42f46 clears WCAG AA where #ec3750
+   * does not. themed the same as --accent so non-light themes are unchanged. */
+  .bg-\[\#d42f46\] { background-color: var(--accent); }
   .bg-\[\#ec3750\]\/10 { background-color: var(--accent-soft); }
   .bg-\[\#33d6a6\]\/10 { background-color: var(--success-soft); }
 
@@ -588,6 +591,7 @@
   .hover\:bg-\[\#252429\]:hover { background-color: var(--bg-elev-3); }
   .hover\:bg-\[\#3e1240\]:hover { background-color: var(--bg-darker); }
   .hover\:bg-\[\#d42f46\]:hover { background-color: var(--accent-strong); }
+  .hover\:bg-\[\#b82840\]:hover { background-color: var(--accent-strong); }
   .hover\:bg-\[\#ec3750\]:hover { background-color: var(--accent); }
   .hover\:bg-\[\#f9fafc\]:hover { background-color: var(--bg-elev-2); }
   .hover\:border-\[\#ec3750\]:hover { border-color: var(--accent); }

--- a/app/views/admin/airport_mode/show.html.erb
+++ b/app/views/admin/airport_mode/show.html.erb
@@ -94,7 +94,7 @@
       <div class="flex flex-wrap gap-2 mb-3 items-center text-sm">
         <span class="text-gray-500">Group:</span>
         <%= link_to "All", url_for(request.params.except(:group_id).merge(only_path: true)),
-            class: "px-2.5 py-1 rounded-full border #{@selected_group.nil? ? 'bg-[#ec3750] text-white border-[#ec3750]' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}" %>
+            class: "px-2.5 py-1 rounded-full border #{@selected_group.nil? ? 'bg-[#d42f46] text-white border-[#ec3750]' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}" %>
         <% current_event.groups.ordered.each do |g| %>
           <%= link_to g.name, url_for(request.params.merge(group_id: g.id, only_path: true)),
               class: "px-2.5 py-1 rounded-full border #{@selected_group&.id == g.id ? 'border-transparent text-white' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}",

--- a/app/views/admin/audit_logs/index.html.erb
+++ b/app/views/admin/audit_logs/index.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="col-span-2 md:col-span-4 flex justify-end">
           <%= link_to "Clear", admin_audit_logs_path, class: "px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors mr-2" %>
-          <%= f.submit "Filter", class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+          <%= f.submit "Filter", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/audit_logs/versions.html.erb
+++ b/app/views/admin/audit_logs/versions.html.erb
@@ -31,7 +31,7 @@
         </div>
         <div class="col-span-2 md:col-span-5 flex justify-end">
           <%= link_to "Clear", versions_admin_audit_logs_path, class: "px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 mr-2" %>
-          <%= f.submit "Filter", class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Filter", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/bans/_form.html.erb
+++ b/app/views/admin/bans/_form.html.erb
@@ -54,6 +54,6 @@
 
   <div class="flex flex-col sm:flex-row justify-end gap-3">
     <%= link_to "Cancel", admin_bans_path, class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-    <%= f.submit submit_label, class: "w-full sm:w-auto px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+    <%= f.submit submit_label, class: "w-full sm:w-auto px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/bans/index.html.erb
+++ b/app/views/admin/bans/index.html.erb
@@ -4,7 +4,7 @@
       <h1 class="text-2xl font-bold text-gray-900">Ban List</h1>
       <p class="text-sm text-gray-500">Emails on this list are blocked from being added to any event.</p>
     </div>
-    <%= link_to "Add Ban", new_admin_ban_path, class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors" %>
+    <%= link_to "Add Ban", new_admin_ban_path, class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors" %>
   </div>
 
   <div class="bg-white border border-gray-200 rounded-lg">

--- a/app/views/admin/bans/show.html.erb
+++ b/app/views/admin/bans/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex gap-3">
       <%= link_to "Edit", edit_admin_ban_path(@ban), class: "px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
       <% if @ban.revoked? %>
-        <%= button_to "Reinstate", reinstate_admin_ban_path(@ban), method: :patch, class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors", data: { turbo_confirm: "Reinstate this ban? Its emails will be blocked from events again." } %>
+        <%= button_to "Reinstate", reinstate_admin_ban_path(@ban), method: :patch, class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors", data: { turbo_confirm: "Reinstate this ban? Its emails will be blocked from events again." } %>
       <% else %>
         <%= button_to "Revoke", revoke_admin_ban_path(@ban), method: :patch, class: "px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors", data: { turbo_confirm: "Revoke this ban? Its emails will be allowed into events again, but the record is kept." } %>
       <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -5,7 +5,7 @@
     <h1 class="text-2xl font-semibold text-gray-900">Events</h1>
     <% if policy(Event).create? || policy(EventSeries).create? %>
       <div class="relative" data-controller="dropdown">
-        <button type="button" data-action="dropdown#toggle" class="inline-flex items-center gap-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors">
+        <button type="button" data-action="dropdown#toggle" class="inline-flex items-center gap-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
           New
           <svg class="w-4 h-4 -mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
@@ -80,7 +80,7 @@
       <h2 class="text-base font-medium text-gray-900 mb-1">No events yet</h2>
       <p class="text-sm text-gray-500 mb-6">Create your first event to get started.</p>
       <% if policy(Event).create? %>
-        <%= link_to admin_new_event_path, class: "inline-flex items-center gap-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
+        <%= link_to admin_new_event_path, class: "inline-flex items-center gap-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
           Create Event
         <% end %>

--- a/app/views/admin/dashboard/integrations.html.erb
+++ b/app/views/admin/dashboard/integrations.html.erb
@@ -60,7 +60,7 @@
               <%= link_to "Use default template",
                   admin_event_docuseal_template_use_default_path(current_event, "waiver"),
                   data: { turbo_method: :post },
-                  class: "inline-flex items-center px-3 py-1.5 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
+                  class: "inline-flex items-center px-3 py-1.5 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
             <% end %>
           </div>
         </div>
@@ -88,7 +88,7 @@
                 <%= link_to "Use default template",
                     admin_event_docuseal_template_use_default_path(current_event, "freedom_waiver"),
                     data: { turbo_method: :post },
-                    class: "inline-flex items-center px-3 py-1.5 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
+                    class: "inline-flex items-center px-3 py-1.5 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
               <% end %>
             </div>
           </div>
@@ -283,7 +283,7 @@
 
     <!-- Save Button -->
     <div class="flex justify-end">
-      <%= f.submit "Save Integration Settings", class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+      <%= f.submit "Save Integration Settings", class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
     </div>
   <% end %>
 
@@ -502,7 +502,7 @@
             <%= f.text_field :name, placeholder: "attend-integration-name", required: true,
                 class: "flex-1 bg-transparent px-1 py-2 text-sm font-mono focus:outline-none" %>
           </div>
-          <%= f.submit "Create token", class: "bg-[#ec3750] text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Create token", class: "bg-[#d42f46] text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-[#b82840] cursor-pointer" %>
         <% end %>
       </div>
 
@@ -571,7 +571,7 @@
         <div class="flex items-center gap-3">
           <% if current_event.vote_event_admin_url.present? %>
             <%= link_to "Manage on vote.hackclub.com", current_event.vote_event_admin_url, target: "_blank", rel: "noopener",
-                class: "bg-[#ec3750] text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-[#d42f46]" %>
+                class: "bg-[#d42f46] text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-[#b82840]" %>
           <% end %>
           <% if current_event.vote_event_gallery_url.present? %>
             <%= link_to "View gallery", current_event.vote_event_gallery_url, target: "_blank", rel: "noopener",
@@ -597,7 +597,7 @@
               method: :post,
               disabled: !vote_ready,
               data: { confirm: "Create a new DRAFT event on vote.hackclub.com for \"#{current_event.name}\"?" },
-              class: "bg-[#ec3750] text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-[#d42f46] disabled:opacity-50 disabled:cursor-not-allowed" %>
+              class: "bg-[#d42f46] text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-[#b82840] disabled:opacity-50 disabled:cursor-not-allowed" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/docuseal_templates/mappings.html.erb
+++ b/app/views/admin/docuseal_templates/mappings.html.erb
@@ -39,7 +39,7 @@
       <%= button_to "Sync Fields from DocuSeal", 
           admin_event_docuseal_template_sync_path(current_event, @template_type),
           method: :post,
-          class: "inline-flex items-center px-4 py-2 bg-[#ec3750] hover:bg-[#d42f46] text-white font-medium rounded-lg transition-colors" %>
+          class: "inline-flex items-center px-4 py-2 bg-[#d42f46] hover:bg-[#b82840] text-white font-medium rounded-lg transition-colors" %>
     </div>
   <% else %>
     <!-- Template Info -->

--- a/app/views/admin/email_logs/index.html.erb
+++ b/app/views/admin/email_logs/index.html.erb
@@ -17,7 +17,7 @@
         </div>
         <div class="flex items-end gap-2">
           <%= link_to "Clear", admin_email_logs_path, class: "px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-          <%= f.submit "Filter", class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+          <%= f.submit "Filter", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/event_series/_form.html.erb
+++ b/app/views/admin/event_series/_form.html.erb
@@ -56,6 +56,6 @@
 
   <div class="flex flex-col sm:flex-row justify-between gap-3">
     <%= link_to "Cancel", @series.persisted? ? admin_series_path(@series) : admin_series_index_path, class: "w-full sm:w-auto text-center text-gray-500 hover:text-gray-700 font-medium py-2 px-4" %>
-    <%= f.submit @series.persisted? ? "Save changes" : "Create series", class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+    <%= f.submit @series.persisted? ? "Save changes" : "Create series", class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/event_series/index.html.erb
+++ b/app/views/admin/event_series/index.html.erb
@@ -4,7 +4,7 @@
   <div class="flex items-center justify-between mb-8">
     <h1 class="text-2xl font-semibold text-gray-900">Event Series</h1>
     <% if policy(EventSeries).create? %>
-      <%= link_to new_admin_series_path, class: "inline-flex items-center gap-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
+      <%= link_to new_admin_series_path, class: "inline-flex items-center gap-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
         New Series
       <% end %>
@@ -43,7 +43,7 @@
       <h2 class="text-base font-medium text-gray-900 mb-1">No series yet</h2>
       <p class="text-sm text-gray-500 mb-6">A series groups related events — like Sunbeam London and Sunbeam NYC — under shared branding and a shared team.</p>
       <% if policy(EventSeries).create? %>
-        <%= link_to new_admin_series_path, class: "inline-flex items-center gap-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
+        <%= link_to new_admin_series_path, class: "inline-flex items-center gap-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
           Create Series
         <% end %>

--- a/app/views/admin/event_series/show.html.erb
+++ b/app/views/admin/event_series/show.html.erb
@@ -31,7 +31,7 @@
         <% end %>
       <% end %>
       <% if policy(Event.new(event_series_id: @series.id)).create? %>
-        <%= link_to admin_new_event_path(series: @series.slug), class: "inline-flex items-center gap-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
+        <%= link_to admin_new_event_path(series: @series.slug), class: "inline-flex items-center gap-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
           New Event
         <% end %>
@@ -56,7 +56,7 @@
       <h2 class="text-base font-medium text-gray-900 mb-1">No events in this series yet</h2>
       <p class="text-sm text-gray-500 mb-6">Create the first event — it'll inherit this series' branding automatically.</p>
       <% if policy(Event.new(event_series_id: @series.id)).create? %>
-        <%= link_to admin_new_event_path(series: @series.slug), class: "inline-flex items-center gap-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
+        <%= link_to admin_new_event_path(series: @series.slug), class: "inline-flex items-center gap-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
           Create Event
         <% end %>

--- a/app/views/admin/event_setup/_progress.html.erb
+++ b/app/views/admin/event_setup/_progress.html.erb
@@ -18,7 +18,7 @@
         <% end %>
         <% step_content = capture do %>
           <span class="flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold
-            <%= index == current_index ? 'bg-[#ec3750] text-white' : (index < current_index ? 'bg-[#ec3750]/10 text-[#ec3750]' : 'bg-gray-100 text-gray-500 group-hover:bg-gray-200') %>">
+            <%= index == current_index ? 'bg-[#d42f46] text-white' : (index < current_index ? 'bg-[#ec3750]/10 text-[#ec3750]' : 'bg-gray-100 text-gray-500 group-hover:bg-gray-200') %>">
             <%= index + 1 %>
           </span>
           <span class="hidden sm:inline <%= index == current_index ? 'font-semibold text-gray-900' : 'text-gray-500 group-hover:text-gray-700' %>">

--- a/app/views/admin/event_setup/_waiver_options.html.erb
+++ b/app/views/admin/event_setup/_waiver_options.html.erb
@@ -4,7 +4,7 @@
       <div class="flex items-start gap-3">
         <%= radio_button_tag :waiver_mode, "auto", true, class: "mt-1 h-4 w-4 text-[#ec3750] focus:ring-[#ec3750] border-gray-300", data: { wizard_reveal_target: "input", action: "change->wizard-reveal#update" } %>
         <div>
-          <span class="text-sm font-semibold text-gray-900">Use the standard Hack Club waivers <span class="ml-1 text-xs font-medium text-white bg-[#ec3750] rounded-full px-2 py-0.5">Recommended</span></span>
+          <span class="text-sm font-semibold text-gray-900">Use the standard Hack Club waivers <span class="ml-1 text-xs font-medium text-white bg-[#d42f46] rounded-full px-2 py-0.5">Recommended</span></span>
           <p class="text-sm text-gray-500 mt-1">
             We'll create <%= event.freedom_waivers_enabled? ? "waiver and freedom waiver templates" : "a waiver template" %> for this event on DocuSeal and wire up all the field mappings automatically. Nothing else to configure.
           </p>
@@ -55,6 +55,6 @@
     <% else %>
       <%= link_to "Back", admin_event_setup_modules_path(event), class: "w-full sm:w-auto text-center text-gray-500 hover:text-gray-700 font-medium py-2 px-4" %>
     <% end %>
-    <%= f.submit "Continue", class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+    <%= f.submit "Continue", class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/event_setup/modules.html.erb
+++ b/app/views/admin/event_setup/modules.html.erb
@@ -98,7 +98,7 @@
 
     <div class="flex flex-col sm:flex-row justify-between gap-3">
       <%= link_to "Back", admin_event_setup_schedule_path(@event), class: "w-full sm:w-auto text-center text-gray-500 hover:text-gray-700 font-medium py-2 px-4" %>
-      <%= f.submit "Continue", class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+      <%= f.submit "Continue", class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/event_setup/review.html.erb
+++ b/app/views/admin/event_setup/review.html.erb
@@ -107,6 +107,6 @@
   </div>
 
   <div class="mt-6 flex flex-col sm:flex-row justify-end gap-3">
-    <%= button_to "Finish setup", admin_event_setup_complete_path(@event), method: :post, class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-6 rounded-lg transition-colors cursor-pointer" %>
+    <%= button_to "Finish setup", admin_event_setup_complete_path(@event), method: :post, class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-6 rounded-lg transition-colors cursor-pointer" %>
   </div>
 </div>

--- a/app/views/admin/event_setup/schedule.html.erb
+++ b/app/views/admin/event_setup/schedule.html.erb
@@ -78,7 +78,7 @@
 
     <div class="flex flex-col sm:flex-row justify-between gap-3">
       <%= link_to "Skip for now", admin_event_setup_modules_path(@event), class: "w-full sm:w-auto text-center text-gray-500 hover:text-gray-700 font-medium py-2 px-4" %>
-      <%= f.submit "Continue", class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+      <%= f.submit "Continue", class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/event_setup/team.html.erb
+++ b/app/views/admin/event_setup/team.html.erb
@@ -81,6 +81,6 @@
 
   <div class="mt-6 flex flex-col sm:flex-row justify-between gap-3">
     <%= link_to "Back", admin_event_setup_waivers_path(@event), class: "w-full sm:w-auto text-center text-gray-500 hover:text-gray-700 font-medium py-2 px-4" %>
-    <%= link_to "Continue", admin_event_setup_review_path(@event), class: "w-full sm:w-auto text-center bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
+    <%= link_to "Continue", admin_event_setup_review_path(@event), class: "w-full sm:w-auto text-center bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
   </div>
 </div>

--- a/app/views/admin/event_staff/index.html.erb
+++ b/app/views/admin/event_staff/index.html.erb
@@ -1,7 +1,7 @@
 <div class="space-y-6">
   <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
     <h1 class="text-2xl font-bold text-gray-900">Event Staff</h1>
-    <%= link_to "Add Staff Member", new_admin_event_staff_path(current_event), class: "w-full sm:w-auto text-center px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors" %>
+    <%= link_to "Add Staff Member", new_admin_event_staff_path(current_event), class: "w-full sm:w-auto text-center px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors" %>
   </div>
 
   <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">

--- a/app/views/admin/event_staff/new.html.erb
+++ b/app/views/admin/event_staff/new.html.erb
@@ -57,7 +57,7 @@
         <div class="bg-gray-50 -mx-6 -mb-4 px-6 py-4 mt-6">
           <div class="flex flex-col sm:flex-row justify-end gap-3">
             <%= link_to "Cancel", admin_event_staff_index_path(current_event), class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-            <%= f.submit "Add Staff Member", class: "w-full sm:w-auto px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+            <%= f.submit "Add Staff Member", class: "w-full sm:w-auto px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
           </div>
         </div>
       <% end %>

--- a/app/views/admin/events/_avatar.html.erb
+++ b/app/views/admin/events/_avatar.html.erb
@@ -11,7 +11,7 @@
     <%= image_tag logo.variant(resize_to_fill: [size * 2, size * 2]), class: "#{rounded} object-cover flex-shrink-0", style: "height: #{size}px; width: #{size}px;" %>
   <% end %>
 <% else %>
-  <span class="<%= rounded %> bg-[#ec3750] flex items-center justify-center font-bold text-white flex-shrink-0" style="height: <%= size %>px; width: <%= size %>px; font-size: <%= (size * 0.42).round %>px;">
+  <span class="<%= rounded %> bg-[#d42f46] flex items-center justify-center font-bold text-white flex-shrink-0" style="height: <%= size %>px; width: <%= size %>px; font-size: <%= (size * 0.42).round %>px;">
     <%= event.name.first.upcase %>
   </span>
 <% end %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -297,6 +297,6 @@
 
   <div class="flex flex-col sm:flex-row justify-end gap-3">
     <%= link_to "Cancel", (event.persisted? ? admin_event_dashboard_path(event.slug) : admin_root_path), class: "w-full sm:w-auto text-center bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-2 px-4 rounded-lg transition-colors" %>
-    <%= f.submit class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#ec3750] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+    <%= f.submit class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -4,7 +4,7 @@
   <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
     <h1 class="text-2xl font-bold">Events</h1>
     <% if policy(Event).create? %>
-      <%= link_to "New Event", admin_new_event_path, class: "bg-[#ec3750] hover:bg-[#ec3750] text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
+      <%= link_to "New Event", admin_new_event_path, class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
     <% end %>
   </div>
 

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -64,7 +64,7 @@
 
     <div class="flex flex-col sm:flex-row justify-between gap-3">
       <%= link_to "Cancel", admin_root_path, class: "w-full sm:w-auto text-center text-gray-500 hover:text-gray-700 font-medium py-2 px-4" %>
-      <%= f.submit "Create event & continue", class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d63146] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+      <%= f.submit "Create event & continue", class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -7,7 +7,7 @@
       <p class="text-gray-500"><%= @event.slug %></p>
     </div>
     <div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-      <%= button_to "Select Event", select_admin_event_path(@event), method: :post, class: "w-full sm:w-auto text-center bg-[#ec3750] hover:bg-[#ec3750] text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
+      <%= button_to "Select Event", select_admin_event_path(@event), method: :post, class: "w-full sm:w-auto text-center bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
       <%= link_to "Edit", edit_admin_event_path(@event), class: "w-full sm:w-auto text-center bg-gray-500 hover:bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg transition-colors" %>
     </div>
   </div>
@@ -252,7 +252,7 @@
               regenerate_api_key_admin_event_path(@event),
               method: :post,
               data: @event.api_key_set? ? { confirm: "This will invalidate the existing API key. Continue?" } : {},
-              class: "bg-[#ec3750] text-white px-4 py-2 rounded hover:bg-[#d42f46] text-sm" %>
+              class: "bg-[#d42f46] text-white px-4 py-2 rounded hover:bg-[#b82840] text-sm" %>
         </div>
       </div>
     </div>

--- a/app/views/admin/exports/index.html.erb
+++ b/app/views/admin/exports/index.html.erb
@@ -29,7 +29,7 @@
                 <span class="text-xs text-gray-500 ml-2"><%= pluralize(template.columns.size, "column") %><%= ", #{pluralize(template.filters.size, 'filter')}" if template.filters.any? %></span>
               </div>
               <div class="flex items-center gap-2 shrink-0">
-                <%= button_to "Download", admin_event_exports_path(current_event, template_id: template.id), method: :post, data: { turbo: false }, class: "px-3 py-1 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] text-xs" %>
+                <%= button_to "Download", admin_event_exports_path(current_event, template_id: template.id), method: :post, data: { turbo: false }, class: "px-3 py-1 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] text-xs" %>
                 <%= link_to "Load", admin_event_exports_path(current_event, template_id: template.id), class: "px-3 py-1 border border-gray-300 rounded-md text-xs text-gray-700 hover:bg-gray-100" %>
                 <%= button_to "Delete", admin_event_export_template_path(current_event, template), method: :delete, data: { turbo_confirm: "Delete template \"#{template.name}\"?" }, class: "px-3 py-1 border border-gray-300 rounded-md text-xs text-gray-500 hover:text-[#ec3750]" %>
               </div>
@@ -143,7 +143,7 @@
     </div>
 
     <div class="bg-white rounded-lg border border-gray-200 p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-      <%= button_tag "Download CSV", type: "submit", class: "px-6 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] text-sm font-medium cursor-pointer" %>
+      <%= button_tag "Download CSV", type: "submit", class: "px-6 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] text-sm font-medium cursor-pointer" %>
       <div class="flex items-center gap-2">
         <%= text_field_tag :template_name, nil, placeholder: "Template name", class: "rounded-md border-gray-300 text-sm" %>
         <%= button_tag "Save as template", type: "submit", formaction: admin_event_export_templates_path(current_event), formmethod: "post",

--- a/app/views/admin/global_api_tokens/index.html.erb
+++ b/app/views/admin/global_api_tokens/index.html.erb
@@ -21,7 +21,7 @@
                 class: "w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-[#ec3750] focus:border-[#ec3750]" %>
         </div>
         <%= f.submit "Generate Token",
-              class: "bg-[#ec3750] hover:bg-[#d42f46] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer" %>
+              class: "bg-[#d42f46] hover:bg-[#b82840] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer" %>
       <% end %>
 
       <% if flash[:global_api_token] %>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -46,6 +46,6 @@
 
   <div class="pt-4 flex flex-col sm:flex-row justify-end gap-3">
     <%= link_to "Cancel", admin_event_groups_path(current_event), class: "w-full sm:w-auto text-center bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300" %>
-    <%= f.submit group.persisted? ? "Update Group" : "Create Group", class: "w-full sm:w-auto bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+    <%= f.submit group.persisted? ? "Update Group" : "Create Group", class: "w-full sm:w-auto bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -75,7 +75,7 @@
           </div>
         </div>
       </div>
-      <button type="submit" class="bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46]">Add selected</button>
+      <button type="submit" class="bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840]">Add selected</button>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/groups/index.html.erb
+++ b/app/views/admin/groups/index.html.erb
@@ -4,7 +4,7 @@
       <h1 class="text-2xl font-bold">Groups</h1>
       <p class="text-sm text-gray-500 mt-1">Cohorts within this event (e.g. Hardware, General Attendance). Shown on tickets, scans, and the participant table.</p>
     </div>
-    <%= link_to "New Group", new_admin_event_group_path(current_event), class: "bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46]" %>
+    <%= link_to "New Group", new_admin_event_group_path(current_event), class: "bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840]" %>
   </div>
 
   <% if @groups.any? %>

--- a/app/views/admin/guardians/edit.html.erb
+++ b/app/views/admin/guardians/edit.html.erb
@@ -108,7 +108,7 @@
         </section>
 
         <div class="pt-4 border-t flex flex-col sm:flex-row gap-3">
-          <%= f.submit "Save Guardian", class: "w-full sm:w-auto bg-[#ec3750] text-white px-6 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Save Guardian", class: "w-full sm:w-auto bg-[#d42f46] text-white px-6 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
           <%= link_to "Cancel", admin_event_participant_path(current_event, @participant_event), class: "w-full sm:w-auto text-center px-6 py-2 text-gray-600 hover:text-gray-900" %>
         </div>
       </div>

--- a/app/views/admin/imports/new.html.erb
+++ b/app/views/admin/imports/new.html.erb
@@ -43,7 +43,7 @@
             <h3 class="font-semibold text-blue-800">Need a template?</h3>
             <p class="text-sm text-blue-700">Download a CSV template with all supported columns.</p>
           </div>
-          <%= link_to template_admin_event_imports_path(current_event), class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] text-sm" do %>
+          <%= link_to template_admin_event_imports_path(current_event), class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] text-sm" do %>
             Download Template
           <% end %>
         </div>
@@ -73,7 +73,7 @@
 
       <div class="flex justify-end gap-4">
         <%= link_to "Cancel", admin_event_participants_path(current_event), class: "px-4 py-2 text-gray-700 hover:text-gray-900" %>
-        <%= submit_tag "Upload & Preview", class: "px-6 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed", id: "submit-btn", data: { dropzone_target: "submit" }, disabled: true %>
+        <%= submit_tag "Upload & Preview", class: "px-6 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed", id: "submit-btn", data: { dropzone_target: "submit" }, disabled: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/imports/progress.html.erb
+++ b/app/views/admin/imports/progress.html.erb
@@ -71,7 +71,7 @@
 
   <% if @import_batch.completed? %>
     <div class="mt-6 flex justify-center">
-      <%= link_to "View Imported Participants", admin_event_participants_path(current_event), class: "px-6 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46]" %>
+      <%= link_to "View Imported Participants", admin_event_participants_path(current_event), class: "px-6 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840]" %>
     </div>
   <% end %>
 

--- a/app/views/admin/incident_reports/index.html.erb
+++ b/app/views/admin/incident_reports/index.html.erb
@@ -18,7 +18,7 @@
   <div class="flex flex-wrap gap-2 mb-6 text-sm">
     <% nav_link = ->(label, params_hash) {
          active = params_hash.all? { |k, v| params[k].to_s == v.to_s } && (params_hash.any? || params[:priority].blank?)
-         link_to label, admin_incidents_path(params_hash), class: "px-3 py-1.5 rounded-md border #{active ? 'bg-[#ec3750] text-white border-[#ec3750]' : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'}"
+         link_to label, admin_incidents_path(params_hash), class: "px-3 py-1.5 rounded-md border #{active ? 'bg-[#d42f46] text-white border-[#ec3750]' : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'}"
        } %>
     <%= nav_link.("All priorities", {}) %>
     <%= nav_link.("Emergency only", { priority: "emergency" }) %>

--- a/app/views/admin/incident_reports/show.html.erb
+++ b/app/views/admin/incident_reports/show.html.erb
@@ -85,7 +85,7 @@
                 {},
                 class: "border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
           </div>
-          <%= f.submit "Add Comment", class: "bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Add Comment", class: "bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
         </div>
         <% if @incident_report.reporter_phone.present? %>
           <label class="flex items-center gap-2 text-sm text-gray-700">
@@ -134,7 +134,7 @@
                       <% elsif timeline_user&.avatar_displayable? %>
                         <%= image_tag timeline_user.avatar.variant(resize_to_fill: [ 32, 32 ]), class: "h-8 w-8 rounded-full object-cover ring-8 ring-white" %>
                       <% elsif entry[:type] == :comment %>
-                        <span class="h-8 w-8 rounded-full bg-[#ec3750] flex items-center justify-center ring-8 ring-white text-xs font-medium text-white">
+                        <span class="h-8 w-8 rounded-full bg-[#d42f46] flex items-center justify-center ring-8 ring-white text-xs font-medium text-white">
                           <%= timeline_user&.initials || "?" %>
                         </span>
                       <% else %>

--- a/app/views/admin/incident_settings/show.html.erb
+++ b/app/views/admin/incident_settings/show.html.erb
@@ -80,7 +80,7 @@
 
       <div class="pt-2">
         <%= submit_tag "Save settings",
-              class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-medium px-5 py-2 rounded-md cursor-pointer" %>
+              class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-medium px-5 py-2 rounded-md cursor-pointer" %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/incidents/_form.html.erb
+++ b/app/views/admin/incidents/_form.html.erb
@@ -181,6 +181,6 @@
 
   <div class="pt-4 flex flex-col sm:flex-row justify-end gap-3">
     <%= link_to "Cancel", admin_event_incidents_path(current_event), class: "w-full sm:w-auto text-center bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300" %>
-    <%= f.submit incident.persisted? ? "Update Incident" : "Create Incident", class: "w-full sm:w-auto bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+    <%= f.submit incident.persisted? ? "Update Incident" : "Create Incident", class: "w-full sm:w-auto bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/incidents/index.html.erb
+++ b/app/views/admin/incidents/index.html.erb
@@ -3,7 +3,7 @@
 <div class="w-full">
   <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
     <h1 class="text-2xl font-bold">Incidents</h1>
-    <%= link_to "New Incident", new_admin_event_incident_path(current_event), class: "bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46]" %>
+    <%= link_to "New Incident", new_admin_event_incident_path(current_event), class: "bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840]" %>
   </div>
 
   <% if @incidents.any? %>

--- a/app/views/admin/incidents/show.html.erb
+++ b/app/views/admin/incidents/show.html.erb
@@ -7,7 +7,7 @@
       <% if @incident.behavior? || @incident.safeguarding? || @incident.other? %>
         <%= button_to "Send to Slack", send_to_slack_admin_event_incident_path(current_event, @incident), method: :post, class: "w-full sm:w-auto text-center bg-purple-600 text-white px-4 py-2 rounded-md hover:bg-purple-700 cursor-pointer", data: { turbo_confirm: "Send this conduct report to Slack?" } %>
       <% end %>
-      <%= link_to "Edit", edit_admin_event_incident_path(current_event, @incident), class: "w-full sm:w-auto text-center bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46]" %>
+      <%= link_to "Edit", edit_admin_event_incident_path(current_event, @incident), class: "w-full sm:w-auto text-center bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840]" %>
       <%= link_to "← Back to Incidents", admin_event_incidents_path(current_event), class: "w-full sm:w-auto text-center bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300" %>
     </div>
   </div>
@@ -123,7 +123,7 @@
                 {},
                 class: "border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
           </div>
-          <%= f.submit "Add Comment", class: "bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Add Comment", class: "bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
         </div>
       <% end %>
     </div>
@@ -170,7 +170,7 @@
                     <% elsif timeline_user&.avatar_displayable? %>
                       <%= image_tag timeline_user.avatar.variant(resize_to_fill: [32, 32]), class: "h-8 w-8 rounded-full object-cover ring-8 ring-white" %>
                     <% elsif entry[:type] == :comment %>
-                      <span class="h-8 w-8 rounded-full bg-[#ec3750] flex items-center justify-center ring-8 ring-white text-xs font-medium text-white">
+                      <span class="h-8 w-8 rounded-full bg-[#d42f46] flex items-center justify-center ring-8 ring-white text-xs font-medium text-white">
                         <%= timeline_user&.initials || "?" %>
                       </span>
                     <% else %>

--- a/app/views/admin/messages/_form.html.erb
+++ b/app/views/admin/messages/_form.html.erb
@@ -190,7 +190,7 @@
       <!-- Actions -->
       <div class="flex justify-end items-center pt-4 border-t border-gray-200">
         <%= f.submit "Next: Preview →",
-            class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold py-2 px-6 rounded-lg cursor-pointer" %>
+            class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-6 rounded-lg cursor-pointer" %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/messages/index.html.erb
+++ b/app/views/admin/messages/index.html.erb
@@ -7,7 +7,7 @@
       <p class="text-gray-600">Send messages to attendees and guardians via multiple channels.</p>
     </div>
     <%= link_to "New Message", new_admin_event_message_path(current_event), 
-        class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold py-2 px-4 rounded-lg" %>
+        class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg" %>
   </div>
 
   <% if @messages.any? %>
@@ -116,7 +116,7 @@
       <p class="mt-1 text-sm text-gray-500">Get started by creating a new message.</p>
       <div class="mt-6">
         <%= link_to "New Message", new_admin_event_message_path(current_event), 
-            class: "inline-flex items-center px-4 py-2 border border-transparent  text-sm font-medium rounded-md text-white bg-[#ec3750] hover:bg-[#d42f46]" %>
+            class: "inline-flex items-center px-4 py-2 border border-transparent  text-sm font-medium rounded-md text-white bg-[#d42f46] hover:bg-[#b82840]" %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/messages/preview.html.erb
+++ b/app/views/admin/messages/preview.html.erb
@@ -63,7 +63,7 @@
           </h2>
           <div class="bg-[#1a1d21] rounded-lg p-4 text-white">
             <div class="flex items-start gap-3">
-              <div class="w-9 h-9 rounded bg-[#ec3750] flex items-center justify-center flex-shrink-0">
+              <div class="w-9 h-9 rounded bg-[#d42f46] flex items-center justify-center flex-shrink-0">
                 <span class="text-white font-bold text-sm">HC</span>
               </div>
               <div class="flex-1 min-w-0">
@@ -157,7 +157,7 @@
           <%= button_to "Send Now", send_now_admin_event_message_path(current_event, @message), 
               method: :post,
               data: { confirm: "Send this message to #{@total_count} recipients now?" },
-              class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold py-2 px-6 rounded-lg",
+              class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-6 rounded-lg",
               disabled: @total_count == 0 %>
         <% end %>
       </div>

--- a/app/views/admin/messages/show.html.erb
+++ b/app/views/admin/messages/show.html.erb
@@ -101,7 +101,7 @@
         <%= button_to "Send Now", send_now_admin_event_message_path(current_event, @message), 
             method: :post,
             data: { confirm: "Are you sure you want to send this message now?" },
-            class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold py-2 px-4 rounded-lg" %>
+            class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg" %>
       <% end %>
 
       <% if @message.scheduled? %>

--- a/app/views/admin/participants/accommodation.html.erb
+++ b/app/views/admin/participants/accommodation.html.erb
@@ -110,7 +110,7 @@
         </div>
 
         <div class="pt-4 flex flex-col sm:flex-row gap-3">
-          <%= f.submit "Save Accommodation", class: "w-full sm:w-auto bg-[#ec3750] text-white px-6 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Save Accommodation", class: "w-full sm:w-auto bg-[#d42f46] text-white px-6 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
           <%= link_to "Cancel", admin_event_participant_path(current_event, @participant_event), class: "w-full sm:w-auto text-center px-6 py-2 text-gray-600 hover:text-gray-900" %>
         </div>
       </div>

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -82,7 +82,7 @@
         </div>
 
         <div class="pt-4 flex flex-col sm:flex-row gap-3">
-          <%= f.submit "Save Changes", class: "w-full sm:w-auto bg-[#ec3750] text-white px-6 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Save Changes", class: "w-full sm:w-auto bg-[#d42f46] text-white px-6 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
           <%= link_to "Cancel", admin_event_participant_path(current_event, @participant_event), class: "w-full sm:w-auto text-center px-6 py-2 text-gray-600 hover:text-gray-900" %>
         </div>
       </div>

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -27,7 +27,7 @@
         </svg>
         Import
       <% end %>
-      <%= link_to new_invite_admin_event_participants_path(current_event), class: "text-sm font-medium text-white bg-[#ec3750] px-3 py-1.5 rounded-md hover:bg-[#d42f46] transition-colors inline-flex items-center gap-1.5" do %>
+      <%= link_to new_invite_admin_event_participants_path(current_event), class: "text-sm font-medium text-white bg-[#d42f46] px-3 py-1.5 rounded-md hover:bg-[#b82840] transition-colors inline-flex items-center gap-1.5" do %>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>

--- a/app/views/admin/participants/medical.html.erb
+++ b/app/views/admin/participants/medical.html.erb
@@ -216,7 +216,7 @@
     </div>
 
     <div class="mt-6 flex flex-col sm:flex-row gap-3">
-      <%= form.submit "Save All Information", class: "w-full sm:w-auto bg-[#ec3750] text-white px-6 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+      <%= form.submit "Save All Information", class: "w-full sm:w-auto bg-[#d42f46] text-white px-6 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
       <%= link_to "Cancel", admin_event_participant_path(current_event, @participant_event), class: "w-full sm:w-auto text-center px-6 py-2 text-gray-600 hover:text-gray-900" %>
     </div>
   <% end %>

--- a/app/views/admin/participants/merge.html.erb
+++ b/app/views/admin/participants/merge.html.erb
@@ -18,7 +18,7 @@
       <div class="flex gap-2">
         <%= f.text_field :q, value: @query, placeholder: "Search by name or email…",
             class: "flex-1 px-3 py-2 rounded-md border-gray-300 focus:border-[#ec3750] focus:ring-[#ec3750] text-sm" %>
-        <%= f.submit "Search", class: "text-sm font-medium text-white bg-[#ec3750] px-4 py-2 rounded-md hover:bg-[#d63146] cursor-pointer" %>
+        <%= f.submit "Search", class: "text-sm font-medium text-white bg-[#d42f46] px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
       </div>
     <% end %>
 

--- a/app/views/admin/participants/new_invite.html.erb
+++ b/app/views/admin/participants/new_invite.html.erb
@@ -51,7 +51,7 @@
 
         <div class="flex flex-col sm:flex-row justify-end gap-3">
           <%= link_to "Cancel", admin_event_participants_path(current_event), class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-          <%= f.submit "Send Invitation", class: "w-full sm:w-auto px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+          <%= f.submit "Send Invitation", class: "w-full sm:w-auto px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/participants/notes.html.erb
+++ b/app/views/admin/participants/notes.html.erb
@@ -26,7 +26,7 @@
         </div>
 
         <div>
-          <%= f.submit "Add Note", class: "bg-[#ec3750] text-white px-6 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= f.submit "Add Note", class: "bg-[#d42f46] text-white px-6 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
         </div>
       </div>
     <% end %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -213,7 +213,7 @@
             <%# always submit at least an empty array %>
             <input type="hidden" name="group_ids[]" value="">
             <div class="pt-2">
-              <button type="submit" class="bg-[#ec3750] text-white px-4 py-1.5 rounded-md hover:bg-[#d42f46] text-sm">Save groups</button>
+              <button type="submit" class="bg-[#d42f46] text-white px-4 py-1.5 rounded-md hover:bg-[#b82840] text-sm">Save groups</button>
               <%= link_to "Manage groups", admin_event_groups_path(current_event), class: "ml-3 text-sm text-gray-500 hover:text-gray-700" %>
             </div>
           <% end %>

--- a/app/views/admin/participants/table.html.erb
+++ b/app/views/admin/participants/table.html.erb
@@ -51,7 +51,7 @@
         </svg>
         Filter
         <% if params[:filters].present? %>
-          <span class="bg-[#ec3750] text-white text-xs px-1.5 py-0.5 rounded-full"><%= params[:filters].keys.count %></span>
+          <span class="bg-[#d42f46] text-white text-xs px-1.5 py-0.5 rounded-full"><%= params[:filters].keys.count %></span>
         <% end %>
       </button>
 
@@ -174,7 +174,7 @@
           Clear all
         </button>
         <button type="button"
-                class="px-3 py-1.5 bg-[#ec3750] text-white text-sm rounded hover:bg-[#d42f46]"
+                class="px-3 py-1.5 bg-[#d42f46] text-white text-sm rounded hover:bg-[#b82840]"
                 data-action="click->data-table#applyFilters">
           Apply Filters
         </button>

--- a/app/views/admin/participants/travel.html.erb
+++ b/app/views/admin/participants/travel.html.erb
@@ -292,7 +292,7 @@
     <!-- Submit -->
     <div class="flex justify-end gap-3">
       <%= link_to "Cancel", admin_event_participant_path(current_event, @participant_event), class: "px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200" %>
-      <%= form.submit "Save Travel Information", class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+      <%= form.submit "Save Travel Information", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/profile/edit.html.erb
+++ b/app/views/admin/profile/edit.html.erb
@@ -77,7 +77,7 @@
         </div>
 
         <div class="flex justify-end pt-4">
-          <%= f.submit "Save Changes", class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+          <%= f.submit "Save Changes", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
         </div>
       <% end %>
 

--- a/app/views/admin/rooming_wizard/_group_filter.html.erb
+++ b/app/views/admin/rooming_wizard/_group_filter.html.erb
@@ -2,7 +2,7 @@
   <div class="mb-4 flex items-center gap-2 text-sm">
     <span class="text-gray-500">Group:</span>
     <%= link_to "All", url_for(request.params.except(:group_id).merge(only_path: true)),
-        class: "px-2.5 py-1 rounded-full border #{selected_group.nil? ? 'bg-[#ec3750] text-white border-[#ec3750]' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}" %>
+        class: "px-2.5 py-1 rounded-full border #{selected_group.nil? ? 'bg-[#d42f46] text-white border-[#ec3750]' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}" %>
     <% current_event.groups.ordered.each do |g| %>
       <%= link_to g.name, url_for(request.params.merge(group_id: g.id, only_path: true)),
           class: "px-2.5 py-1 rounded-full border #{selected_group&.id == g.id ? 'border-transparent text-white' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}",

--- a/app/views/admin/rooming_wizard/_summary_bar.html.erb
+++ b/app/views/admin/rooming_wizard/_summary_bar.html.erb
@@ -44,7 +44,7 @@
           Lock
         <% end %>
       <% end %>
-      <%= link_to finalize_admin_event_rooming_wizard_path(@event.slug), class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md  text-white bg-[#ec3750] hover:bg-[#d42f46]" do %>
+      <%= link_to finalize_admin_event_rooming_wizard_path(@event.slug), class: "inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md  text-white bg-[#d42f46] hover:bg-[#b82840]" do %>
         Continue to Finalize
         <svg class="ml-2 -mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>

--- a/app/views/admin/rooming_wizard/assignments.html.erb
+++ b/app/views/admin/rooming_wizard/assignments.html.erb
@@ -62,7 +62,7 @@
           <button type="button" onclick="document.getElementById('add-room-modal').classList.add('hidden')" class="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 border border-gray-300 rounded-md">
             Cancel
           </button>
-          <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-[#ec3750] hover:bg-[#d42f46] rounded-md">
+          <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-[#d42f46] hover:bg-[#b82840] rounded-md">
             Create Room
           </button>
         </div>

--- a/app/views/admin/rooming_wizard/export_csv.html.erb
+++ b/app/views/admin/rooming_wizard/export_csv.html.erb
@@ -16,7 +16,7 @@
       <p class="mt-2 text-gray-500">The rooming assignments have been finalized.</p>
       
       <div class="mt-6 flex justify-center gap-4">
-        <%= link_to export_csv_admin_event_rooming_wizard_path(@event.slug, format: :csv), class: "inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md  text-white bg-[#ec3750] hover:bg-[#d42f46]" do %>
+        <%= link_to export_csv_admin_event_rooming_wizard_path(@event.slug, format: :csv), class: "inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md  text-white bg-[#d42f46] hover:bg-[#b82840]" do %>
           <svg class="-ml-1 mr-3 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
           </svg>

--- a/app/views/admin/rooming_wizard/preferences.html.erb
+++ b/app/views/admin/rooming_wizard/preferences.html.erb
@@ -29,7 +29,7 @@
       </div>
       <div class="flex gap-3">
         <%= form_with url: auto_assign_admin_event_rooming_wizard_path(@event.slug), method: :post, class: "inline" do %>
-          <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md  text-white bg-[#ec3750] hover:bg-[#d42f46]">
+          <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md  text-white bg-[#d42f46] hover:bg-[#b82840]">
             Continue to Auto-Assign
             <svg class="ml-2 -mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -147,7 +147,7 @@
           <button type="button" onclick="closeLinkModal()" class="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 border border-gray-300 rounded-md">
             Cancel
           </button>
-          <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-[#ec3750] hover:bg-[#d42f46] rounded-md">
+          <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-[#d42f46] hover:bg-[#b82840] rounded-md">
             Link
           </button>
         </div>

--- a/app/views/admin/rooming_wizard/setup.html.erb
+++ b/app/views/admin/rooming_wizard/setup.html.erb
@@ -110,7 +110,7 @@
       </button>
 
       <div class="flex justify-end pt-2">
-        <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-[#ec3750] hover:bg-[#d42f46] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#ec3750]">
+        <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-[#d42f46] hover:bg-[#b82840] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#ec3750]">
           Continue to Preference Linking
           <svg class="ml-2 -mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -257,7 +257,7 @@
           <button type="button" onclick="document.getElementById('sibling-modal').classList.add('hidden')" class="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 border border-gray-300 rounded-md">
             Cancel
           </button>
-          <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-[#ec3750] hover:bg-[#d42f46] rounded-md">
+          <button type="submit" class="px-4 py-2 text-sm font-medium text-white bg-[#d42f46] hover:bg-[#b82840] rounded-md">
             Create Group
           </button>
         </div>

--- a/app/views/admin/scan_contexts/_form.html.erb
+++ b/app/views/admin/scan_contexts/_form.html.erb
@@ -68,6 +68,6 @@
 
   <div class="pt-4 flex flex-col sm:flex-row justify-end gap-3">
     <%= link_to "Cancel", admin_event_scan_contexts_path(current_event), class: "w-full sm:w-auto text-center bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300" %>
-    <%= f.submit scan_context.persisted? ? "Update Context" : "Create Context", class: "w-full sm:w-auto bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+    <%= f.submit scan_context.persisted? ? "Update Context" : "Create Context", class: "w-full sm:w-auto bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/scan_contexts/index.html.erb
+++ b/app/views/admin/scan_contexts/index.html.erb
@@ -4,7 +4,7 @@
       <h1 class="text-2xl font-bold">Scan Contexts</h1>
       <p class="text-sm text-gray-500 mt-1">Manage locations and contexts for QR code scanning</p>
     </div>
-    <%= link_to "New Context", new_admin_event_scan_context_path(current_event), class: "bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46]" %>
+    <%= link_to "New Context", new_admin_event_scan_context_path(current_event), class: "bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840]" %>
   </div>
 
   <% if @scan_contexts.any? %>

--- a/app/views/admin/scans/history.html.erb
+++ b/app/views/admin/scans/history.html.erb
@@ -53,7 +53,7 @@
         <% end %>
 
         <div>
-          <%= submit_tag "Filter", class: "bg-[#ec3750] text-white px-4 py-2 rounded-md hover:bg-[#d42f46] cursor-pointer" %>
+          <%= submit_tag "Filter", class: "bg-[#d42f46] text-white px-4 py-2 rounded-md hover:bg-[#b82840] cursor-pointer" %>
           <% if params[:search].present? || params[:scan_context_id].present? || params[:user_id].present? || params[:date].present? || params[:group_id].present? %>
             <%= link_to "Clear", history_admin_event_scans_path(current_event), class: "ml-2 text-gray-600 hover:text-gray-900" %>
           <% end %>
@@ -186,7 +186,7 @@
         </div>
         
         <div class="mt-6 flex gap-3">
-          <button type="submit" class="flex-1 bg-[#ec3750] text-white px-4 py-2 rounded-lg hover:bg-[#d42f46] font-medium">
+          <button type="submit" class="flex-1 bg-[#d42f46] text-white px-4 py-2 rounded-lg hover:bg-[#b82840] font-medium">
             Save Changes
           </button>
           <button type="button" onclick="closeEditModal()" class="flex-1 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 font-medium">

--- a/app/views/admin/scans/index.html.erb
+++ b/app/views/admin/scans/index.html.erb
@@ -20,7 +20,7 @@
         </svg>
         History
       <% end %>
-      <%= link_to scanner_admin_event_scans_path(current_event), class: "inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#ec3750] text-sm font-semibold text-white hover:bg-[#d42f46] transition-colors" do %>
+      <%= link_to scanner_admin_event_scans_path(current_event), class: "inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#d42f46] text-sm font-semibold text-white hover:bg-[#b82840] transition-colors" do %>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
         </svg>

--- a/app/views/admin/scans/scanner.html.erb
+++ b/app/views/admin/scans/scanner.html.erb
@@ -73,7 +73,7 @@
         <form id="manual-scan-form" class="flex flex-col sm:flex-row gap-2">
           <input type="text" id="manual-participant-id" placeholder="Participant ID (UUID)" 
                  class="flex-1 border border-gray-300 rounded-md px-3 py-2.5 sm:py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-[#ec3750]">
-          <button type="submit" class="bg-[#ec3750] text-white px-4 py-2.5 sm:py-2 rounded-md hover:bg-[#d42f46] text-sm font-medium min-h-[44px] sm:min-h-0">
+          <button type="submit" class="bg-[#d42f46] text-white px-4 py-2.5 sm:py-2 rounded-md hover:bg-[#b82840] text-sm font-medium min-h-[44px] sm:min-h-0">
             Look Up
           </button>
         </form>
@@ -201,7 +201,7 @@
       </dl>
 
       <div class="mt-6 flex flex-col sm:flex-row gap-3">
-        <a id="modal-view-link" href="#" class="flex-1 bg-[#ec3750] text-white px-4 py-3 sm:py-2 rounded-lg text-center hover:bg-[#d42f46] font-medium min-h-[44px] flex items-center justify-center">
+        <a id="modal-view-link" href="#" class="flex-1 bg-[#d42f46] text-white px-4 py-3 sm:py-2 rounded-lg text-center hover:bg-[#b82840] font-medium min-h-[44px] flex items-center justify-center">
           View Full Profile
         </a>
         <button onclick="closeModal()" class="flex-1 bg-gray-100 text-gray-700 px-4 py-3 sm:py-2 rounded-lg hover:bg-gray-200 font-medium min-h-[44px]">

--- a/app/views/admin/series_members/index.html.erb
+++ b/app/views/admin/series_members/index.html.erb
@@ -6,7 +6,7 @@
       <%= render "admin/events/avatar", event: @series, size: 32, rounded: "rounded-lg" %>
       <h1 class="text-2xl font-bold text-gray-900 truncate"><%= @series.name %> Members</h1>
     </div>
-    <%= link_to "Add Member", new_admin_series_member_path(@series), class: "w-full sm:w-auto text-center px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors" %>
+    <%= link_to "Add Member", new_admin_series_member_path(@series), class: "w-full sm:w-auto text-center px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors" %>
   </div>
 
   <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">

--- a/app/views/admin/series_members/new.html.erb
+++ b/app/views/admin/series_members/new.html.erb
@@ -59,7 +59,7 @@
         <div class="bg-gray-50 -mx-6 -mb-4 px-6 py-4 mt-6">
           <div class="flex flex-col sm:flex-row justify-end gap-3">
             <%= link_to "Cancel", admin_series_members_path(@series), class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-            <%= f.submit "Add Member", class: "w-full sm:w-auto px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+            <%= f.submit "Add Member", class: "w-full sm:w-auto px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
           </div>
         </div>
       <% end %>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -92,7 +92,7 @@
                   value: @twilio_from_number,
                   placeholder: "+1234567890",
                   class: "px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-[#ec3750] focus:border-[#ec3750]" %>
-            <%= f.submit "Save", class: "px-4 py-2 bg-[#ec3750] hover:bg-[#d42f46] text-white rounded-md font-medium transition-colors cursor-pointer" %>
+            <%= f.submit "Save", class: "px-4 py-2 bg-[#d42f46] hover:bg-[#b82840] text-white rounded-md font-medium transition-colors cursor-pointer" %>
           <% end %>
         </div>
       </div>
@@ -138,7 +138,7 @@
                 placeholder: "+14155551234\n+447700900123",
                 class: "w-full max-w-md px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-[#ec3750] focus:border-[#ec3750]" %>
           <div>
-            <%= f.submit "Save", class: "px-4 py-2 bg-[#ec3750] hover:bg-[#d42f46] text-white rounded-md font-medium transition-colors cursor-pointer" %>
+            <%= f.submit "Save", class: "px-4 py-2 bg-[#d42f46] hover:bg-[#b82840] text-white rounded-md font-medium transition-colors cursor-pointer" %>
           </div>
         <% end %>
       </div>

--- a/app/views/admin/slack_blasts/index.html.erb
+++ b/app/views/admin/slack_blasts/index.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-4xl mx-auto">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold">Slack Blast History</h1>
-    <%= link_to "Send New Blast", new_admin_event_slack_blast_path(current_event), class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold py-2 px-4 rounded-lg" %>
+    <%= link_to "Send New Blast", new_admin_event_slack_blast_path(current_event), class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg" %>
   </div>
 
   <% if @slack_blasts.any? %>

--- a/app/views/admin/slack_blasts/new.html.erb
+++ b/app/views/admin/slack_blasts/new.html.erb
@@ -32,7 +32,7 @@
         <div class="flex justify-end gap-3 pt-4">
           <%= link_to "Cancel", admin_event_dashboard_path(current_event.slug), class: "px-4 py-2 text-gray-700 hover:text-gray-900" %>
           <%= submit_tag "Send Blast", 
-              class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold py-2 px-4 rounded-lg cursor-pointer",
+              class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-4 rounded-lg cursor-pointer",
               data: { confirm: "Are you sure you want to send this message to #{@participant_count} participants?" } %>
         </div>
       <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -53,7 +53,7 @@
 
         <div class="flex flex-col sm:flex-row justify-end gap-3">
           <%= link_to "Cancel", admin_user_path(@user), class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-          <%= f.submit "Save Changes", class: "w-full sm:w-auto px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+          <%= f.submit "Save Changes", class: "w-full sm:w-auto px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,7 +4,7 @@
       <h1 class="text-2xl font-bold text-gray-900">Users</h1>
       <p class="text-sm text-gray-500"><%= pluralize(@total_count, "user") %> total</p>
     </div>
-    <%= link_to "Add User", new_admin_user_path, class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors" %>
+    <%= link_to "Add User", new_admin_user_path, class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors" %>
   </div>
 
   <div class="bg-white border border-gray-200 rounded-lg">
@@ -16,7 +16,7 @@
         <div>
           <%= f.select :role, [["All Roles", ""], ["Global Admin", "global_admin"], ["Read Only", "read_only"], ["No Role", "none"]], { selected: params[:role] }, class: "px-3 py-2 rounded-md border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750]" %>
         </div>
-        <%= f.submit "Search", class: "px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+        <%= f.submit "Search", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
       <% end %>
     </div>
 

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -44,7 +44,7 @@
 
         <div class="flex flex-col sm:flex-row justify-end gap-3">
           <%= link_to "Cancel", admin_users_path, class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors" %>
-          <%= f.submit "Create User", class: "w-full sm:w-auto px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors cursor-pointer" %>
+          <%= f.submit "Create User", class: "w-full sm:w-auto px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -5,7 +5,7 @@
       <% if current_user.global_admin? && @user != current_user %>
         <%= button_to "Impersonate", admin_user_impersonation_path(@user), method: :post, class: "w-full sm:w-auto text-center px-4 py-2 rounded-md transition-colors", style: "background-color: #f97316; color: white;", data: { confirm: "You will be signed in as #{@user.display_name_or_fallback}. Continue?" } %>
       <% end %>
-      <%= link_to "Edit", edit_admin_user_path(@user), class: "w-full sm:w-auto text-center px-4 py-2 bg-[#ec3750] text-white rounded-md hover:bg-[#d42f46] transition-colors" %>
+      <%= link_to "Edit", edit_admin_user_path(@user), class: "w-full sm:w-auto text-center px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors" %>
     </div>
   </div>
 

--- a/app/views/dashboard/messages/show.html.erb
+++ b/app/views/dashboard/messages/show.html.erb
@@ -62,7 +62,7 @@
       </svg>
       Back to inbox
     <% end %>
-    <%= link_to dashboard_event_path(@delivery.participant_event), class: "inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-[#ec3750] text-white text-sm font-semibold hover:bg-[#d42f46] transition-colors" do %>
+    <%= link_to dashboard_event_path(@delivery.participant_event), class: "inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-[#d42f46] text-white text-sm font-semibold hover:bg-[#b82840] transition-colors" do %>
       View event
       <svg class="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />

--- a/app/views/dashboard/profile.html.erb
+++ b/app/views/dashboard/profile.html.erb
@@ -260,7 +260,7 @@
             <div class="pt-1">
               <%# f.button (not f.submit): themes.css themes every `input` element in dark
                   modes with an unlayered rule that beats Tailwind's utility layer. %>
-              <%= f.button "Save public profile", class: "inline-flex items-center px-4 py-2 bg-[#ec3750] hover:bg-[#d42f46] text-[#ffffff] text-sm font-semibold rounded-lg transition-colors cursor-pointer" %>
+              <%= f.button "Save public profile", class: "inline-flex items-center px-4 py-2 bg-[#d42f46] hover:bg-[#b82840] text-[#ffffff] text-sm font-semibold rounded-lg transition-colors cursor-pointer" %>
             </div>
           <% end %>
         </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -72,7 +72,7 @@
           </p>
         </div>
         <%= link_to "Continue registration", onboarding_path(event_id: @event.id),
-            class: "shrink-0 inline-flex items-center justify-center px-5 py-2.5 bg-[#ec3750] hover:bg-[#d42f46] text-white font-medium rounded-lg transition-colors" %>
+            class: "shrink-0 inline-flex items-center justify-center px-5 py-2.5 bg-[#d42f46] hover:bg-[#b82840] text-white font-medium rounded-lg transition-colors" %>
       </div>
     </section>
   <% end %>
@@ -88,7 +88,7 @@
       </h2>
 
       <div class="max-w-md bg-white rounded-2xl shadow-lg overflow-hidden border border-[#e0e6ed]">
-        <div class="bg-[#ec3750] text-white px-4 py-3 flex justify-between items-center">
+        <div class="bg-[#d42f46] text-white px-4 py-3 flex justify-between items-center">
           <span class="font-bold tracking-wider text-sm">BOARDING PASS</span>
           <img src="/flag.png" alt="Hack Club" class="h-5 opacity-90">
         </div>
@@ -274,7 +274,7 @@
           <%= button_to gpe.invite_token_sent_at ? "Resend invitation" : "Send invitation",
               dashboard_resend_guardian_invite_path(@participant_event),
               method: :post,
-              class: "shrink-0 inline-flex items-center px-4 py-2 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
+              class: "shrink-0 inline-flex items-center px-4 py-2 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium rounded-lg transition-colors cursor-pointer" %>
         <% end %>
       </div>
     </section>
@@ -320,7 +320,7 @@
               <span class="text-sm text-(--text-muted)">Pending guardian</span>
             <% elsif doc.participant_signs? %>
               <%= link_to doc.physical? ? "Sign & upload" : "Sign now", dashboard_sign_document_path(@participant_event, doc),
-                  class: "inline-flex items-center px-3 py-1.5 bg-[#ec3750] hover:bg-[#d42f46] text-white text-sm font-medium rounded-lg transition-colors" %>
+                  class: "inline-flex items-center px-3 py-1.5 bg-[#d42f46] hover:bg-[#b82840] text-white text-sm font-medium rounded-lg transition-colors" %>
             <% elsif consent.nil? || consent.pending? %>
               <span class="text-sm text-(--text-muted)">Pending guardian</span>
             <% else %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,7 +5,7 @@
     <h1 class="text-2xl font-semibold mb-4">Welcome back</h1>
     <p class="text-gray-600 mb-8">You're signed in as <%= current_user.email %></p>
     <%= link_to "Go to Dashboard", dashboard_path,
-          class: "bg-[#ec3750] hover:bg-[#d42f46] text-white font-medium py-2.5 px-6 rounded-md transition-colors" %>
+          class: "bg-[#d42f46] hover:bg-[#b82840] text-white font-medium py-2.5 px-6 rounded-md transition-colors" %>
   </div>
 <% else %>
   <style>
@@ -87,7 +87,7 @@
               <%= button_to user_hack_club_omniauth_authorize_path,
                     method: :post,
                     data: { turbo: false },
-                    class: "group inline-flex items-center gap-3 rounded-lg bg-[#ec3750] px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_-10px_rgba(236,55,80,0.6)] hover:bg-[#d42f46] transition-colors" do %>
+                    class: "group inline-flex items-center gap-3 rounded-lg bg-[#d42f46] px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_-10px_rgba(236,55,80,0.6)] hover:bg-[#b82840] transition-colors" do %>
                 <img src="https://assets.hackclub.com/icon-rounded.svg" alt="" class="size-5">
                 Continue with Hack Club
               <% end %>

--- a/app/views/incident_reports/new.html.erb
+++ b/app/views/incident_reports/new.html.erb
@@ -187,7 +187,7 @@
       <div>
         <%= f.submit "Submit report",
               data: { incident_report_target: "submit" },
-              class: "w-full sm:w-auto bg-[#ec3750] hover:bg-[#d42f46] text-white font-semibold px-6 py-2.5 rounded-lg transition-colors cursor-pointer" %>
+              class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold px-6 py-2.5 rounded-lg transition-colors cursor-pointer" %>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/_admin_sidebar_footer.html.erb
+++ b/app/views/layouts/_admin_sidebar_footer.html.erb
@@ -30,7 +30,7 @@
         <% if current_user.avatar_displayable? %>
           <%= image_tag current_user.avatar.variant(resize_to_fill: [24, 24]), class: "h-6 w-6 rounded-full object-cover flex-shrink-0" %>
         <% else %>
-          <span class="h-6 w-6 rounded-full bg-[#ec3750] flex items-center justify-center text-[10px] font-semibold text-white flex-shrink-0">
+          <span class="h-6 w-6 rounded-full bg-[#d42f46] flex items-center justify-center text-[10px] font-semibold text-white flex-shrink-0">
             <%= current_user.initials %>
           </span>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
                 </svg>
                 <% if unread_count > 0 %>
-                  <span class="absolute -top-1 -right-1 inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-bold leading-none text-white bg-[#ec3750] rounded-full">
+                  <span class="absolute -top-1 -right-1 inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-bold leading-none text-white bg-[#d42f46] rounded-full">
                     <%= unread_count > 99 ? "99+" : unread_count %>
                   </span>
                 <% end %>
@@ -111,7 +111,7 @@
                 Messages
               </span>
               <% if unread_count > 0 %>
-                <span class="inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold text-white bg-[#ec3750] rounded-full">
+                <span class="inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold text-white bg-[#d42f46] rounded-full">
                   <%= unread_count > 99 ? "99+" : unread_count %>
                 </span>
               <% end %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -45,7 +45,7 @@
               </div>
 
               <nav class="mt-8 flex-1 px-2 space-y-1">
-                <%= link_to support_tickets_path, class: "group flex items-center px-3 py-2 text-sm font-medium rounded-lg #{request.path == support_tickets_path ? 'bg-[#ec3750] text-white' : 'text-[#8492a6] hover:bg-[#252429] hover:text-white'}" do %>
+                <%= link_to support_tickets_path, class: "group flex items-center px-3 py-2 text-sm font-medium rounded-lg #{request.path == support_tickets_path ? 'bg-[#d42f46] text-white' : 'text-[#8492a6] hover:bg-[#252429] hover:text-white'}" do %>
                   <svg class="mr-3 h-5 w-5 text-current opacity-75" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
                   </svg>


### PR DESCRIPTION
## What

Hack Club red (`#ec3750`) measures **4.02:1** against white — below WCAG AA's 4.5:1 for normal text. WCAG's large-text exemption (3:1) starts at 18.66px bold or 24px regular, which no button in Attend reaches, so no type change fixes this. The fill has to move.

Wherever white text sits on a red surface, the resting fill is now `--accent-strong` (`#d42f46`, **4.89:1**), hovering to `#b82840` (**6.15:1**). The brand red keeps every use that carries no text on it: unread dots, the wallet-pass bar, the Turbo progress bar, borders, icon fills, and `/10` tints. The two reds are one perceptual step apart — the change is invisible at a glance and measurable to a contrast checker.

112 fills across 84 view files.

## Theming

`themes.css` maps the new utilities to the same semantic vars the old ones used:

- `.bg-[#d42f46]` → `var(--accent)`
- `.hover:bg-[#b82840]` → `var(--accent-strong)`

So the seven non-light themes render **identically to before**. Only the default light theme changes.

## Two bugs fixed on the way

- Three buttons in `admin/events` (index, show, `_form`) had `bg-[#ec3750] hover:bg-[#ec3750]` — a no-op hover with `transition-colors` doing nothing. They now have a real hover state.
- Eight sites used `hover:bg-[#d63146]`, a one-off hex `themes.css` never remapped, so they broke out of theming on hover. All now use the mapped token.

## Docs

Adds `PRODUCT.md` and `DESIGN.md` recording the product context and the incumbent visual system, where this rule lives as **The Deepened Red Rule**, plus the `.impeccable/design.json` sidecar.

## Verification

- Contrast computed for every pair (numbers above)
- Tailwind rebuilt; both new utilities confirmed present in the compiled CSS
- All 84 changed ERB files parse
- Design detector run over the diff: 47 findings, **0 touching the new fills** — all pre-existing

## Known gaps, deliberately out of scope

- The decorative wallet-pass mock on `home#index` (10px `text-white/80` on red, plus initials on a red→orange gradient at ~2.2:1) still fails. It's illustration, not interactive UI.
- Dark theme resolves `text-white` to `--bg-elev` (`#161922`), giving **4.37:1** on `--accent`. Same class of problem, separate fix.