### PR TITLE
Stop undecodable image uploads from 500ing variant requests

### DIFF
--- a/app/controllers/admin/airport_mode_controller.rb
+++ b/app/controllers/admin/airport_mode_controller.rb
@@ -113,7 +113,7 @@ module Admin
     def collect_journeys(direction)
       participant_events = current_event.participant_events
         .where(status: :complete)
-        .includes(participant: :headshot_attachment)
+        .includes(participant: { headshot_attachment: :blob })
         .includes(:groups, scans: :scan_context, travel_inbound: { travel_legs: :picked_up_by }, travel_outbound: { travel_legs: :picked_up_by })
 
       journeys = []
@@ -143,7 +143,7 @@ module Admin
           participant_event_id: pe.id,
           participant_name: pe.participant.display_name,
           participant_preferred_name: pe.participant.preferred_name,
-          participant_has_headshot: pe.participant.headshot.attached?,
+          participant_has_headshot: pe.participant.headshot_displayable?,
           direction: direction,
           legs: legs_data,
           final_leg: legs_data.last,

--- a/app/controllers/api/v1/airport_mode_controller.rb
+++ b/app/controllers/api/v1/airport_mode_controller.rb
@@ -67,7 +67,7 @@ module Api
       def collect_journeys(direction)
         participant_events = @event.participant_events
           .where(status: :complete)
-          .includes(participant: :headshot_attachment)
+          .includes(participant: { headshot_attachment: :blob })
           .includes(scans: :scan_context, travel_inbound: { travel_legs: :picked_up_by }, travel_outbound: { travel_legs: :picked_up_by })
 
         journeys = []
@@ -95,7 +95,7 @@ module Api
             participant_event_id: pe.id,
             participant_name: pe.participant.display_name,
             participant_preferred_name: pe.participant.preferred_name,
-            participant_has_headshot: pe.participant.headshot.attached?,
+            participant_has_headshot: pe.participant.headshot_displayable?,
             participant_headshot_url: headshot_url_for(pe.participant),
             direction: direction,
             legs: legs_data,

--- a/app/controllers/public_profiles_controller.rb
+++ b/app/controllers/public_profiles_controller.rb
@@ -73,7 +73,7 @@ class PublicProfilesController < ApplicationController
     logo = event.effective_logo
     return nil unless logo&.attached?
 
-    if logo.variable?
+    if DecodableImageAttachment.displayable?(logo)
       rails_representation_path(logo.variant(resize_to_fill: [ 80, 80 ]), only_path: true)
     elsif logo.content_type == "image/svg+xml"
       rails_storage_proxy_path(logo, only_path: true)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -395,6 +395,13 @@ def admin_tool(class_name = "", element = "div", **options, &block)
     end
   end
 
+  # Whether an attachment can safely be handed to the variant processor. Use it
+  # wherever the attachment doesn't belong to the record in hand (e.g. a logo
+  # inherited from an event series) and there is no `*_displayable?` to call.
+  def variant_safe?(attachment)
+    DecodableImageAttachment.displayable?(attachment)
+  end
+
   # HEIC photos (iPhone default) don't render in most browsers — serve a JPEG
   # variant instead. Conversion happens lazily on first request and is cached
   # in the variant records.

