### PR TITLE
Stop event deletion tripping over records that point at participant events

### DIFF
--- a/app/models/participant_event.rb
+++ b/app/models/participant_event.rb
@@ -27,6 +27,10 @@ class ParticipantEvent < ApplicationRecord
   has_one :room, through: :room_assignment
   has_many :roommate_preferences, dependent: :destroy
   has_many :roommate_exclusions, dependent: :destroy
+  # The other side of the pairing — someone else naming this participant as a
+  # preferred or excluded roommate also holds a foreign key to us.
+  has_many :inbound_roommate_preferences, class_name: "RoommatePreference", foreign_key: :preferred_participant_event_id, dependent: :destroy, inverse_of: :preferred_participant_event
+  has_many :inbound_roommate_exclusions, class_name: "RoommateExclusion", foreign_key: :excluded_participant_event_id, dependent: :destroy, inverse_of: :excluded_participant_event
   has_one :dietary, dependent: :destroy
   has_one :accessibility, dependent: :destroy
   has_one :safeguarding_info, dependent: :destroy
@@ -35,9 +39,13 @@ class ParticipantEvent < ApplicationRecord
   accepts_nested_attributes_for :emergency_contacts, allow_destroy: true, reject_if: :all_blank
 
   has_many :consents, dependent: :destroy
-  has_many :incidents
-  has_many :notes
+  # Incidents and notes outlive the participant's enrolment — they stay on the
+  # event as a safeguarding record — but the join rows pointing at us can't.
+  has_many :incidents, dependent: :nullify
+  has_many :notes, dependent: :nullify
+  has_many :incident_participants, dependent: :destroy
   has_many :scans, dependent: :destroy
+  has_many :slack_blast_recipients, dependent: :destroy
   has_many :message_deliveries, dependent: :destroy
   has_many :group_memberships, dependent: :destroy
   has_many :groups, through: :group_memberships

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -235,4 +235,30 @@ RSpec.describe Event, type: :model do
       expect(event.errors[:banner]).to include("must be smaller than 5MB")
     end
   end
+
+  describe "#destroy" do
+    let(:event) { create(:event) }
+    let(:reporter) { create(:user) }
+    let(:participant_event) { create(:participant_event, event: event) }
+    let(:other_participant_event) { create(:participant_event, event: event) }
+
+    # Participant events are destroyed before the event's own incidents and
+    # notes, so anything still pointing at a participant event at that moment
+    # used to blow up with a foreign key violation.
+    it "tears down records that point at its participant events" do
+      incident = Incident.create!(event: event, reported_by: reporter, category: :other, severity: :low)
+      incident.incident_participants.create!(participant_event: participant_event)
+      Note.create!(event: event, participant_event: participant_event, author: reporter, body: "note")
+      RoommatePreference.create!(participant_event: other_participant_event, preferred_participant_event: participant_event)
+      RoommateExclusion.create!(participant_event: other_participant_event, excluded_participant_event: participant_event)
+      blast = event.slack_blasts.create!(sent_by_user: reporter, message: "hi")
+      blast.slack_blast_recipients.create!(participant_event: participant_event)
+
+      expect { event.destroy! }.not_to raise_error
+      expect(Event.exists?(event.id)).to be false
+      expect(IncidentParticipant.count).to eq 0
+      expect(Incident.count).to eq 0
+      expect(RoommatePreference.count).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
Deleting an event 500'd — Sentry [ATTEND-5V](https://hack-club-hcb.sentry.io/issues/ATTEND-5V), `DELETE /admin/events/assemble`.

`Event` destroys its `participant_events` before its `incidents`, so the `incident_participants` join rows were still holding a foreign key to a participant event when it went away:

```
PG::ForeignKeyViolation: update or delete on table "participant_events" violates
foreign key constraint "fk_rails_ea6deabc8e" on table "incident_participants"
```

`ParticipantEvent` had no `incident_participants` association at all, so nothing cleaned them up. Auditing the rest of the foreign keys pointing at `participant_events` turned up the same gap in three more places, each of which would have been the next error:

- `slack_blast_recipients` — blasts are destroyed after participant events
- the inbound side of roommate preferences and exclusions — someone else naming you as preferred/excluded also holds a foreign key to you, and only the outbound side was covered
- `incidents` and `notes` — now `dependent: :nullify` rather than `:destroy`. They're a record of the event, not of the enrolment, and the event destroys them itself moments later.

`hospitality_acts` also has a foreign key to `participant_events`, but it has no model and no migration in the repo — nothing writes it, so it can't hold rows. Left alone.

## Testing

New spec in `spec/models/event_spec.rb` builds an event with all five kinds of pointer and destroys it. Reverting the model change reproduces the production error exactly; with it, green.

Fixes ATTEND-5V