### PR TITLE
Let admins resend and reset a participant's custom documents

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -443,6 +443,49 @@ module Admin
       end
     end
 
+    # Re-issue an electronic custom document: void the stale DocuSeal
+    # submission, put the consent back to pending, and let the normal job build
+    # a fresh one so whoever must sign gets a link that works.
+    def resend_custom_document
+      authorize @participant_event, :reset_waiver?
+
+      custom_document, consent = custom_document_and_consent
+
+      if (error = custom_document_resend_error(custom_document, consent))
+        redirect_to consents_admin_event_participant_path(current_event, @participant_event), alert: error
+        return
+      end
+
+      reissue_custom_document(custom_document, consent)
+
+      redirect_to consents_admin_event_participant_path(current_event, @participant_event),
+        notice: custom_document_resend_notice(custom_document)
+    end
+
+    # The destructive counterpart: throw away an existing signature and issue a
+    # fresh document. Separate from resend so the signature can only ever be
+    # discarded on purpose.
+    def reset_custom_document
+      authorize @participant_event, :reset_waiver?
+
+      custom_document, consent = custom_document_and_consent
+
+      if (error = custom_document_reset_error(custom_document, consent))
+        redirect_to consents_admin_event_participant_path(current_event, @participant_event), alert: error
+        return
+      end
+
+      reissue_custom_document(custom_document, consent)
+
+      # A signature just vanished, so the participant isn't done any more and a
+      # guardian who had finished needs their portal back to sign again.
+      reopen_guardian_portal_access
+      @participant_event.update!(status: :in_progress) if @participant_event.complete?
+
+      redirect_to consents_admin_event_participant_path(current_event, @participant_event),
+        notice: "The previous signature has been discarded. #{custom_document_resend_notice(custom_document)}"
+    end
+
     def notes
       authorize @participant_event, :view_notes?
       @notes = @participant_event.notes.includes(:author).order(created_at: :desc)
@@ -1306,6 +1349,127 @@ module Admin
       else
         ParticipantMailer.waiver_ready(participant_event: @participant_event).deliver_later
       end