--- a/app/models/concerns/decodable_image_attachment.rb
+++ b/app/models/concerns/decodable_image_attachment.rb
@@ -1,0 +1,92 @@
+# Browsers label an upload from its extension, so a renamed HEIC, a truncated
+# transfer, or a file libvips refuses to open (it blocks its untrusted loaders —
+# see config/initializers/vips_svg_loader.rb) all arrive looking like a
+# perfectly good image/png. Vips only finds out when it opens the bytes, and by
+# then we are inside the variant processor: the Active Storage representation
+# request 500s, and keeps 500ing on every page that shows that photo
+# (ATTEND-9H).
+#
+# Two guards, front and back. `validate_decodable_image` rejects the upload
+# while the user is still looking at the form, and `displayable_image?` keeps
+# blobs that turned out to be undecodable away from the variant processor.
+module DecodableImageAttachment
+  extend ActiveSupport::Concern
+
+  # Analysis records width/height for everything Vips could open and nothing for
+  # what it couldn't, so an analyzed blob with no width is one to keep away from
+  # the variant processor. A blob that hasn't been analyzed yet gets the benefit
+  # of the doubt; the representation controller rescue is the backstop for that
+  # window (see config/initializers/active_storage_image_errors.rb).
+  def self.displayable?(attachment)
+    return false unless attachment&.attached?
+    return false unless attachment.variable?
+
+    blob = attachment.blob
+    !blob.analyzed? || blob.metadata["width"].present?
+  end
+
+  private
+
+  # Validates the pending attachment for `name` — a no-op when nothing new was
+  # attached, so re-saving a record with an old (possibly bad) blob still works.
+  def validate_decodable_image(name)
+    change = attachment_changes[name.to_s]
+    return unless change.respond_to?(:attachable)
+    # SVGs are rasterized before save and report their own error if librsvg
+    # can't read them — see RasterizesSvgLogo.
+    return if change.blob.content_type == "image/svg+xml"
+    return if decodable_image?(change.attachable)
+
+    errors.add(name, "could not be read as an image — please re-save it as a JPEG, PNG, or WebP and upload it again")
+  end
+
+  def displayable_image?(attachment)
+    DecodableImageAttachment.displayable?(attachment)
+  end
+
+  def decodable_image?(attachable)
+    kind, source = decodable_image_source(attachable)
+    return true if kind.nil? # Nothing we can read here — leave it to analysis.
+
+    image = if kind == :path
+      Vips::Image.new_from_file(source, access: :sequential)
+    else
+      Vips::Image.new_from_buffer(source, "", access: :sequential)
+    end
+    image.width.positive?
+  rescue Vips::Error => e
+    Rails.logger.info("#{self.class.name}: rejected undecodable image upload: #{e.message}")
+    false
+  end
+
+  # A path when the upload is already on disk (the common case — Rack spools
+  # uploaded files to a tempfile), otherwise the bytes. Anything read here is
+  # rewound: Active Storage reads the same io again when it uploads the blob.
+  def decodable_image_source(attachable)
+    case attachable
+    when Hash
+      read_image_bytes(attachable[:io])
+    when ActiveStorage::Blob
+      # An already-stored blob (a merge moving a headshot between participants,
+      # say) was validated when it was first uploaded. Not worth a download.
+      nil
+    else
+      if attachable.respond_to?(:tempfile)
+        [ :path, attachable.tempfile.path ]
+      elsif attachable.respond_to?(:path)
+        [ :path, attachable.path ]
+      else
+        read_image_bytes(attachable)
+      end
+    end
+  end
+
+  def read_image_bytes(io)
+    return nil unless io.respond_to?(:read)
+
+    io.rewind if io.respond_to?(:rewind)
+    bytes = io.read
+    io.rewind if io.respond_to?(:rewind)
+    [ :buffer, bytes ]
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   include WalletPassUpdatable
   include RasterizesSvgLogo
+  include DecodableImageAttachment
 
   has_paper_trail
 
@@ -337,7 +338,9 @@ class Event < ApplicationRecord
   end
 
   def logo_displayable?
-    logo.attached? && (logo.variable? || logo.content_type == "image/svg+xml")
+    return true if logo.attached? && logo.content_type == "image/svg+xml"
+
+    displayable_image?(logo)
   end
 
   # Memoized because list views reach this once or twice per row via
@@ -404,6 +407,8 @@ class Event < ApplicationRecord
     if logo.byte_size && logo.byte_size > MAX_LOGO_BYTE_SIZE
       errors.add(:logo, "must be smaller than 5MB")
     end
+
+    validate_decodable_image(:logo)
   end
 
   def acceptable_banner
@@ -416,6 +421,8 @@ class Event < ApplicationRecord
     if banner.byte_size && banner.byte_size > MAX_BANNER_BYTE_SIZE
       errors.add(:banner, "must be smaller than 5MB")
     end
+
+    validate_decodable_image(:banner)
   end
 
   def participant_events_to_update

--- a/app/models/event_series.rb
+++ b/app/models/event_series.rb
@@ -1,5 +1,6 @@
 class EventSeries < ApplicationRecord
   include RasterizesSvgLogo
+  include DecodableImageAttachment
 
   has_paper_trail
 
@@ -35,7 +36,9 @@ class EventSeries < ApplicationRecord
   end
 
   def logo_displayable?
-    logo.attached? && (logo.variable? || logo.content_type == "image/svg+xml")
+    return true if logo.attached? && logo.content_type == "image/svg+xml"
+
+    displayable_image?(logo)
   end
 
   private
