### PR TITLE
Create the solid_* tables when a new environment's database is empty

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -19,6 +19,13 @@ if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   echo "=== Running db:prepare ==="
   ./bin/rails db:prepare 2>&1 || { echo "db:prepare failed with exit code $?"; exit 1; }
   echo "=== db:prepare complete ==="
+
+  # db:prepare cannot create the cache/queue/cable tables when those connections
+  # share the primary database — see lib/tasks/secondary_schemas.rake. Without
+  # this, a new environment boots and then dies in Solid Queue's supervisor.
+  echo "=== Ensuring secondary schemas ==="
+  ./bin/rails db:ensure_secondary_schemas 2>&1 || { echo "db:ensure_secondary_schemas failed with exit code $?"; exit 1; }
+  echo "=== secondary schemas complete ==="
 fi
 
 echo "=== Starting server ==="

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -16,7 +16,12 @@ Rails.application.configure do
   staging_host = ENV.fetch("APP_HOST", "staging.attend.hackclub.com")
 
   config.action_mailer.default_url_options = { host: staging_host, protocol: "https" }
-  config.hosts |= [ staging_host ]
+  # staging_host covers the public ingress. The other two are how the cluster
+  # itself reaches the app: kubelet probes and in-cluster traffic arrive with the
+  # service's internal name, and Orchard also serves an auto-generated
+  # *.k.hackclub.dev ingress alongside the real hostname. Without them those
+  # requests are rejected by host authorization.
+  config.hosts |= [ staging_host, ".svc.cluster.local", ".k.hackclub.dev" ]
 
   # Staging uploads must not land in production's R2 bucket.
   config.active_storage.service = :cloudflare_r2_staging

--- a/lib/tasks/secondary_schemas.rake
+++ b/lib/tasks/secondary_schemas.rake
@@ -1,0 +1,41 @@
+# The cache, queue and cable connections in config/database.yml point at the
+# same database as primary, and the migrations_paths they name (db/queue_migrate
+# and friends) do not exist — those tables come from db/<name>_schema.rb.
+#
+# db:prepare only loads a schema when it creates the database. On a fresh
+# database primary creates it and loads db/schema.rb; by the time the cache,
+# queue and cable connections are prepared the database already exists, so each
+# takes the "run pending migrations" path against an empty directory and their
+# tables are never created. Booting then dies in Solid Queue's supervisor with
+#
+#   PG::UndefinedTable: relation "solid_queue_recurring_tasks" does not exist
+#
+# Production predates this setup and already has the tables, so it only shows up
+# when standing up a new environment.
+namespace :db do
+  desc "Load db/<name>_schema.rb for secondary connections whose tables are missing"
+  task ensure_secondary_schemas: :environment do
+    sentinels = {
+      "cache" => "solid_cache_entries",
+      "queue" => "solid_queue_processes",
+      "cable" => "solid_cable_messages"
+    }
+
+    sentinels.each do |name, sentinel|
+      config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
+      next if config.nil?
+
+      schema_file = Rails.root.join("db", "#{name}_schema.rb")
+      next unless schema_file.exist?
+
+      # Checked on the primary connection because every one of these configs
+      # resolves to the same database; loading is skipped as soon as the tables
+      # are there, which keeps this a no-op on every boot after the first.
+      present = ActiveRecord::Base.connection_pool.with_connection { |c| c.table_exists?(sentinel) }
+      next if present
+
+      puts "[db] #{sentinel} missing — loading db/#{name}_schema.rb"
+      ActiveRecord::Tasks::DatabaseTasks.load_schema(config, :ruby, schema_file.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Staging booted, ran `db:prepare`, started Puma, then died:

```
PG::UndefinedTable: relation "solid_queue_recurring_tasks" does not exist
Detected Solid Queue has gone away, stopping Puma...
```

## Cause

The `cache`, `queue` and `cable` connections share **primary's database**, and the `migrations_paths` they name (`db/queue_migrate` and friends) **do not exist** — those tables come from `db/<name>_schema.rb`.

`db:prepare` only loads a schema when it *creates* the database. Primary creates it and loads `db/schema.rb`; by the time the other three are prepared the database already exists, so each takes the "run pending migrations" path against an empty directory and their tables are never created.

Production predates this setup and already has the tables, which is why it only appears when standing up a new environment. It would equally bite anyone restoring from scratch or spinning up a review app.

## Fix

`db:ensure_secondary_schemas` loads `db/<name>_schema.rb` for any of the three whose sentinel table is missing, and the entrypoint runs it after `db:prepare`. It no-ops once the tables exist — one table lookup per boot for existing deployments, and it never touches queued jobs or cache entries.

Also allows `.svc.cluster.local` and `.k.hackclub.dev` in staging's `config.hosts`. The same log showed:

```
[ActionDispatch::HostAuthorization] Blocked hosts: attend-staging.ysws-attend.svc.cluster.local:3000
```

kubelet probes and in-cluster traffic arrive with the service's internal name, and Orchard serves an auto-generated `*.k.hackclub.dev` ingress alongside the real hostname.

## Verification

Against a scratch database, reproducing the failure first:

| step | result |
|---|---|
| `db:prepare` alone | 82 tables, **0** `solid_*` — reproduces the crash |
| `+ db:ensure_secondary_schemas` | 13 `solid_*` tables incl. `solid_queue_recurring_tasks` |
| second run | loads nothing (no-op confirmed) |
| the code path that crashed | `SolidQueue::Configuration` builds `["process_scheduled_messages", "clear_solid_queue_finished_jobs"]`, `valid? == true` |

Rubocop clean; entrypoint passes `bash -n`.

Stacks with #32 — both are needed before staging comes up.