### PR TITLE
Set the passkit path fallbacks during asset precompilation too

### DIFF
--- a/config/initializers/passkit.rb
+++ b/config/initializers/passkit.rb
@@ -33,14 +33,19 @@ if passkit_config.present? && !ENV["SECRET_KEY_BASE_DUMMY"]
   Passkit.configure do |config|
     # config.available_passes['Passkit::YourPass'] = -> { User.create }
   end
-elsif !ENV["SECRET_KEY_BASE_DUMMY"]
+else
   # Passkit::Generator resolves these paths when the class is loaded
   # (Rails.root.join(ENV[...]) at the class body), so leaving them nil turns a
   # missing passkit config into a boot failure instead of just an app without
   # wallet passes. Point them at paths that do not exist: booting works, and
   # generating a pass raises with a readable Errno::ENOENT.
+  #
+  # This must run during asset precompilation too. Zeitwerk eager-loads the
+  # class then as well, so gating this branch on SECRET_KEY_BASE_DUMMY — as the
+  # branch above is, because it has real certificates to write — left the paths
+  # nil in exactly the case that has no credentials to fall back on.
   ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"] ||= "tmp/certs/missing-certificate.p12"
   ENV["PASSKIT_APPLE_INTERMEDIATE_CERTIFICATE"] ||= "tmp/certs/missing-WWDR.cer"
 
-  Rails.logger&.warn("[passkit] no :passkit credentials — wallet passes are disabled")
+  Rails.logger&.warn("[passkit] no :passkit credentials — wallet passes are disabled") unless ENV["SECRET_KEY_BASE_DUMMY"]
 end


### PR DESCRIPTION
`Passkit::Generator` resolves `Rails.root.join(ENV["PASSKIT_PRIVATE_P12_CERTIFICATE"])` in its **class body**, and Zeitwerk eager-loads it during `assets:precompile` — so those env vars must hold real strings by then, not `nil`.

Both branches of `config/initializers/passkit.rb` were gated on `!ENV["SECRET_KEY_BASE_DUMMY"]`. That gate is correct for the configured branch, which decodes certificates out of credentials and writes them to disk — pointless work during precompile. Applying it to the *fallback* branch too meant that during precompile **neither** branch ran and the paths stayed `nil`:

```
passkit-0.7.0/lib/passkit/generator.rb:117:in '<class:Generator>'
TypeError: no implicit conversion of nil into String
```

Every image build takes the unconfigured path, since the image has no `config/master.key` and #30 drops `RAILS_MASTER_KEY` for the precompile step.

My own regression, introduced in #29 while fixing the adjacent problem that a missing `:passkit` credential was a hard boot failure.

## Verification

Booting with no master key present, which previously raised:

| environment | before | after |
|---|---|---|
| production | `TypeError` | exit 0 |
| staging | `TypeError` | exit 0 |

Rubocop clean.