### PR TITLE
Let admins edit a custom document instead of remove-and-re-add

### DIFF
--- a/app/controllers/admin/custom_documents_controller.rb
+++ b/app/controllers/admin/custom_documents_controller.rb
@@ -24,6 +24,44 @@ module Admin
       redirect_to admin_event_integrations_path(@event), alert: "Couldn't add document: #{e.message}"
     end
 
+    def edit
+      @custom_document = @event.custom_documents.find(params[:id])
+    end
+
+    def update
+      @custom_document = @event.custom_documents.find(params[:id])
+      attributes = editable_params(@custom_document)
+
+      # Switching an electronic document to paper leaves its template id behind
+      # as a stale pointer, so drop it as part of the same save.
+      switching_to_physical = attributes[:document_kind] == "physical" && @custom_document.electronic?
+      attributes[:docuseal_template_id] = nil if switching_to_physical
+
+      switching_to_electronic = attributes[:document_kind] == "electronic" && @custom_document.physical?
+      template_id_changed = attributes.key?(:docuseal_template_id) &&
+        attributes[:docuseal_template_id] != @custom_document.docuseal_template_id
+
+      if @custom_document.update(attributes)
+        # Mappings are keyed by the old template's field names, so they're
+        # meaningless once the template changes or the document goes physical.
+        remove_field_mappings(@custom_document) if template_id_changed
+
+        if switching_to_electronic
+          @custom_document.template_pdf.purge_later
+          @custom_document.update_column(:template_page_count, nil)
+        end
+
+        redirect_to admin_event_integrations_path(@event),
+                    notice: "\"#{@custom_document.name}\" updated.#{" Sync its fields again to reconfigure pre-fill." if template_id_changed && @custom_document.electronic?}"
+      else
+        flash.now[:alert] = "Couldn't update document: #{@custom_document.errors.full_messages.to_sentence}"
+        render :edit, status: :unprocessable_entity
+      end
+    rescue ArgumentError => e
+      redirect_to admin_event_custom_document_edit_path(@event, @custom_document),
+                  alert: "Couldn't update document: #{e.message}"
+    end
+
     def destroy
       custom_document = @event.custom_documents.find(params[:id])
 
@@ -53,6 +91,19 @@ module Admin
     def custom_document_params
       params.require(:custom_document)
             .permit(:name, :document_kind, :description, :docuseal_template_id, :signer_type, :template_pdf, :optional)
+    end
+
+    # Name and description are labels — safe to change at any point, and the
+    # new wording shows up on every existing consent. Everything else changes
+    # who must sign or how, and DocuSeal submissions have already been created
+    # against the old shape, so it's frozen once anybody has a consent.
+    def editable_params(custom_document)
+      permitted = [ :name, :description ]
+      if custom_document.consents.none?
+        permitted += [ :document_kind, :docuseal_template_id, :signer_type, :template_pdf, :optional ]
+      end
+
+      params.require(:custom_document).permit(*permitted)
     end
 
     def remove_field_mappings(custom_document)

--- a/app/models/custom_document.rb
+++ b/app/models/custom_document.rb
@@ -24,6 +24,11 @@ class CustomDocument < ApplicationRecord
   validate :template_pdf_required_for_physical
 
   after_create_commit :reopen_completed_participants
+  # Editing who signs can hand a new blocking document to people who already
+  # finished — same problem as adding one, same fix.
+  # Distinct method name on purpose: registering the same symbol twice in the
+  # after_commit chain replaces the create callback instead of adding to it.
+  after_update_commit :reopen_completed_participants_after_edit
 
   scope :active, -> { where(archived_at: nil) }
 
@@ -84,6 +89,16 @@ class CustomDocument < ApplicationRecord
   end
 
   private
+
+  # Only signer_type and optional decide who the document applies to; renaming
+  # it or swapping the template doesn't change the audience.
+  # reopen_completed_participants ignores optional documents itself, so a
+  # required → optional flip stops short of the job.
+  def reopen_completed_participants_after_edit
+    return unless saved_change_to_signer_type? || saved_change_to_optional?
+
+    reopen_completed_participants
+  end
 
   # Participants who finished onboarding before this document existed now have
   # a new blocking step — reopen them so their db status matches. While