@@ -54,6 +57,8 @@ class EventSeries < ApplicationRecord
     if logo.byte_size && logo.byte_size > Event::MAX_LOGO_BYTE_SIZE
       errors.add(:logo, "must be smaller than 5MB")
     end
+
+    validate_decodable_image(:logo)
   end
 
   def acceptable_banner
@@ -66,5 +71,7 @@ class EventSeries < ApplicationRecord
     if banner.byte_size && banner.byte_size > Event::MAX_BANNER_BYTE_SIZE
       errors.add(:banner, "must be smaller than 5MB")
     end
+
+    validate_decodable_image(:banner)
   end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,5 +1,6 @@
 class Participant < ApplicationRecord
   include WalletPassUpdatable
+  include DecodableImageAttachment
 
   has_paper_trail
 
@@ -183,6 +184,12 @@ class Participant < ApplicationRecord
     user&.hca_verified? || false
   end
 
+  # Whether the headshot can safely be rendered as a variant. Attached is not
+  # enough: see DecodableImageAttachment.
+  def headshot_displayable?
+    displayable_image?(headshot)
+  end
+
   # The photo shown on the public profile: the participant's uploaded photo,
   # falling back to the official event headshot.
   def public_profile_display_photo
@@ -260,6 +267,8 @@ class Participant < ApplicationRecord
     if headshot.blob.byte_size > 10.megabytes
       errors.add(:headshot, "must be less than 10MB")
     end
+
+    validate_decodable_image(:headshot)
   end
 
   def public_profile_photo_content_type
@@ -272,5 +281,7 @@ class Participant < ApplicationRecord
     if public_profile_photo.blob.byte_size > 10.megabytes
       errors.add(:public_profile_photo, "must be less than 10MB")
     end
