### PR TITLE
Fix hover on the admin events list reddening every row

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -51,10 +51,12 @@
   <% end %>
 
   <% if @completed_events.any? %>
-    <details class="mt-6 group" <%= "open" if @current_events.empty? %>>
+    <%# Named group: an unnamed one would also match the rows' `group-hover:`
+        utilities, so hovering any row would light up every row inside. %>
+    <details class="mt-6 group/completed" <%= "open" if @current_events.empty? %>>
       <summary class="list-none [&::-webkit-details-marker]:hidden cursor-pointer inline-flex items-center gap-2 rounded-sm text-sm font-medium text-gray-600 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#ec3750]/30 transition-colors">
         <span>Looking for a completed event?</span>
-        <svg class="w-4 h-4 transition-transform group-open:rotate-90" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+        <svg class="w-4 h-4 transition-transform group-open/completed:rotate-90" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
       </summary>
       <div class="mt-4">
         <%= render "event_list",

--- a/spec/requests/admin/dashboard_index_spec.rb
+++ b/spec/requests/admin/dashboard_index_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Admin::Dashboard#index", type: :request do
       get admin_root_path
 
       expect(response.body).to include("Nothing running right now")
-      expect(response.body).to include('<details class="mt-6 group" open>')
+      expect(response.body).to include('<details class="mt-6 group/completed" open>')
     end
   end
 


### PR DESCRIPTION
Hovering any event on `/admin` turned **every** completed event's title red.

The completed-events disclosure wrapped the list in an unnamed group:

```erb
<details class="mt-6 group">
```

Each row uses `group-hover:text-[#ec3750]`, which Tailwind compiles to `:is(:where(.group):hover *)` — so the outer `<details>` matched too, and hovering anywhere inside it fired the hover style on all rows at once.

Named the group (`group/completed`, with `group-open/completed:rotate-90` on its chevron) so it only drives its own disclosure arrow. This is the same pattern `_series_group.html.erb` already uses with `group/series`.

Rebuilt Tailwind and confirmed the named variant compiles, and that the rows' `group-hover:` rule no longer has a matching ancestor.