--- a/app/views/admin/custom_documents/edit.html.erb
+++ b/app/views/admin/custom_documents/edit.html.erb
@@ -1,0 +1,155 @@
+<% content_for :title, "Edit #{@custom_document.name} – #{current_event.name} – Attend" %>
+<% locked = @custom_document.consents.exists? %>
+
+<div class="max-w-3xl mx-auto px-4 py-6">
+  <!-- Header -->
+  <div class="flex items-center gap-3 mb-1">
+    <%= link_to admin_event_integrations_path(current_event), class: "text-gray-400 hover:text-gray-600" do %>
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path></svg>
+    <% end %>
+    <h1 class="text-2xl font-bold text-gray-900">Edit <%= @custom_document.name %></h1>
+  </div>
+  <p class="text-sm text-gray-500 mb-6">Custom document for <%= current_event.name %></p>
+
+  <%= form_with url: admin_event_custom_document_path(current_event, @custom_document), scope: :custom_document,
+      model: @custom_document, method: :patch, multipart: true,
+      data: { controller: "document-kind" }, class: "bg-white border border-gray-200 rounded-lg p-4" do |cd| %>
+
+    <div>
+      <%= cd.label :name, "Name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= cd.text_field :name, required: true,
+          class: "block w-full rounded-md border-gray-300 focus:border-teal-500 focus:ring-teal-500 px-3 py-2 text-sm" %>
+    </div>
+
+    <div class="mt-4">
+      <%= cd.label :description, "Description (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= cd.text_area :description, rows: 2,
+          class: "block w-full rounded-md border-gray-300 focus:border-teal-500 focus:ring-teal-500 px-3 py-2 text-sm",
+          placeholder: "Shown to participants — which activity it's for, or which sections to fill in" %>
+    </div>
+
+    <% if locked %>
+      <!-- Signatures exist: the shape of the document is now a legal record -->
+      <div class="mt-6 border-t border-gray-100 pt-4">
+        <div class="rounded-lg bg-amber-50 border border-amber-200 p-4">
+          <p class="text-sm font-semibold text-amber-800">Signing setup is locked</p>
+          <p class="text-sm text-amber-700 mt-0.5">
+            <%= pluralize(@custom_document.consents.count, "participant") %> already
+            <%= @custom_document.consents.count == 1 ? "has" : "have" %> this document, and their DocuSeal
+            submissions were created against the current setup. Changing who signs it, or which template it
+            uses, would leave those signatures pointing at a document that no longer matches what was signed.
+            Remove this document and add a replacement if the setup itself needs to change — existing
+            signatures are kept.
+          </p>
+        </div>
+        <dl class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+          <div>
+            <dt class="text-gray-500">Type</dt>
+            <dd class="text-gray-900 font-medium mt-0.5"><%= @custom_document.document_kind.humanize %></dd>
+          </div>
+          <div>
+            <dt class="text-gray-500">Who signs</dt>
+            <dd class="text-gray-900 font-medium mt-0.5"><%= @custom_document.signer_type.humanize %></dd>
+          </div>
+          <div>
+            <dt class="text-gray-500"><%= @custom_document.physical? ? "PDF" : "DocuSeal template" %></dt>
+            <dd class="text-gray-900 font-medium mt-0.5">
+              <% if @custom_document.physical? %>
+                <% if @custom_document.template_pdf.attached? %>
+                  <%= link_to "Download", rails_blob_path(@custom_document.template_pdf, disposition: "attachment"),
+                      class: "text-indigo-600 hover:text-indigo-800" %>
+                <% else %>
+                  —
+                <% end %>
+              <% else %>
+                <span class="font-mono">#<%= @custom_document.docuseal_template_id %></span>
+              <% end %>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    <% else %>
+      <fieldset class="mt-6 border-t border-gray-100 pt-4">
+        <legend class="text-sm font-semibold text-gray-900">Document type</legend>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+          <label class="bg-white border border-gray-200 rounded-lg p-4 cursor-pointer hover:border-teal-500 transition-colors has-[:checked]:border-teal-500 has-[:checked]:ring-1 has-[:checked]:ring-teal-500">
+            <div class="flex items-start gap-3">
+              <%= cd.radio_button :document_kind, "electronic",
+                  data: { action: "document-kind#toggle" },
+                  class: "mt-0.5 h-4 w-4 accent-teal-600 text-teal-600 focus:ring-teal-500 border-gray-300" %>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Electronic</p>
+                <p class="text-sm text-gray-500 mt-0.5">Signed online through DocuSeal, with participant details pre-filled.</p>
+              </div>
+            </div>
+          </label>
+          <label class="bg-white border border-gray-200 rounded-lg p-4 cursor-pointer hover:border-teal-500 transition-colors has-[:checked]:border-teal-500 has-[:checked]:ring-1 has-[:checked]:ring-teal-500">
+            <div class="flex items-start gap-3">
+              <%= cd.radio_button :document_kind, "physical",
+                  data: { action: "document-kind#toggle" },
+                  class: "mt-0.5 h-4 w-4 accent-teal-600 text-teal-600 focus:ring-teal-500 border-gray-300" %>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Physical</p>
+                <p class="text-sm text-gray-500 mt-0.5">Downloaded as a PDF, signed on paper, and uploaded as a photo.</p>
+              </div>
+            </div>
+          </label>
+        </div>
+      </fieldset>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+        <div data-document-kind-target="electronic">
+          <%= cd.label :docuseal_template_id, "DocuSeal Template ID", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= cd.text_field :docuseal_template_id, required: true,
+              class: "block w-full rounded-md border-gray-300 focus:border-teal-500 focus:ring-teal-500 px-3 py-2 font-mono text-sm",
+              placeholder: "1234" %>
+          <p class="text-xs text-gray-500 mt-1">Changing this clears the pre-fill mappings — sync the new template's fields afterwards.</p>
+        </div>
+        <div data-document-kind-target="physical" class="hidden">
+          <%= cd.label :template_pdf, "PDF document", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= cd.file_field :template_pdf, accept: "application/pdf", required: !@custom_document.template_pdf.attached?,
+              class: "block w-full text-sm text-gray-700 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:bg-teal-50 file:text-teal-700 hover:file:bg-teal-100" %>
+          <p class="text-xs text-gray-500 mt-1">
+            <% if @custom_document.template_pdf.attached? %>
+              Leave empty to keep the
+              <%= link_to "current PDF", rails_blob_path(@custom_document.template_pdf, disposition: "attachment"),
+                  class: "text-indigo-600 hover:text-indigo-800" %>.
+            <% else %>
+              Required for a physical document.
+            <% end %>
+          </p>
+        </div>
+        <div>
+          <%= cd.label :signer_type, "Who signs?", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= cd.select :signer_type,
+              [ [ "Participant", "participant" ], [ "Guardian", "guardian" ],
+                [ "Participant + Guardian", "participant_and_guardian" ],
+                [ "Participant + Guardian, under-18s only", "minor_and_guardian" ] ],
+              {},
+              class: "block w-full rounded-md border-gray-300 focus:border-teal-500 focus:ring-teal-500 px-3 py-2 text-sm" %>
+          <p class="text-xs text-gray-500 mt-1">Guardian roles only apply to under-18s — adults sign by themselves, and guardian-only or under-18s-only documents are skipped for them.</p>
+        </div>
+      </div>
+
+      <div class="mt-4">
+        <label class="flex items-start gap-3 bg-white border border-gray-200 rounded-lg p-4 cursor-pointer hover:border-teal-500 transition-colors has-[:checked]:border-teal-500 has-[:checked]:ring-1 has-[:checked]:ring-teal-500">
+          <%= cd.check_box :optional, class: "mt-0.5 h-4 w-4 rounded accent-teal-600 text-teal-600 focus:ring-teal-500 border-gray-300" %>
+          <span>
+            <span class="block text-sm font-semibold text-gray-900">Optional — participants choose whether to add it</span>
+            <span class="block text-sm text-gray-500 mt-0.5">
+              The document stays hidden — including from parents/guardians — until the participant adds it
+              themselves. Turning this off makes it required for everyone, which reopens participants who
+              already finished registering.
+            </span>
+          </span>
+        </label>
+      </div>
+    <% end %>
+
+    <div class="flex items-center gap-3 mt-6">
+      <%= cd.button "Save changes", type: :submit, class: "bg-teal-600 hover:bg-teal-700 text-white text-sm font-medium py-2 px-4 rounded-lg transition-colors cursor-pointer" %>
+      <%= link_to "Cancel", admin_event_integrations_path(current_event),
+          class: "text-sm text-gray-500 hover:text-gray-700 font-medium" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/dashboard/integrations.html.erb
+++ b/app/views/admin/dashboard/integrations.html.erb
@@ -345,6 +345,8 @@
                   <%= link_to "Configure Mappings", admin_event_docuseal_template_mappings_path(current_event, doc.mapping_key),
                       class: "text-sm text-indigo-600 hover:text-indigo-800 font-medium" %>
                 <% end %>
