### PR TITLE
Stop the asset build from decrypting credentials it has no key for

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,17 @@ RUN echo "${GIT_REVISION}" > REVISION
 # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
 RUN bundle exec bootsnap precompile -j 1 app/ lib/
 
-# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+# Precompiling assets for production without requiring secret RAILS_MASTER_KEY.
+#
+# RAILS_MASTER_KEY is dropped for this step rather than merely left unset: the
+# platform injects a deployment's env vars into the build, so the staging
+# deployment's build would otherwise try to decrypt config/credentials.yml.enc —
+# production's file, because RAILS_ENV is production here — with staging's key
+# and fail with ActiveSupport::MessageEncryptor::InvalidMessage. Loading the
+# production environment reads credentials (mailer settings, config.hosts), and
+# none of those values affect the compiled assets. With no key at all the reads
+# return nil, which is what a local or CI build has always done.
+RUN env -u RAILS_MASTER_KEY SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 
 


### PR DESCRIPTION
Fixes the `attend-staging` build, which has been failing on every attempt with:

```
ActiveSupport::MessageEncryptor::InvalidMessage
/rails/config/environments/production.rb:82
```

## Cause

Orchard injects a deployment's env vars into its build. The Dockerfile pins `ENV RAILS_ENV="production"` for `assets:precompile`, so staging's build loads the **production** environment — which reads credentials at load time for the Postmark mailer settings (`production.rb:82`) and `config.hosts` (`production.rb:97`) — while holding **staging's** `RAILS_MASTER_KEY`. That key can't decrypt `config/credentials.yml.enc`, so the build aborts before compiling a single asset.

Production's build was unaffected because its key matches that file. This is a gap in the staging environment I added in #29 — it was only ever verified by booting `RAILS_ENV=staging` locally, never through the Docker build.

## Fix

Drop `RAILS_MASTER_KEY` for the precompile step only. The credential reads then return `nil`, exactly as they do in a local or CI build with no key, and none of those values affect compiled assets. Unset rather than emptied: `ActiveSupport::EncryptedFile` treats `""` as a key and fails identically.

## Verification

Reproduced and fixed locally:

| | |
|---|---|
| `RAILS_ENV=production` + staging key | `InvalidMessage`, matching the build log |
| same, key dropped | precompiles, exit 0 |

`env -u` is standard coreutils and present in `ruby:3.4.7-slim`, but the Docker daemon isn't running here so this is verified on macOS only — the staging build itself is the real test.