### PR TITLE
Skip the travel onboarding step when the event has travel disabled

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -52,7 +52,7 @@ module Admin
       if params[:flag].present?
         case params[:flag]
         when "incomplete_onboarding"
-          @participant_events = @participant_events.missing_onboarding_data(accommodation_required: current_event.accommodation_enabled?)
+          @participant_events = @participant_events.missing_onboarding_data(accommodation_required: current_event.accommodation_enabled?, travel_required: current_event.travel_enabled?)
         when "missing_travel"
           @participant_events = @participant_events.left_joins(:travel_inbound).where(travels: { id: nil })
         when "missing_medical"
@@ -1168,7 +1168,7 @@ module Admin
 
     def apply_onboarding_filter(scope, operator, value)
       complete = value == "true"
-      incomplete = current_event.participant_events.missing_onboarding_data(accommodation_required: current_event.accommodation_enabled?)
+      incomplete = current_event.participant_events.missing_onboarding_data(accommodation_required: current_event.accommodation_enabled?, travel_required: current_event.travel_enabled?)
 
       if complete
         scope.where.not(id: incomplete.select(:id))

--- a/app/models/participant_event.rb
+++ b/app/models/participant_event.rb
@@ -77,16 +77,18 @@ class ParticipantEvent < ApplicationRecord
 
   # SQL mirror of !onboarding_complete? so list filters don't have to load
   # every row into Ruby. Keep in sync with #onboarding_complete?.