+                <%= link_to "Edit", admin_event_custom_document_edit_path(current_event, doc),
+                    class: "text-sm text-indigo-600 hover:text-indigo-800 font-medium" %>
                 <%= button_to "Remove", admin_event_custom_document_path(current_event, doc),
                     method: :delete,
                     data: { turbo_confirm: "Remove \"#{doc.name}\"? Participants will no longer be asked to sign it. Existing signatures are kept." },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -382,6 +382,8 @@ Rails.application.routes.draw do
     # Custom documents (per-event DocuSeal templates beyond the built-in waivers)
     scope ":slug", constraints: { slug: /[a-z0-9-]+/ } do
       post "custom_documents", to: "custom_documents#create", as: :event_custom_documents
+      get "custom_documents/:id/edit", to: "custom_documents#edit", as: :event_custom_document_edit
+      patch "custom_documents/:id", to: "custom_documents#update"
       delete "custom_documents/:id", to: "custom_documents#destroy", as: :event_custom_document
     end
   end

--- a/spec/requests/custom_documents_spec.rb
+++ b/spec/requests/custom_documents_spec.rb
@@ -33,6 +33,104 @@ RSpec.describe "Custom documents", type: :request do
       expect(response).to redirect_to(admin_event_integrations_path(event))
     end
 
