### PR TITLE
Silence the false-positive SQL injection warning on optional document sort

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -39,8 +39,28 @@
       "user_input": ":role",
       "confidence": "Medium",
       "note": "Role assignment in admin controller is intentional - only series owners/global admins reach this (require_series_owner_access), and role is an enum restricted to owner/organizer."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "a3c826887eecb37e1dbeddbfe8cfa821c730f3f312d213ac15701948cbf1f54d",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/admin/participants_controller.rb",
+      "line": 1237,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"#{optional_document_rank_sql(optional_document_for_key(@sort_field))} #{(:desc or :asc).to_s.upcase}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::ParticipantsController",
+        "method": "apply_table_sorting"
+      },
+      "user_input": "optional_document_rank_sql(optional_document_for_key(@sort_field))",
+      "confidence": "Medium",
+      "note": "False positive - optional_document_rank_sql builds its SQL through sanitize_sql_array with the document id bound as :id, the document itself is resolved against the current event's own document list, and the interpolated sort direction is one of two literal symbols."
     }
   ],
-  "updated": "2026-02-04",
+  "updated": "2026-08-17",
   "brakeman_version": "8.0.2"
 }


### PR DESCRIPTION
CI's `scan_ruby` job has been failing on `main` since the optional document sorting landed — `60c3a678`, `db32c7fe` and `4853d168` are all red — so every PR opened since inherits a failing check.

The warning is a false positive:

```ruby
def optional_document_rank_sql(doc)
  ActiveRecord::Base.sanitize_sql_array([ OPTIONAL_DOCUMENT_RANK_SQL, { id: doc.id } ])
end
```

- the document id is **bound** as `:id` through `sanitize_sql_array`, not interpolated
- `doc` comes from `optional_document_by_id`, which resolves the id against `current_event.active_custom_documents` — another event's id can't get through
- the only other interpolation is the sort direction, which is `@sort_direction == "desc" ? :desc : :asc`, so two literal symbols

Brakeman just can't see through the helper method to the sanitize call. Recorded in `config/brakeman.ignore` with that reasoning, rather than reshaping query code that's already correct.

Verified locally: `bin/brakeman --no-pager -i config/brakeman.ignore` → 0 warnings, 7 ignored.

Worth merging first — #38 and #39 are both green apart from this inherited failure.