-  scope :missing_onboarding_data, ->(accommodation_required:) {
+  scope :missing_onboarding_data, ->(accommodation_required:, travel_required: true) {
     clauses = [
-      "NOT EXISTS (SELECT 1 FROM travels t WHERE t.participant_event_id = participant_events.id AND t.direction = 'inbound')",
-      "NOT EXISTS (SELECT 1 FROM travels t WHERE t.participant_event_id = participant_events.id AND t.direction = 'outbound')",
       "NOT EXISTS (SELECT 1 FROM medicals m WHERE m.participant_event_id = participant_events.id)",
       "NOT EXISTS (SELECT 1 FROM dietaries d WHERE d.participant_event_id = participant_events.id)",
       "NOT EXISTS (SELECT 1 FROM accessibilities a WHERE a.participant_event_id = participant_events.id)",
       "NOT EXISTS (SELECT 1 FROM safeguarding_infos si WHERE si.participant_event_id = participant_events.id)",
       "NOT EXISTS (SELECT 1 FROM consents c WHERE c.participant_event_id = participant_events.id)"
     ]
+    if travel_required
+      clauses << "NOT EXISTS (SELECT 1 FROM travels t WHERE t.participant_event_id = participant_events.id AND t.direction = 'inbound')"
+      clauses << "NOT EXISTS (SELECT 1 FROM travels t WHERE t.participant_event_id = participant_events.id AND t.direction = 'outbound')"
+    end
     if accommodation_required
       clauses << "NOT EXISTS (SELECT 1 FROM accommodations ac WHERE ac.participant_event_id = participant_events.id)"
     end
@@ -104,8 +106,8 @@ class ParticipantEvent < ApplicationRecord
   end
 
   def onboarding_complete?
-    travel_inbound.present? &&
-      travel_outbound.present? &&
+    (travel_inbound.present? || !event.travel_enabled?) &&
+      (travel_outbound.present? || !event.travel_enabled?) &&
       (accommodation.present? || !event.accommodation_enabled?) &&
       medical.present? &&
       dietary.present? &&
@@ -272,7 +274,7 @@ class ParticipantEvent < ApplicationRecord
     steps = []
 
     steps << { name: "profile", done: participant.legal_first_name.present? && participant.legal_last_name.present? && participant.date_of_birth.present? }
-    steps << { name: "travel", done: travel_inbound.present? && travel_outbound.present? }
+    steps << { name: "travel", done: travel_inbound.present? && travel_outbound.present? } if event.travel_enabled?
     steps << { name: "accommodation", done: accommodation.present? } if event.accommodation_enabled?
     steps << { name: "health", done: medical.present? && dietary.present? && accessibility.present? }
 

--- a/spec/models/participant_event_spec.rb
+++ b/spec/models/participant_event_spec.rb
@@ -35,25 +35,45 @@ RSpec.describe ParticipantEvent, type: :model do
     end
 
     [ true, false ].each do |accommodation_enabled|
-      context "with accommodation_enabled=#{accommodation_enabled}" do
-        let(:event) { create(:event, accommodation_enabled: accommodation_enabled) }
+      [ true, false ].each do |travel_enabled|
+        context "with accommodation_enabled=#{accommodation_enabled}, travel_enabled=#{travel_enabled}" do
+          let(:event) { create(:event, accommodation_enabled: accommodation_enabled, travel_enabled: travel_enabled) }
 
-        it "matches exactly the records where onboarding_complete? is false" do
-          all_on = { travel_in: true, travel_out: true, medical: true, dietary: true,
-                     accessibility: true, safeguarding: true, consent: true, accommodation: true }
+          it "matches exactly the records where onboarding_complete? is false" do
+            all_on = { travel_in: true, travel_out: true, medical: true, dietary: true,
+                       accessibility: true, safeguarding: true, consent: true, accommodation: true }
 
-          pes = [ build_pe(event, **all_on), build_pe(event) ]
-          all_on.each_key do |flag|
-            pes << build_pe(event, **all_on.merge(flag => false))
+            pes = [ build_pe(event, **all_on), build_pe(event) ]
+            all_on.each_key do |flag|
+              pes << build_pe(event, **all_on.merge(flag => false))
+            end
+
+            scope_ids = event.participant_events
+              .missing_onboarding_data(accommodation_required: event.accommodation_enabled?,
+                                       travel_required: event.travel_enabled?)
+              .pluck(:id).sort
+            ruby_ids = pes.reject { |pe| pe.reload.onboarding_complete? }.map(&:id).sort
+
+            expect(scope_ids).to eq(ruby_ids)
           end
-
-          scope_ids = event.participant_events
-            .missing_onboarding_data(accommodation_required: event.accommodation_enabled?)
-            .pluck(:id).sort
-          ruby_ids = pes.reject { |pe| pe.reload.onboarding_complete? }.map(&:id).sort
-
-          expect(scope_ids).to eq(ruby_ids)
         end
+      end
+    end
+  end
+
+  describe "#onboarding_progress" do
+    # Every optional event module must gate its onboarding step, otherwise
+    # participants get stuck on a step that doesn't exist in the wizard.
+    { travel_enabled: "travel", accommodation_enabled: "accommodation" }.each do |flag, step|
+      it "includes the #{step} step when #{flag} is on" do
+        pe = create(:participant_event, event: create(:event, flag => true))
+        expect(pe.onboarding_progress[:steps].map { |s| s[:name] }).to include(step)
+      end
+
+      it "omits the #{step} step when #{flag} is off" do
+        pe = create(:participant_event, event: create(:event, flag => false))
+        expect(pe.onboarding_progress[:steps].map { |s| s[:name] }).not_to include(step)
+        expect(pe.onboarding_progress[:blocking_step]).not_to eq(step)
       end
     end
   end


### PR DESCRIPTION
Fixes a user-reported bug: an organizer (Sunbeam) disabled travel collection for their event, but participants still saw "Next: Travel" on the dashboard with a permanently-stuck registration progress bar (e.g. 4/6), even though the onboarding wizard had nothing left for them to fill out.

## Cause

The onboarding wizard already removes the travel step when `event.travel_enabled?` is false, but three other places still unconditionally required inbound + outbound travel:

- `ParticipantEvent#compute_onboarding_progress` — drove the dashboard "Next: Travel" card and kept `display_status` stuck at "Awaiting Participant"
- `ParticipantEvent#onboarding_complete?` — admin table showed these participants as "In progress" forever
- the `missing_onboarding_data` SQL mirror scope — the "incomplete onboarding" admin filter flagged them

## Fix

Gate all three on `event.travel_enabled?`, mirroring how `accommodation_enabled?` was already handled. The scope gains a `travel_required:` kwarg (default `true`) and both call sites pass the event flag.

## Tests

- Extended the scope-vs-Ruby parity matrix to run across `travel_enabled` × `accommodation_enabled`
- Added `#onboarding_progress` specs asserting every module-flagged step (travel, accommodation) is omitted when its flag is off — so the next optional module gets the same guarantee

All 35 model specs plus the admin/onboarding request suites (157 examples) pass.