+    it "links to the edit page from the integrations list" do
+      doc = create(:custom_document, event: event, name: "Hotel Waiver")
+
+      get admin_event_integrations_path(event)
+
+      expect(response.body).to include(admin_event_custom_document_edit_path(event, doc))
+    end
+
+    it "renders the edit form" do
+      doc = create(:custom_document, event: event, name: "Hotel Waiver")
+
+      get admin_event_custom_document_edit_path(event, doc)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Edit Hotel Waiver")
+      expect(response.body).to include("Who signs?")
+    end
+
+    it "updates the name, description and signer type when nobody has signed" do
+      doc = create(:custom_document, event: event, name: "Hotel Waiver", signer_type: "participant")
+
+      patch admin_event_custom_document_path(event, doc), params: {
+        custom_document: { name: "Hotel Indemnity", description: "Sign page 2", signer_type: "participant_and_guardian" }
+      }
+
+      expect(response).to redirect_to(admin_event_integrations_path(event))
+      expect(doc.reload).to have_attributes(
+        name: "Hotel Indemnity",
+        description: "Sign page 2",
+        signer_type: "participant_and_guardian"
+      )
+    end
+
+    it "keeps the signing setup but still renames once a consent exists" do
+      doc = create(:custom_document, event: event, name: "Hotel Waiver", signer_type: "participant",
+        docuseal_template_id: "1234")
+      create(:consent, :custom_document, custom_document: doc,
+        participant_event: create(:participant_event, event: event))
+
+      patch admin_event_custom_document_path(event, doc), params: {
+        custom_document: { name: "Hotel Waiver (2026)", signer_type: "guardian", docuseal_template_id: "9999" }
+      }
+
+      expect(doc.reload).to have_attributes(
+        name: "Hotel Waiver (2026)",
+        signer_type: "participant",
+        docuseal_template_id: "1234"
+      )
+    end
+
+    it "shows the edit form without the signing fields once a consent exists" do
+      doc = create(:custom_document, event: event)
+      create(:consent, :custom_document, custom_document: doc,
+        participant_event: create(:participant_event, event: event))
+
+      get admin_event_custom_document_edit_path(event, doc)
+
+      expect(response.body).to include("Signing setup is locked")
+      expect(response.body).not_to include("Who signs?")
+    end
+
+    it "drops stale field mappings when the template changes" do
+      doc = create(:custom_document, event: event, docuseal_template_id: "1234")
+      event.update!(docuseal_field_mappings: {
+        doc.mapping_key => { "mappings" => [ { "field_name" => "Name", "source_key" => "participant.full_name" } ] }
+      })
+
+      patch admin_event_custom_document_path(event, doc), params: {
+        custom_document: { name: doc.name, docuseal_template_id: "5678" }
+      }
+
+      expect(doc.reload.docuseal_template_id).to eq("5678")
+      expect(event.reload.docuseal_field_mappings).not_to have_key(doc.mapping_key)
+    end
+
+    it "reopens completed participants when an optional document becomes required" do
+      doc = create(:custom_document, event: event, optional: true)
+
+      expect {
+        patch admin_event_custom_document_path(event, doc), params: {
+          custom_document: { name: doc.name, docuseal_template_id: doc.docuseal_template_id, optional: "0" }
+        }
+      }.to have_enqueued_job(ReopenParticipantsForCustomDocumentsJob).with(event.id)
+
+      expect(doc.reload).not_to be_optional
+    end
+
+    it "rejects an invalid update instead of saving it" do
+      doc = create(:custom_document, event: event, name: "Hotel Waiver")
+
+      patch admin_event_custom_document_path(event, doc), params: {
+        custom_document: { name: "", docuseal_template_id: doc.docuseal_template_id }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(doc.reload.name).to eq("Hotel Waiver")
+    end
+
     it "destroys a document without consents but archives one with consents" do
       unused = create(:custom_document, event: event)
       used = create(:custom_document, event: event)


### PR DESCRIPTION
Custom documents were write-once. Changing a name, description or signer type meant removing the document — which *archives* it once anybody has a consent — and adding a replacement, losing the DocuSeal field mappings on the way.

## What this adds

An **Edit** link on each custom document row in `/admin/:slug/integrations`, going to a dedicated edit page.

- **Name and description** are always editable. They're labels, and existing consents pick up the new wording.
- **Signing setup** (`document_kind`, `docuseal_template_id`, `signer_type`, `template_pdf`, `optional`) is editable only while `consents.none?`. Once anybody has a consent, DocuSeal submissions exist against the old shape, so the form replaces those fields with a read-only summary and points at remove-and-replace. Locked fields aren't rejected loudly — they're simply not permitted, so a stale form can't sneak a change through.

## Side-effects handled

- Changing the template id drops the now-meaningless field mappings; the notice tells you to re-sync.
- electronic → physical nils the stale `docuseal_template_id`; physical → electronic purges the PDF and clears `template_page_count`.
- Editing a physical document leaves the file field empty-means-keep.
- Editing `signer_type` or `optional` reopens completed participants, the same way adding a document does.

## Worth a reviewer's eye

The reopen-on-edit callback needed its own method name. Registering the same symbol twice in the `after_commit` chain *replaces* the create callback instead of adding to it — the first version of this silently killed reopen-on-add, which `custom_document_reopen_spec.rb` caught.

## Testing

8 new request specs: the link, both edit renders, the unlocked update, the locked-field no-op, mapping cleanup, the optional→required reopen, and the invalid-name 422. Custom-document spec files pass (78 examples), rubocop clean.

Not visually reviewed yet — `max-w-3xl` is new to the codebase, so it needs a fresh Tailwind build.