+    end
+
+    def custom_document_and_consent
+      custom_document = current_event.custom_documents.find_by(id: params[:custom_document_id])
+      consent = custom_document && @participant_event.consents.find_by(custom_document_id: custom_document.id)
+
+      [ custom_document, consent ]
+    end
+
+    # Void the stale DocuSeal submission, put the consent back to pending, and
+    # let the normal job build a fresh one so whoever must sign gets a working
+    # link. Shared by resend and reset — they differ only in what state they
+    # accept beforehand and what they clean up afterwards.
+    def reissue_custom_document(custom_document, consent)
+      if consent
+        void_docuseal_submission(consent)
+        consent.update!(
+          status: :pending,
+          docuseal_envelope_id: nil,
+          docuseal_participant_slug: nil,
+          docuseal_guardian_slug: nil,
+          docuseal_template_id: nil,
+          participant_signed_at: nil,
+          guardian_signed_at: nil,
+          signed_at: nil,
+          document_url: nil,
+          failure_reason: nil,
+          pending_on: nil,
+          sent_at: nil
+        )
+      else
+        consent = @participant_event.consents.create!(
+          consent_type: :custom_document,
+          custom_document: custom_document
+        )
+      end
+
+      DocusealJobs::CreateCustomDocumentJob.perform_later(consent.id)
+
+      # DocuSeal emails the guardian their link, but participants sign embedded
+      # in Attend and are never emailed by DocuSeal — they need Attend's nudge.
+      if custom_document.participant_signs?
+        ParticipantMailer.new_document_ready(participant_event: @participant_event).deliver_later
+      end
+
+      consent
+    end
+
+    # Everything that makes a resend pointless or harmful, in the order an
+    # admin would hit it. A signed document is a legal record, so discarding
+    # the signature is the separate, explicit reset action.
+    def custom_document_resend_error(custom_document, consent)
+      return "#{quoted(custom_document)} is already signed. Use Reset to discard the signature and issue a new one." if consent&.signed?
+
+      custom_document_sendable_error(custom_document)
+    end
+
+    def custom_document_reset_error(custom_document, consent)
+      return "Document not found for this event." if custom_document.nil?
+
+      unless consent&.signed?
+        return "#{quoted(custom_document)} isn't signed, so there's nothing to reset — use Resend instead."
+      end
+
+      custom_document_sendable_error(custom_document)
+    end
+
+    # Reasons a fresh DocuSeal submission can't be built at all.
+    def custom_document_sendable_error(custom_document)
+      return "Document not found for this event." if custom_document.nil?
+
+      name = quoted(custom_document)
+
+      unless custom_document.electronic?
+        return "#{name} is signed on paper, so it doesn't go through DocuSeal."
+      end
+
+      unless custom_document.applies_to?(@participant_event)
+        return "#{name} doesn't apply to this participant."
+      end
+
+      if custom_document.guardian_signs? && @participant_event.requires_guardian?
+        return "#{name} needs a guardian, and none is on file yet." if resend_guardian.nil?
+        if current_event.guardian_invites_locked?
+          return "Guardian invites are still locked for this event, so #{name} can't be sent yet."
+        end
+      end
+
+      nil
+    end
+
+    def quoted(custom_document)
+      "\"#{custom_document.name}\""
+    end
+
+    def resend_guardian
+      @participant_event.guardian_participant_events.first&.guardian
+    end
+
+    def custom_document_resend_notice(custom_document)
+      name = quoted(custom_document)
+
+      if custom_document.signed_by_guardian?
+        "#{name} has been re-sent — the guardian will be emailed a new signing link."
+      elsif custom_document.guardian_signs? && @participant_event.requires_guardian?
+        "#{name} has been re-sent — the participant has been emailed, and their guardian is emailed their link once the participant signs."
+      else
+        "#{name} has been re-sent — the participant has been emailed a link to sign it."
+      end
+    end
+
+    # Best effort: the point is to stop the old link working, but a DocuSeal
+    # failure mustn't block re-issuing the document.
+    def void_docuseal_submission(consent)
+      return if consent.docuseal_envelope_id.blank?
+
+      Docuseal::Client.for(consent).archive_submission(consent.docuseal_envelope_id)
+    rescue Docuseal::Error => e
+      Rails.logger.warn(
+        "Couldn't archive DocuSeal submission #{consent.docuseal_envelope_id} for consent #{consent.id}: #{e.message}"
+      )
     end
 
     def reopen_guardian_portal_access

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -29,6 +29,8 @@ class AuditLog < ApplicationRecord
     withdraw: "withdraw",
     unwithdraw: "unwithdraw",
     resend_waiver_completion_email: "resend_waiver_completion_email",
+    resend_custom_document: "resend_custom_document",
+    reset_custom_document: "reset_custom_document",
     update_medical: "update_medical",
     undo_check_in: "undo_check_in",
     update_safeguarding: "update_safeguarding",

--- a/app/views/admin/participants/consents.html.erb
+++ b/app/views/admin/participants/consents.html.erb
@@ -186,6 +186,7 @@
   </div>
 
   <% if @custom_documents.any? %>
+    <% can_resend_custom_documents = policy(@participant_event).reset_waiver? %>
     <h2 class="text-lg font-semibold mt-8 mb-4">Additional Documents</h2>
     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <table class="min-w-full divide-y divide-gray-100">
@@ -196,6 +197,9 @@
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Signed By</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
             <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Document</th>
+            <% if can_resend_custom_documents %>
+              <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            <% end %>
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-gray-100">
@@ -275,6 +279,28 @@
                   —
                 <% end %>
               </td>
