### PR TITLE
Mark staging with a permanent dashed frame

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,3 +19,15 @@
   cursor: pointer !important;
   pointer-events: auto !important;
 }
+
+/* Staging-only chrome. Fixed rather than a border on <body> so it never shifts
+   layout or scrolls away, and pointer-events: none so it cannot swallow clicks
+   at the edges of the viewport. The z-index sits above the Places dropdown
+   (10000) and hackclub.css's stacking (30) so nothing paints over the frame. */
+.staging-frame {
+  position: fixed;
+  inset: 0;
+  border: 3px dashed #ff8c37;
+  pointer-events: none;
+  z-index: 2147483647;
+}

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -205,5 +205,6 @@
         </div>
       </div>
     </div>
+    <%= render "shared/staging_frame" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -207,5 +207,6 @@
       </div>
       <%= render "shared/debug_footer" %>
     </footer>
+    <%= render "shared/staging_frame" %>
   </body>
 </html>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -124,5 +124,6 @@
         </main>
       </div>
     </div>
+    <%= render "shared/staging_frame" %>
   </body>
 </html>

--- a/app/views/shared/_staging_frame.html.erb
+++ b/app/views/shared/_staging_frame.html.erb
@@ -1,0 +1,7 @@
+<%# A permanent dashed frame around staging, so a staging tab is never mistaken
+    for production — the two look identical otherwise, and staging holds scratch
+    data that people should not act on. Rendered from every human-facing layout;
+    deliberately not from the mailer layout. %>
+<% if Rails.env.staging? %>
+  <div class="staging-frame" aria-hidden="true"></div>
+<% end %>

--- a/spec/requests/staging_frame_spec.rb
+++ b/spec/requests/staging_frame_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "The staging frame", type: :request do
+  it "is not rendered outside staging" do
+    get root_path
+
+    expect(response.body).not_to include("staging-frame")
+  end
+
+  it "is rendered on staging" do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("staging"))
+
+    get root_path
+
+    expect(response.body).to include('class="staging-frame"')
+  end
+end


### PR DESCRIPTION
Staging and production render identically, so a stale tab is easy to mistake for the real thing — and staging holds scratch data nobody should act on.

```
.staging-frame {
  position: fixed;
  inset: 0;
  border: 3px dashed #ff8c37;
  pointer-events: none;
  z-index: 2147483647;
}
```

- **Fixed overlay, not a border on `<body>`** — so it shifts no layout and never scrolls out of view.
- **`pointer-events: none`** — cannot swallow clicks near the viewport edges.
- **z-index above everything** — clears the Places autocomplete dropdown (`10000`) and `hackclub.css`'s stacking (`30`).
- Rendered from `application`, `admin` and `support` layouts. The **mailer layout is deliberately excluded** — emails shouldn't carry it.
- The `Rails.env.staging?` check lives in the partial, so the three layouts each render one line.

## Verification

- New request spec: absent outside staging, `class="staging-frame"` present when the environment is staging.
- 33 examples across the three touched layouts' specs, 0 failures.
- Confirmed the class actually ships: `stylesheet_link_tag :app` resolves to `/assets/application-*.css` **plus** `/assets/tailwind-*.css`, and this rule is in `app/assets/stylesheets/application.css` — the first of those. No Tailwind rebuild needed since it's a plain class, not a utility.

**Not verified visually** — I can't drive a browser, so the actual look on staging (and dark mode, where `themes.css` loads after `application.css`) is worth a glance.