+
+    validate_decodable_image(:public_profile_photo)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include DecodableImageAttachment
+
   self.implicit_order_column = "created_at"
 
   has_paper_trail ignore: [
@@ -355,15 +357,19 @@ class User < ApplicationRecord
   end
 
   def avatar_displayable?
-    avatar.attached? && avatar.variable?
+    displayable_image?(avatar)
   end
 
   private
 
   def acceptable_avatar
     return unless attachment_changes["avatar"].present?
-    return if ALLOWED_AVATAR_CONTENT_TYPES.include?(avatar.content_type)
 
-    errors.add(:avatar, "must be a JPEG, PNG, GIF, or WebP image")
+    unless ALLOWED_AVATAR_CONTENT_TYPES.include?(avatar.content_type)
+      errors.add(:avatar, "must be a JPEG, PNG, GIF, or WebP image")
+      return
+    end
+
+    validate_decodable_image(:avatar)
   end
 end

--- a/app/views/admin/events/_avatar.html.erb
+++ b/app/views/admin/events/_avatar.html.erb
@@ -4,12 +4,10 @@
 <% size ||= 24 %>
 <% rounded ||= "rounded-full" %>
 <% logo = event.effective_logo %>
-<% if logo %>
-  <% if logo.content_type == "image/svg+xml" %>
-    <%= image_tag logo, class: "#{rounded} object-cover flex-shrink-0 bg-white", style: "height: #{size}px; width: #{size}px;" %>
-  <% else %>
-    <%= image_tag logo.variant(resize_to_fill: [size * 2, size * 2]), class: "#{rounded} object-cover flex-shrink-0", style: "height: #{size}px; width: #{size}px;" %>
-  <% end %>
+<% if logo&.content_type == "image/svg+xml" %>
+  <%= image_tag logo, class: "#{rounded} object-cover flex-shrink-0 bg-white", style: "height: #{size}px; width: #{size}px;" %>
+<% elsif variant_safe?(logo) %>
+  <%= image_tag logo.variant(resize_to_fill: [size * 2, size * 2]), class: "#{rounded} object-cover flex-shrink-0", style: "height: #{size}px; width: #{size}px;" %>
 <% else %>
   <span class="<%= rounded %> bg-[#d42f46] flex items-center justify-center font-bold text-white flex-shrink-0" style="height: <%= size %>px; width: <%= size %>px; font-size: <%= (size * 0.42).round %>px;">
     <%= event.name.first.upcase %>

--- a/app/views/admin/events/_image_preview.html.erb
+++ b/app/views/admin/events/_image_preview.html.erb
@@ -2,13 +2,11 @@
     instant upload. `field` is "logo" or "banner". %>
 <div id="<%= field %>_preview" class="flex items-center">
   <% attachment = event.public_send(field) %>
-  <% if attachment.attached? && attachment.blob&.persisted? %>
+  <% if attachment.attached? && attachment.blob&.persisted? && field == "logo" && attachment.content_type == "image/svg+xml" %>
+    <%= image_tag attachment, class: "h-12 w-12 rounded-lg object-cover bg-white border border-gray-200" %>
+  <% elsif attachment.blob&.persisted? && variant_safe?(attachment) %>
     <% if field == "logo" %>
-      <% if attachment.content_type == "image/svg+xml" %>
-        <%= image_tag attachment, class: "h-12 w-12 rounded-lg object-cover bg-white border border-gray-200" %>
-      <% else %>
-        <%= image_tag attachment.variant(resize_to_fill: [ 48, 48 ]), class: "h-12 w-12 rounded-lg object-cover border border-gray-200" %>
-      <% end %>
+      <%= image_tag attachment.variant(resize_to_fill: [ 48, 48 ]), class: "h-12 w-12 rounded-lg object-cover border border-gray-200" %>
     <% else %>
       <%= image_tag attachment.variant(resize_to_fill: [ 90, 71 ]), class: "h-[71px] w-[90px] rounded-lg object-cover border border-gray-200" %>
     <% end %>

--- a/app/views/support/tickets/_participant_card.html.erb
+++ b/app/views/support/tickets/_participant_card.html.erb
@@ -1,5 +1,5 @@
 <div class="flex items-start gap-3">
-  <% if participant.headshot.attached? %>
+  <% if participant.headshot_displayable? %>
     <%= image_tag participant.headshot.variant(resize_to_fill: [48, 48]), class: "w-12 h-12 rounded-full object-cover" %>
   <% else %>
     <div class="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 text-sm font-medium">

--- a/config/initializers/active_storage_image_errors.rb
+++ b/config/initializers/active_storage_image_errors.rb
@@ -1,0 +1,15 @@
+# A blob whose bytes libvips can't decode (a renamed HEIC, a truncated upload,
+# a format whose loader the CVE-2026-66066 patch blocks) raises out of the
+# variant processor inside Active Storage's own controller, so every request
+# for that representation is an unhandled 500 — one per <img> on the page, for
+# as long as the record exists (ATTEND-9H).
+#
+# Models keep known-bad blobs away from the variant processor (see
+# DecodableImageAttachment); this covers the rest: blobs not yet analyzed, and
+# any call site that forgets to ask. A broken image beats a 500.
+Rails.application.config.to_prepare do
+  ActiveStorage::BaseController.rescue_from(Vips::Error) do |error|
+    Rails.logger.warn("Active Storage: could not process representation: #{error.message}")
+    head :unprocessable_entity
+  end
+end

--- a/spec/lib/google_wallet/event_ticket_spec.rb
+++ b/spec/lib/google_wallet/event_ticket_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe GoogleWallet::EventTicket do
+  # Banners are validated as real images, so dummy bytes won't attach.
+  ONE_PIXEL_PNG = Base64.decode64(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+  ).freeze
+
   let(:participant_event) { create(:participant_event) }
   let(:event) { participant_event.event }
   let(:ticket) { described_class.new(participant_event) }
@@ -34,7 +39,7 @@ RSpec.describe GoogleWallet::EventTicket do
 
     it "uses a public proxy URL for the event banner when attached" do
       event.banner.attach(
-        io: StringIO.new("fake image data"),
+        io: StringIO.new(ONE_PIXEL_PNG),
         filename: "banner.png",
         content_type: "image/png"
       )
@@ -47,7 +52,7 @@ RSpec.describe GoogleWallet::EventTicket do
     it "falls back to the series banner when the event has none" do
       series = create(:event_series)
       series.banner.attach(
-        io: StringIO.new("fake image data"),
+        io: StringIO.new(ONE_PIXEL_PNG),
         filename: "series-banner.png",
         content_type: "image/png"
       )

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -197,8 +197,13 @@ RSpec.describe Event, type: :model do
   describe "banner validation" do
     let(:event) { create(:event) }
 
-    def attach_banner(content_type:, io: StringIO.new("fake image data"))
-      event.banner.attach(io: io, filename: "banner", content_type: content_type)
+    let(:png) { file_fixture("headshot.png").binread }
+    # Active Storage identifies the content type from the bytes, so a
+    # content-type test needs bytes that really are that type.
+    let(:gif) { Base64.decode64("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7") }
+
+    def attach_banner(content_type:, io: nil)
+      event.banner.attach(io: io || StringIO.new(png), filename: "banner", content_type: content_type)
     end
 
     it "accepts a PNG banner" do
@@ -212,9 +217,16 @@ RSpec.describe Event, type: :model do
     end
 
     it "rejects non-PNG/JPEG banners" do
-      attach_banner(content_type: "image/gif")
+      attach_banner(content_type: "image/gif", io: StringIO.new(gif))
       expect(event).not_to be_valid
       expect(event.errors[:banner]).to include("must be a PNG or JPEG image")
+    end
+
+    it "rejects a banner whose bytes aren't really an image" do
+      attach_banner(content_type: "image/png", io: StringIO.new("definitely not a png"))
+
+      expect(event).not_to be_valid
+      expect(event.errors[:banner].join).to include("could not be read as an image")
     end
 
     it "rejects banners over 5MB" do

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -108,6 +108,69 @@ RSpec.describe Participant, type: :model do
     end
   end
 
+  # A browser labels an upload from its extension, so bytes libvips can't decode
+  # arrive looking like a valid image/png — and blow up in the variant processor
+  # later, 500ing every page that shows the photo (ATTEND-9H).
+  describe "headshot decodability" do
+    let(:png) { file_fixture("headshot.png").binread }
+
+    it "accepts a real image" do
+      participant = create(:participant)
+      participant.headshot.attach(io: StringIO.new(png), filename: "headshot.png", content_type: "image/png")
+
+      expect(participant).to be_valid
+      expect(participant.headshot).to be_attached
+    end
+
+    it "rejects a file that isn't really an image" do
+      participant = create(:participant)
+      participant.headshot.attach(io: StringIO.new("not a png at all"), filename: "headshot.png", content_type: "image/png")
+
+      expect(participant).not_to be_valid
+      expect(participant.errors[:headshot].join).to include("could not be read as an image")
+    end
+
+    it "rejects an empty upload" do
+      participant = create(:participant)
+      participant.headshot.attach(io: StringIO.new(""), filename: "headshot.png", content_type: "image/png")
+
+      expect(participant).not_to be_valid
+    end
+
+    it "still validates when an existing headshot is left alone" do
+      participant = create(:participant)
+      participant.headshot.attach(io: StringIO.new(png), filename: "headshot.png", content_type: "image/png")
+
+      expect(participant.update(preferred_name: "Ada")).to be(true)
+    end
+  end
+
+  describe "#headshot_displayable?" do
+    let(:png) { file_fixture("headshot.png").binread }
+
+    it "is false without a headshot" do
+      expect(create(:participant).headshot_displayable?).to be(false)
+    end
+
+    it "is true for an attached image" do
+      participant = create(:participant)
+      participant.headshot.attach(io: StringIO.new(png), filename: "headshot.png", content_type: "image/png")
+
+      expect(participant.headshot_displayable?).to be(true)
+    end
+
+    # Analysis records no width for a blob Vips couldn't open. Those exist in
+    # production from before the upload validation, and asking for a variant of
+    # one is the 500.
+    it "is false for a blob analysis could not read" do
+      participant = create(:participant)
+      participant.headshot.attach(io: StringIO.new(png), filename: "headshot.png", content_type: "image/png")
+      participant.headshot.blob.update!(metadata: { "analyzed" => true })
+
+      expect(participant.headshot_displayable?).to be(false)
+    end
+  end
+
   describe "#public_profile_display_photo" do
     it "prefers the uploaded profile photo over the headshot" do
       png = Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")

--- a/spec/requests/active_storage_representations_spec.rb
+++ b/spec/requests/active_storage_representations_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+# Blobs whose bytes libvips can't decode exist in production (uploaded before
+# the models started validating decodability, or from a format whose loader is
+# blocked). Asking for a variant of one used to be an unhandled 500, repeated
+# for every <img> on every page that showed it — ATTEND-9H.
+RSpec.describe "Active Storage representations", type: :request do
+  let(:blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("this is not an image"),
+      filename: "headshot.png",
+      content_type: "image/png"
+    )
+  end
+
+  it "returns 422 instead of raising when the blob can't be decoded" do
+    path = Rails.application.routes.url_helpers.rails_representation_path(
+      blob.variant(resize_to_fill: [ 56, 56 ]), only_path: true
+    )
+
+    get path
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "still serves a variant of a real image" do
+    real = ActiveStorage::Blob.create_and_upload!(
+      io: File.open(file_fixture("headshot.png")),
+      filename: "headshot.png",
+      content_type: "image/png"
+    )
+    path = Rails.application.routes.url_helpers.rails_representation_path(
+      real.variant(resize_to_fill: [ 56, 56 ]), only_path: true
+    )
+
+    get path
+    follow_redirect!
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/services/participant_merge_service_spec.rb
+++ b/spec/services/participant_merge_service_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe ParticipantMergeService do
   let(:primary) { create(:participant, email: "real@example.com") }
   let(:duplicate) { create(:participant, email: "typo@example.com") }
 
+  let(:png) { file_fixture("headshot.png").binread }
+
   def merge!
     described_class.new(primary: primary, duplicate: duplicate).merge!
   end
@@ -122,7 +124,7 @@ RSpec.describe ParticipantMergeService do
 
   describe "headshot" do
     it "transfers the duplicate's headshot when the primary has none" do
-      duplicate.headshot.attach(io: StringIO.new("fake image data"), filename: "headshot.jpg", content_type: "image/jpeg")
+      duplicate.headshot.attach(io: StringIO.new(png), filename: "headshot.jpg", content_type: "image/jpeg")
 
       merge!
 
@@ -130,8 +132,8 @@ RSpec.describe ParticipantMergeService do
     end
 
     it "keeps the primary's headshot when both have one" do
-      primary.headshot.attach(io: StringIO.new("primary image"), filename: "primary.jpg", content_type: "image/jpeg")
-      duplicate.headshot.attach(io: StringIO.new("dup image"), filename: "dup.jpg", content_type: "image/jpeg")
+      primary.headshot.attach(io: StringIO.new(png), filename: "primary.jpg", content_type: "image/jpeg")
+      duplicate.headshot.attach(io: StringIO.new(png), filename: "dup.jpg", content_type: "image/jpeg")
       primary_blob_id = primary.headshot.blob.id
 
       merge!


### PR DESCRIPTION
Fixes [ATTEND-9H](https://hack-club-hcb.sentry.io/issues/7668420541/) — 64 unhandled 500s from `/rails/active_storage/representations/...`.

## What was wrong

A participant headshot whose bytes libvips can't open passed upload validation, because all we checked was the content type the browser guessed from the file extension. Vips only finds out when it opens the file — by which point we're inside the variant processor in Active Storage's own controller. So every request for that representation is an unhandled 500, one per `<img>`, on every page showing the photo (airport mode renders it at 56×56).

Ways a blob ends up like this: a renamed HEIC, a truncated upload, or a format whose libvips loader the CVE-2026-66066 patch blocks.

## The fix

Three layers, in `DecodableImageAttachment`:

1. **Reject at upload.** `validate_decodable_image` actually opens the pending upload with vips during validation, so the user hears about it while they're still on the form. Wired into participant headshots and profile photos, user avatars, and event/series logos and banners. SVGs are skipped — `RasterizesSvgLogo` already validates those and has a better message.
2. **Never variant a known-bad blob.** Analysis records width/height for anything vips could open, so an analyzed blob with no width is one to keep away from the processor. The `*_displayable?` predicates now check that (new: `Participant#headshot_displayable?`), plus a `variant_safe?` helper for call sites holding an attachment that isn't theirs. This is what stops the 500s for the blob already in production.
3. **Backstop.** `ActiveStorage::BaseController` rescues `Vips::Error` into a 422, covering not-yet-analyzed blobs and any call site that forgets to ask. A broken image beats a 500.

Both airport-mode preloads gain `:blob`, since the displayable check reads it and would otherwise fan out a query per row.

## Testing

- New request spec proves the representation returns 422 rather than raising, and that a real image still serves.
- New participant specs for upload rejection and `headshot_displayable?`, plus an undecodable-banner case on Event.
- Several existing specs attached `StringIO.new("fake image data")` as images — those now correctly fail validation, so they use real PNG bytes. The Event "rejects non-PNG/JPEG" case needed real GIF bytes, since Active Storage identifies content type from the content rather than the declared value.
- Full suite green locally except a pre-existing credentials-dependent webhook spec; rubocop and brakeman clean.