+              <% if can_resend_custom_documents %>
+                <td class="px-6 py-4 text-right text-sm">
+                  <% # Paper documents never touch DocuSeal. Signed ones can only
+                     # be re-issued through Reset, which says out loud that the
+                     # signature is being discarded. %>
+                  <% if !doc.electronic? %>
+                    <span class="text-gray-300">—</span>
+                  <% elsif consent&.signed? %>
+                    <%= button_to "Reset", reset_custom_document_admin_event_participant_path(current_event, @participant_event),
+                        method: :delete,
+                        params: { custom_document_id: doc.id },
+                        class: "text-sm text-red-600 hover:text-red-800 font-medium",
+                        data: { turbo_confirm: "Reset this document? The existing signature is discarded, a new one is issued, and this participant goes back to in progress. Are you sure?" } %>
+                  <% else %>
+                    <%= button_to "Resend", resend_custom_document_admin_event_participant_path(current_event, @participant_event),
+                        method: :post,
+                        params: { custom_document_id: doc.id },
+                        class: "text-sm text-[#ec3750] hover:text-[#d42f46] font-medium",
+                        data: { turbo_confirm: "Re-send this document? Any existing DocuSeal link stops working and a new one is issued." } %>
+                  <% end %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,8 @@ Rails.application.routes.draw do
           delete :reset_waiver
           delete :reset_freedom_waiver
           post :resend_waiver_completion_email
+          post :resend_custom_document
+          delete :reset_custom_document
           get :notes
           get :history
           post :resync_airtable

--- a/spec/requests/custom_documents_spec.rb
+++ b/spec/requests/custom_documents_spec.rb
@@ -75,6 +75,185 @@ RSpec.describe "Custom documents", type: :request do
     end
   end
 
