### PR TITLE
Allow the HCA OAuth host in form-action

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,7 +20,11 @@ Rails.application.configure do
     policy.frame_src   :self, *docuseal_origins, "https://challenges.cloudflare.com"
     policy.frame_ancestors :self
     policy.base_uri    :self
-    policy.form_action :self, *docuseal_origins
+    # HCA sign-in: the button posts to /users/auth/hack_club (self), which then
+    # 302s to auth.hackclub.com/oauth/authorize. Browsers enforce form-action
+    # across the whole redirect chain, so the OAuth host has to be listed here
+    # or the POST is blocked before it ever leaves the page.
+    policy.form_action :self, *docuseal_origins, "https://auth.hackclub.com"
   end
 
   # A fresh nonce per response for the importmap and our inline scripts. Not

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -87,6 +87,17 @@ RSpec.describe "Content Security Policy", type: :request do
     it "the sign-in page is clean" do
       expect_csp_clean(root_path, inline_scripts: LAYOUT_INLINE_SCRIPTS)
     end
+
+    # The sign-in button posts to /users/auth/hack_club, which redirects to
+    # HCA. form-action is enforced across the redirect, so dropping the OAuth
+    # host here blocks sign-in entirely with nothing on the server side to show
+    # for it.
+    it "allows the HCA OAuth host in form-action" do
+      get root_path
+
+      form_action = response.headers["Content-Security-Policy"][/form-action[^;]*/]
+      expect(form_action).to include("https://auth.hackclub.com")
+    end
   end
 
   describe "admin pages" do


### PR DESCRIPTION
Sign-in is currently blocked in Chrome on production:

> Sending form data to 'https://attend.hackclub.com/users/auth/hack_club' violates the following Content Security Policy directive: "form-action 'self' https://docuseal.com https://sign.b.selfhosted.hackclub.com"

The form target *is* `'self'` — but `/users/auth/hack_club` 302s to `https://auth.hackclub.com/oauth/authorize`, and browsers enforce `form-action` across the whole redirect chain while reporting the violation against the original target. So the message blames our own origin while the actually-blocked hop is HCA.

Adds `https://auth.hackclub.com` to `form-action`, plus a regression spec — the existing CSP specs only check `script-src` and inline handlers, so dropping this host again would kill sign-in with nothing failing server-side.

`spec/requests/content_security_policy_spec.rb`: 15 examples, 0 failures.