+  describe "admin resend" do
+    let(:admin) { User.create!(email: "admin-resend@example.com", name: "Admin", global_role: "global_admin") }
+    let(:participant_event) { create(:participant_event, event: event) }
+    let(:docuseal) { instance_double(Docuseal::Client, archive_submission: true) }
+
+    before do
+      sign_in admin
+      allow(Docuseal::Client).to receive(:for).and_return(docuseal)
+    end
+
+    def resend(doc)
+      post resend_custom_document_admin_event_participant_path(event, participant_event),
+        params: { custom_document_id: doc.id }
+    end
+
+    it "voids the old submission, resets the consent, and re-enqueues the job" do
+      doc = create(:custom_document, event: event)
+      consent = create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+        status: :sent, docuseal_envelope_id: "sub-1", docuseal_participant_slug: "abc123",
+        failure_reason: "docuseal_error: boom")
+
+      expect { resend(doc) }
+        .to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob).with(consent.id)
+        .and have_enqueued_mail(ParticipantMailer, :new_document_ready)
+
+      expect(docuseal).to have_received(:archive_submission).with("sub-1")
+      expect(consent.reload).to have_attributes(
+        status: "pending",
+        docuseal_envelope_id: nil,
+        docuseal_participant_slug: nil,
+        failure_reason: nil
+      )
+    end
+
+    it "creates the consent when the document was never started" do
+      doc = create(:custom_document, event: event)
+
+      expect { resend(doc) }.to change(participant_event.consents, :count).by(1)
+      expect(participant_event.consents.last.custom_document).to eq(doc)
+    end
+
+    it "re-issues to the guardian without emailing the participant" do
+      participant_event.participant.update!(date_of_birth: 15.years.ago)
+      create(:guardian_participant_event, participant_event: participant_event)
+      doc = create(:custom_document, :guardian_only, event: event)
+
+      expect { resend(doc) }.to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+      # DocuSeal emails the guardian directly; the participant isn't involved.
+      expect(enqueued_jobs.map { |job| job[:args].first(2) })
+        .not_to include([ "ParticipantMailer", "new_document_ready" ])
+      expect(response).to redirect_to(consents_admin_event_participant_path(event, participant_event))
+    end
+
+    it "refuses to resend a signed document" do
+      doc = create(:custom_document, event: event)
+      create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+        status: :signed, signed_at: Time.current, docuseal_envelope_id: "sub-1")
+
+      expect { resend(doc) }.not_to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+      expect(flash[:alert]).to include("already signed")
+      expect(docuseal).not_to have_received(:archive_submission)
+    end
+
+    describe "resetting a signed document" do
+      def reset(doc)
+        delete reset_custom_document_admin_event_participant_path(event, participant_event),
+          params: { custom_document_id: doc.id }
+      end
+
+      it "discards the signature, re-issues, and reopens the participant" do
+        participant_event.update!(status: :complete)
+        doc = create(:custom_document, event: event)
+        consent = create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+          status: :signed, signed_at: Time.current, participant_signed_at: Time.current,
+          docuseal_envelope_id: "sub-1", document_url: "https://docuseal.test/d/abc")
+
+        expect { reset(doc) }
+          .to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob).with(consent.id)
+          .and have_enqueued_mail(ParticipantMailer, :new_document_ready)
+
+        expect(docuseal).to have_received(:archive_submission).with("sub-1")
+        expect(consent.reload).to have_attributes(
+          status: "pending",
+          signed_at: nil,
+          participant_signed_at: nil,
+          document_url: nil,
+          docuseal_envelope_id: nil
+        )
+        expect(participant_event.reload.status).to eq("in_progress")
+      end
+
+      it "reopens a guardian who had already finished" do
+        participant_event.participant.update!(date_of_birth: 15.years.ago)
+        gpe = create(:guardian_participant_event, participant_event: participant_event,
+          status: :completed, completed_at: Time.current)
+        doc = create(:custom_document, :guardian_only, event: event)
+        create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+          guardian_participant_event: gpe, status: :signed, signed_at: Time.current,
+          guardian_signed_at: Time.current, docuseal_envelope_id: "sub-1")
+
+        reset(doc)
+
+        expect(gpe.reload.status).to eq("in_progress")
+      end
+
+      it "refuses to reset a document that isn't signed" do
+        doc = create(:custom_document, event: event)
+        create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+          status: :sent, docuseal_envelope_id: "sub-1")
+
+        expect { reset(doc) }.not_to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+        expect(flash[:alert]).to include("use Resend instead")
+        expect(docuseal).not_to have_received(:archive_submission)
+      end
+
+      it "refuses to reset a physical document" do
+        doc = create(:custom_document, :physical, event: event)
+        create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+          status: :signed, signed_at: Time.current)
+
+        expect { reset(doc) }.not_to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+        expect(flash[:alert]).to include("doesn't go through DocuSeal")
+      end
+
+      it "shows Reset rather than Resend once the document is signed" do
+        doc = create(:custom_document, event: event)
+        create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+          status: :signed, signed_at: Time.current)
+
+        get consents_admin_event_participant_path(event, participant_event)
+
+        expect(response.body).to include(reset_custom_document_admin_event_participant_path(event, participant_event))
+        expect(response.body).not_to include(resend_custom_document_admin_event_participant_path(event, participant_event))
+      end
+    end
+
+    it "refuses to resend a physical document" do
+      doc = create(:custom_document, :physical, event: event)
+
+      expect { resend(doc) }.not_to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+      expect(flash[:alert]).to include("signed on paper")
+    end
+
+    it "refuses a guardian document when no guardian is on file" do
+      participant_event.participant.update!(date_of_birth: 15.years.ago)
+      doc = create(:custom_document, :guardian_only, event: event)
+
+      expect { resend(doc) }.not_to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+      expect(flash[:alert]).to include("needs a guardian")
+    end
+
+    it "refuses an optional document the participant hasn't added" do
+      doc = create(:custom_document, :optional, event: event)
+
+      expect { resend(doc) }.not_to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob)
+      expect(flash[:alert]).to include("doesn't apply")
+    end
+
+    it "still re-issues when DocuSeal can't archive the old submission" do
+      doc = create(:custom_document, event: event)
+      consent = create(:consent, :custom_document, custom_document: doc, participant_event: participant_event,
+        status: :sent, docuseal_envelope_id: "sub-1")
+      allow(docuseal).to receive(:archive_submission).and_raise(Docuseal::Error, "gone")
+
+      expect { resend(doc) }.to have_enqueued_job(DocusealJobs::CreateCustomDocumentJob).with(consent.id)
+      expect(consent.reload.status).to eq("pending")
+    end
+
+    it "shows a Resend button on the consents page" do
+      doc = create(:custom_document, event: event)
+
+      get consents_admin_event_participant_path(event, participant_event)
+
+      expect(response.body).to include("Resend")
+      expect(response.body).to include(resend_custom_document_admin_event_participant_path(event, participant_event))
+      expect(response.body).to include(doc.id)
+    end
+  end
+
   describe "participant signing flow" do
     let(:user) { create(:user) }
     let(:participant) { create(:participant, user: user) }


### PR DESCRIPTION
A custom document that got stuck — a failed submission, or a guardian who lost their DocuSeal email — had no admin recovery path. Waivers have Reset Waiver; custom documents had nothing.

## What this adds

Two buttons in the **Additional Documents** table on a participant's consents page, in a new Actions column gated on `policy(@participant_event).reset_waiver?` (global admins and event admins — the same permission as Reset Waiver).

Both share `reissue_custom_document`: archive the old DocuSeal submission, clear the consent's DocuSeal state back to `pending` (envelope id, both slugs, template id, signed timestamps, `document_url`, `failure_reason`, `pending_on`, `sent_at`), and re-enqueue `CreateCustomDocumentJob` so a fresh submission is built from the current prefill mappings. Archiving is best effort — the point is to kill the old link, so a `Docuseal::Error` is logged rather than blocking the re-issue. This is the first use of the client's `archive_submission`, which was defined but unused.

The button shown depends on state, so a signature can only ever be discarded on purpose:

| State | Button |
| --- | --- |
| Unsigned electronic | **Resend** |
| Signed electronic | **Reset** (red, with a confirm spelling out the consequences) |
| Physical | — |

Neither route can be driven into the wrong state either: resend refuses a signed document and points at Reset, reset refuses an unsigned one and points at Resend.

**Reset additionally** reopens a guardian who had already completed their portal, and regresses the participant from `complete` to `in_progress`. That second part is a deliberate difference from Reset Waiver, which leaves the db status disagreeing with the live display status — the mismatch that bit us before. I haven't touched Reset Waiver; it has the same gap if we want it fixed separately.

## Emails

DocuSeal only emails the guardian — participants sign embedded in Attend with `send_email: false` — so a participant signer also gets `ParticipantMailer.new_document_ready`. The flash notice says which happened, including the dual-signer case where the guardian's link only goes out after the participant signs.

## Refusals

Each with its own flash: document not on the event, physical, doesn't apply to this participant (including an optional document they haven't added), already signed / not signed, guardian document with no guardian on file, and guardian invites still locked for the event.

## Deliberately out of scope

Physical documents. Participants and guardians can already redo their own paper uploads via `remove_physical_upload` on the dashboard and portal, so an admin reset would be a third path into the same state.

## Testing

14 new request specs covering the happy paths, consent creation when a document was never started, the guardian path not emailing the participant, every refusal, the archive-failure fallback, and which button renders. Rubocop clean across the repo.

One pre-existing spec needed accommodating rather than changing: `admin/participants_spec.rb:111` asserts a document's name appears exactly once on the page, and quoting `doc.name` in the confirm dialogs made it twice. The invariant is sound, so the confirms say "this document" instead — the button sits in that document's own row.

Not visually reviewed yet.