### PR TITLE
Restyle participant onboarding in the guardian portal design language

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -271,6 +271,32 @@
     box-shadow: none;
   }
 
+  /* --- tabs ---------------------------------------------------------- */
+
+  .portal-tab {
+    padding: 0.625rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-soft);
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition: color 0.12s ease, border-color 0.12s ease;
+  }
+
+  .portal-tab:hover {
+    color: var(--text-strong);
+  }
+
+  .portal-tab:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+
+  .portal-tab-active {
+    color: var(--text-strong);
+    border-bottom-color: var(--accent);
+  }
+
   /* --- status ------------------------------------------------------- */
 
   .portal-badge {

--- a/app/views/onboarding/_autosave_status.html.erb
+++ b/app/views/onboarding/_autosave_status.html.erb
@@ -1,3 +1,3 @@
 <div class="flex justify-end mb-2">
-  <span data-autosave-target="status" class="text-sm text-gray-400"></span>
+  <span data-autosave-target="status" class="portal-meta text-sm"></span>
 </div>

--- a/app/views/onboarding/_step_navigation.html.erb
+++ b/app/views/onboarding/_step_navigation.html.erb
@@ -1,7 +1,7 @@
-<div class="pt-4 flex gap-3">
+<div class="pt-4 flex flex-col sm:flex-row gap-3">
   <% if @step_index && @step_index > 0 %>
-    <%= link_to "Back", onboarding_step_path(step: @steps[@step_index - 1], event_id: current_event.id), 
-        class: "w-1/4 bg-white text-gray-700 border border-gray-300 px-6 py-3 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 font-medium text-center" %>
+    <%= link_to "Back", onboarding_step_path(step: @steps[@step_index - 1], event_id: current_event.id),
+        class: "portal-btn portal-btn-secondary w-full sm:w-auto sm:min-w-28" %>
   <% end %>
-  <%= submit_tag "Save & Continue", class: "flex-1 bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 font-medium cursor-pointer" %>
+  <%= submit_tag "Save & Continue", class: "portal-btn portal-btn-primary flex-1" %>
 </div>

--- a/app/views/onboarding/_wizard_nav.html.erb
+++ b/app/views/onboarding/_wizard_nav.html.erb
@@ -1,49 +1,67 @@
 <div class="mb-6 text-center">
-  <p class="text-sm text-gray-500">Registering for</p>
-  <h2 class="text-lg font-semibold text-gray-900"><%= current_event.name %></h2>
+  <p class="portal-meta text-sm">Registering for</p>
+  <h2 class="portal-heading text-lg"><%= current_event.name %></h2>
 </div>
 
-<nav class="mb-8 overflow-x-auto">
-  <ol class="flex w-full min-w-max">
-    <% current_index = @steps.index(@current_step) %>
+<%# Position indicator for the onboarding wizard, mirroring the guardian
+    portal's step nav: completed steps are links back, the current step is
+    marked with aria-current, and steps not yet reached stay inert.
+
+    On phones the rail would need horizontal scrolling to stay legible, so we
+    show a compact "step N of M" line instead and keep the rail for sm and up. %>
+<nav class="mb-8" aria-label="Progress">
+  <% current_index = @steps.index(@current_step) %>
+
+  <p class="sm:hidden portal-hint text-sm font-medium mb-2">
+    Step <%= current_index + 1 %> of <%= @steps.length %> ·
+    <span class="portal-heading"><%= @current_step.to_s.titleize %></span>
+  </p>
+
+  <div class="portal-progress sm:hidden">
+    <div class="portal-progress-fill"
+         style="--portal-progress: <%= ((current_index + 1).to_f / @steps.length).round(3) %>"></div>
+  </div>
+
+  <ol class="hidden sm:flex items-start w-full">
     <% @steps.each_with_index do |step, index| %>
-      <% step_number = index + 1 %>
       <% is_completed = index < current_index %>
       <% is_current = step == @current_step %>
       <% is_last = index == @steps.length - 1 %>
 
-      <li class="relative flex-1 min-w-[5.5rem] px-1">
-        <% unless is_last %>
-          <%# Connector spans from this circle's edge to the next circle's edge,
-              independent of label widths %>
-          <div class="absolute top-[19px] h-0.5 left-[calc(50%+1.5rem)] right-[calc(-50%+1.5rem)] <%= is_completed ? 'bg-green-600' : 'bg-gray-300' %>" aria-hidden="true"></div>
-        <% end %>
-        <div class="relative flex flex-col items-center">
-          <div class="flex items-center justify-center w-10 h-10 rounded-full border-2 shrink-0 <%= if is_completed
-              'bg-green-600 border-green-600 text-white'
-            elsif is_current
-              'bg-blue-600 border-blue-600 text-white'
-            else
-              'bg-white border-gray-300 text-gray-500'
-            end %>">
+      <li class="flex items-start <%= "flex-1" unless is_last %>">
+        <div class="flex flex-col items-center gap-2 w-24 shrink-0">
+          <% marker_class = is_current ? "portal-step-marker-current" : (is_completed ? "portal-step-marker-done" : "") %>
+          <% marker = capture do %>
             <% if is_completed %>
-              <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+              <svg class="size-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/>
               </svg>
             <% else %>
-              <%= step_number %>
+              <%= index + 1 %>
             <% end %>
-          </div>
-          <span class="mt-2 text-xs font-medium whitespace-nowrap <%= if is_current
-              'text-blue-600'
-            elsif is_completed
-              'text-green-600'
-            else
-              'text-gray-500'
-            end %>">
+          <% end %>
+
+          <% if is_completed && !is_current %>
+            <%= link_to onboarding_step_path(step: step, event_id: current_event.id),
+                  class: "portal-step-marker #{marker_class} transition-transform hover:scale-110",
+                  aria: { label: "Back to #{step.to_s.titleize}" } do %>
+              <%= marker %>
+            <% end %>
+          <% else %>
+            <span class="portal-step-marker <%= marker_class %>" <%= "aria-current=step".html_safe if is_current %>>
+              <%= marker %>
+            </span>
+          <% end %>
+
+          <span class="text-xs font-medium text-center leading-tight <%= is_current ? "portal-heading" : (is_completed ? "portal-hint" : "portal-meta") %>">
             <%= step.to_s.titleize %>
           </span>
         </div>
+
+        <% unless is_last %>
+          <div class="flex-1 h-0.5 mt-[0.6875rem] rounded-full"
+               style="background-color: <%= is_completed ? "var(--success)" : "var(--border)" %>"></div>
+        <% end %>
       </li>
     <% end %>
   </ol>

--- a/app/views/onboarding/accommodation.html.erb
+++ b/app/views/onboarding/accommodation.html.erb
@@ -1,8 +1,10 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Accommodation</h1>
-  <p class="text-sm text-gray-600 mb-6">Fields marked with <span class="text-red-500">*</span> are required.</p>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Accommodation</h1>
+    <p class="portal-hint text-sm mt-2">Fields marked with <span class="portal-required" aria-hidden="true">*</span> are required.</p>
+  </header>
 
   <script nonce="<%= content_security_policy_nonce %>">
     document.addEventListener("DOMContentLoaded", function() {
@@ -21,7 +23,7 @@
       function toggleRoommateSection() {
         const genderBase = getSelectedGenderBase();
         const isTransgender = isTransgenderCheckbox.checked;
-        
+
         // Show roommate preferences for non-binary, trans female, trans male
         if (genderBase === "non_binary" || isTransgender) {
           roommateSection.classList.remove("hidden");
@@ -39,16 +41,16 @@
       form.addEventListener("submit", function(e) {
         const genderBase = getSelectedGenderBase();
         const genderBaseError = document.getElementById("gender_base_error");
-        
+
         if (!genderBase) {
           e.preventDefault();
           genderBaseError.classList.remove("hidden");
           return false;
         }
-        
+
         genderBaseError.classList.add("hidden");
       });
-      
+
       genderBaseRadios.forEach(radio => {
         radio.addEventListener("change", function() {
           document.getElementById("gender_base_error").classList.add("hidden");
@@ -62,48 +64,48 @@
   <%= form_with model: @accommodation, url: onboarding_step_path(step: @step, event_id: current_event.id), scope: :accommodation, method: :patch, local: true, data: { turbo: false, controller: "autosave", autosave_url_value: onboarding_step_path(step: @step, event_id: current_event.id), action: "input->autosave#input change->autosave#change" }, novalidate: true do |f| %>
     <%= render "autosave_status" %>
     <div class="space-y-6">
-      <section>
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Gender & Room Preferences</h2>
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-4">Gender & Room Preferences</h2>
 
         <div class="space-y-4">
           <div>
-             <%= f.label :gender_base, label_text("What gender do you identify as?", required: true), class: "block text-sm font-medium text-gray-700 mb-3" %>
-             <div id="gender_base_error" class="text-red-500 text-sm mb-2 hidden">Please select your gender identity</div>
+             <%= f.label :gender_base, label_text("What gender do you identify as?", required: true), class: "portal-label mb-3" %>
+             <div id="gender_base_error" class="text-sm mb-2 hidden" style="color: var(--danger);">Please select your gender identity</div>
              <div class="space-y-2">
-               <label class="flex items-center gap-3 p-4 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors" style="border: 2px solid transparent; border-radius: 8px;">
-                 <%= f.radio_button :gender_base, "female", { id: "gender_base_female", class: "h-4 w-4 text-blue-600 focus:ring-blue-500", data: { gender_base_field: true } } %>
-                 <span class="text-gray-700 font-medium">Woman</span>
+               <label class="portal-check-row px-4 rounded-md" style="border: 1px solid var(--border-strong);">
+                 <%= f.radio_button :gender_base, "female", { id: "gender_base_female", class: "portal-check mt-0.5", data: { gender_base_field: true } } %>
+                 <span class="font-medium">Woman</span>
                </label>
-               <label class="flex items-center gap-3 p-4 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors" style="border: 2px solid transparent; border-radius: 8px;">
-                 <%= f.radio_button :gender_base, "male", { id: "gender_base_male", class: "h-4 w-4 text-blue-600 focus:ring-blue-500", data: { gender_base_field: true } } %>
-                 <span class="text-gray-700 font-medium">Man</span>
+               <label class="portal-check-row px-4 rounded-md" style="border: 1px solid var(--border-strong);">
+                 <%= f.radio_button :gender_base, "male", { id: "gender_base_male", class: "portal-check mt-0.5", data: { gender_base_field: true } } %>
+                 <span class="font-medium">Man</span>
                </label>
-               <label class="flex items-center gap-3 p-4 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors" style="border: 2px solid transparent; border-radius: 8px;">
-                 <%= f.radio_button :gender_base, "non_binary", { id: "gender_base_non_binary", class: "h-4 w-4 text-blue-600 focus:ring-blue-500", data: { gender_base_field: true } } %>
-                 <span class="text-gray-700 font-medium">Non-binary</span>
+               <label class="portal-check-row px-4 rounded-md" style="border: 1px solid var(--border-strong);">
+                 <%= f.radio_button :gender_base, "non_binary", { id: "gender_base_non_binary", class: "portal-check mt-0.5", data: { gender_base_field: true } } %>
+                 <span class="font-medium">Non-binary</span>
                </label>
              </div>
            </div>
 
           <div>
-            <label class="flex items-center gap-3 p-4 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors">
-              <%= f.check_box :is_transgender, { id: "is_transgender_checkbox", class: "h-5 w-5 text-blue-600 focus:ring-blue-500 rounded" }, "true", "false" %>
-              <span class="text-gray-700 font-medium">I identify as transgender</span>
+            <label class="portal-check-row px-4 rounded-md" style="border: 1px dashed var(--border-strong);">
+              <%= f.check_box :is_transgender, { id: "is_transgender_checkbox", class: "portal-check mt-0.5" }, "true", "false" %>
+              <span class="font-medium">I identify as transgender</span>
             </label>
           </div>
 
           <div id="preferred_roommate_genders_section" class="<%= 'hidden' unless @accommodation.gender_base.in?(%w[non_binary]) || @accommodation.is_transgender %>">
-            <span class="block text-sm font-medium text-gray-700 mb-2">What gender(s) would you like to be paired with? <span class="text-red-500">*</span></span>
-            <p class="mb-3 text-sm text-gray-500">Select at least one</p>
-            <div class="space-y-2">
+            <span class="portal-label mb-1">What gender(s) would you like to be paired with? <span class="portal-required" aria-hidden="true">*</span></span>
+            <p class="mb-2 portal-hint text-sm">Select at least one</p>
+            <div>
               <% Accommodation::ROOMMATE_GENDER_OPTIONS.each do |key, value| %>
-                <label class="flex items-center gap-2">
+                <label class="portal-check-row">
                   <%= check_box_tag "accommodation[preferred_roommate_genders][]",
                     value,
                     @accommodation.preferred_roommate_genders&.include?(value),
                     id: "preferred_roommate_genders_#{key}",
-                    class: "h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" %>
-                  <span class="text-sm text-gray-700"><%= key.to_s.titleize %></span>
+                    class: "portal-check mt-0.5" %>
+                  <span class="text-sm"><%= key.to_s.titleize %></span>
                 </label>
               <% end %>
             </div>
@@ -112,20 +114,20 @@
       </section>
 
       <% if current_event.roommate_preferences_enabled? %>
-        <section>
-          <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Roommate Preferences</h2>
+        <section class="portal-card p-5 sm:p-6">
+          <h2 class="portal-heading text-base mb-4">Roommate Preferences</h2>
 
           <div class="space-y-4">
             <div>
-              <%= f.label :roommate_preferences, "Preferred Roommates", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= f.text_area :roommate_preferences, rows: 3, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Enter names of people you'd like to room with" %>
-              <p class="mt-1 text-sm text-gray-500">We'll do our best to accommodate preferences</p>
+              <%= f.label :roommate_preferences, "Preferred Roommates", class: "portal-label" %>
+              <%= f.text_area :roommate_preferences, rows: 3, class: "portal-textarea", placeholder: "Enter names of people you'd like to room with" %>
+              <p class="mt-1 portal-hint text-sm">We'll do our best to accommodate preferences</p>
             </div>
 
             <div>
-              <%= f.label :roommate_exclusions, "Roommate Exclusions", class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= f.text_area :roommate_exclusions, rows: 3, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Enter names of people you cannot room with" %>
-              <p class="mt-1 text-sm text-gray-500">This information is kept confidential</p>
+              <%= f.label :roommate_exclusions, "Roommate Exclusions", class: "portal-label" %>
+              <%= f.text_area :roommate_exclusions, rows: 3, class: "portal-textarea", placeholder: "Enter names of people you cannot room with" %>
+              <p class="mt-1 portal-hint text-sm">This information is kept confidential</p>
             </div>
           </div>
         </section>

--- a/app/views/onboarding/documents.html.erb
+++ b/app/views/onboarding/documents.html.erb
@@ -1,68 +1,82 @@
 <div class="w-full max-w-3xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Sign Your Documents</h1>
-  <% if @participant_event.requires_guardian? %>
-    <p class="text-sm text-gray-600 mb-6">
-      Sign your portion of each document below. Anything that also needs a parent/guardian signature
-      will be sent to them after you submit.
-    </p>
-  <% else %>
-    <p class="text-sm text-gray-600 mb-6">Review and sign each document below to continue.</p>
-  <% end %>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Sign Your Documents</h1>
+    <% if @participant_event.requires_guardian? %>
+      <p class="portal-hint text-sm mt-2">
+        Sign your portion of each document below. Anything that also needs a parent/guardian signature
+        will be sent to them after you submit.
+      </p>
+    <% else %>
+      <p class="portal-hint text-sm mt-2">Review and sign each document below to continue.</p>
+    <% end %>
+  </header>
 
   <% if @documents_paused %>
-    <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center mb-6">
-      <p class="text-gray-700 text-lg mb-2">Documents aren't ready to sign yet.</p>
-      <p class="text-gray-500">You can finish submitting your registration — we'll email you when your documents are ready.</p>
+    <div class="portal-note portal-note-warn mb-6">
+      <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+      </svg>
+      <div>
+        <p class="portal-heading text-sm">Documents aren't ready to sign yet.</p>
+        <p class="portal-body text-sm mt-0.5">You can finish submitting your registration — we'll email you when your documents are ready.</p>
+      </div>
     </div>
     <div class="flex justify-end">
       <%= form_with url: onboarding_step_path(step: "documents", event_id: current_event.id), method: :patch, data: { turbo: false } do %>
-        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-6 rounded-lg transition-colors cursor-pointer">
+        <button type="submit" class="portal-btn portal-btn-primary">
           Continue to Review
         </button>
       <% end %>
     </div>
   <% elsif @missing_guardian %>
-    <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center mb-6">
-      <p class="text-gray-700 text-lg mb-2">We need your guardian's details first.</p>
-      <%= link_to "Add guardian details", onboarding_step_path(step: "guardian", event_id: current_event.id), class: "text-blue-600 hover:underline" %>
+    <div class="portal-note portal-note-warn mb-6">
+      <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/>
+      </svg>
+      <p class="portal-body text-sm">
+        We need your guardian's details first.
+        <%= link_to "Add guardian details", onboarding_step_path(step: "guardian", event_id: current_event.id), class: "portal-link" %>
+      </p>
     </div>
   <% else %>
     <!-- Checklist -->
-    <div class="bg-white border border-gray-200 rounded-lg divide-y divide-gray-100 mb-6">
-      <% @documents.each do |doc| %>
+    <div class="portal-card divide-y mb-6" style="border-color: var(--border);">
+      <% @documents.each_with_index do |doc, index| %>
         <% consent = doc[:consent] %>
         <div class="p-4 flex items-center justify-between gap-4">
           <div class="flex items-center gap-3 min-w-0">
-            <% if consent&.participant_portion_signed? %>
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-green-100 text-green-600 shrink-0">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-              </span>
-            <% elsif doc == @current_document %>
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-600 shrink-0">
-                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M10 3a7 7 0 100 14 7 7 0 000-14z"/></svg>
-              </span>
-            <% else %>
-              <span class="w-6 h-6 rounded-full border-2 border-gray-300 shrink-0"></span>
-            <% end %>
-            <span class="font-medium text-gray-900 truncate"><%= doc[:name] %></span>
+            <span class="portal-step-marker <%= if consent&.participant_portion_signed?
+                "portal-step-marker-done"
+              elsif doc == @current_document
+                "portal-step-marker-current"
+              end %>">
+              <% if consent&.participant_portion_signed? %>
+                <svg class="size-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/>
+                </svg>
+              <% else %>
+                <%= index + 1 %>
+              <% end %>
+            </span>
+            <span class="portal-heading text-sm truncate"><%= doc[:name] %></span>
           </div>
           <div class="shrink-0 text-sm">
             <% if consent&.participant_portion_signed? %>
-              <span class="text-green-600 font-medium"><%= doc[:custom_document]&.physical? ? "Uploaded" : "Signed" %></span>
+              <span class="portal-badge portal-badge-done"><%= doc[:custom_document]&.physical? ? "Uploaded" : "Signed" %></span>
             <% elsif doc[:custom_document]&.physical? && @current_document.nil? && !@documents_preparing %>
               <%# Matches the render condition on the upload sections below —
                   while an electronic document is being signed or prepared the
                   upload UI isn't on the page yet. %>
-              <span class="text-blue-600 font-medium">Upload below</span>
+              <span class="portal-badge portal-badge-waiting">Upload below</span>
             <% elsif consent&.failed? %>
               <%= button_to "Retry", onboarding_document_signed_path(consent_id: consent.id, event_id: current_event.id, retry: 1),
-                  method: :post, class: "text-red-600 hover:text-red-800 font-medium" %>
+                  method: :post, class: "portal-btn portal-btn-secondary text-sm" %>
             <% elsif doc == @current_document %>
-              <span class="text-blue-600 font-medium">Sign below</span>
+              <span class="portal-badge portal-badge-waiting">Sign below</span>
             <% else %>
-              <span class="text-gray-400">Waiting</span>
+              <span class="portal-badge portal-badge-neutral">Waiting</span>
             <% end %>
           </div>
         </div>
@@ -79,16 +93,16 @@
       <div data-controller="document-status"
            data-document-status-url-value="<%= onboarding_documents_status_path(event_id: current_event.id) %>"
            data-document-status-signed-ids-value="<%= @documents.filter_map { |d| d[:consent]&.id.to_s if d[:consent]&.participant_portion_signed? }.sort.to_json %>"></div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-3">Now signing: <%= @current_document[:name] %></h2>
-      <div class="border rounded-lg overflow-hidden bg-white shadow-sm mb-4">
+      <h2 class="portal-heading text-lg mb-3">Now signing: <%= @current_document[:name] %></h2>
+      <div class="portal-card overflow-hidden mb-4">
         <docuseal-form
           id="docusealForm"
           data-src="<%= signing_url %>"
           style="height: 500px; overflow: auto;">
         </docuseal-form>
       </div>
-      <div class="text-center text-sm text-gray-500 mb-6">
-        <p>Having trouble? <a href="<%= signing_url %>" target="_blank" class="text-blue-600 hover:underline">Open in a new tab</a></p>
+      <div class="text-center text-sm portal-hint mb-6">
+        <p>Having trouble? <a href="<%= signing_url %>" target="_blank" class="portal-link">Open in a new tab</a></p>
       </div>
 
       <script src="https://<%= consent.docuseal_host %>/js/form.js"></script>
@@ -119,7 +133,7 @@
     <% if @physical_pending.present? && @current_document.nil? && !@documents_preparing %>
       <% @physical_pending.each do |doc| %>
         <div class="mb-6">
-          <h2 class="text-lg font-semibold text-gray-900 mb-3"><%= doc[:name] %> — print, sign & upload</h2>
+          <h2 class="portal-heading text-lg mb-3"><%= doc[:name] %> — print, sign & upload</h2>
           <%= render "shared/physical_document_upload",
               custom_document: doc[:custom_document],
               consent: doc[:consent],
@@ -134,20 +148,20 @@
          Nothing here is required, and until you add one nobody is asked to
          sign it — your parent/guardian included. -->
     <% if @optional_documents.present? %>
-      <div class="bg-white border border-gray-200 rounded-lg mt-6">
-        <div class="p-4 border-b border-gray-100">
-          <h2 class="font-semibold text-gray-900">Optional extras</h2>
-          <p class="text-sm text-gray-500 mt-0.5">
+      <div class="portal-card mt-6">
+        <div class="p-4 portal-inset-bottom">
+          <h2 class="portal-heading">Optional extras</h2>
+          <p class="portal-hint text-sm mt-0.5">
             Only for activities you want to take part in. Skip anything you're not doing — you can add it later from your dashboard.
           </p>
         </div>
-        <div class="divide-y divide-gray-100">
+        <div class="divide-y" style="border-color: var(--border);">
           <% @optional_documents.each do |doc| %>
             <% added = @participant_event.opted_into_custom_document?(doc) %>
             <div class="p-4 flex flex-wrap items-center justify-between gap-3">
               <div class="min-w-0">
-                <p class="font-medium text-gray-900"><%= doc.name %></p>
-                <p class="text-xs text-gray-500 mt-0.5">
+                <p class="portal-heading text-sm"><%= doc.name %></p>
+                <p class="portal-hint text-xs mt-0.5">
                   <% if added && doc.participant_signs? %>
                     Added — sign it in the list above.
                   <% elsif added %>
@@ -164,13 +178,13 @@
               <% if added %>
                 <%= button_to onboarding_withdraw_optional_document_path(custom_document_id: doc.id, event_id: current_event.id),
                     method: :delete, data: { turbo_confirm: "Remove \"#{doc.name}\"? You can add it back any time." },
-                    class: "text-sm text-gray-500 hover:text-gray-700 underline underline-offset-2 cursor-pointer shrink-0" do %>
+                    class: "portal-btn portal-btn-quiet text-sm shrink-0" do %>
                   Remove<span class="sr-only"> <%= doc.name %></span>
                 <% end %>
               <% else %>
                 <%= button_to onboarding_add_optional_document_path(custom_document_id: doc.id, event_id: current_event.id),
                     method: :post,
-                    class: "bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium py-1.5 px-4 rounded-lg transition-colors cursor-pointer shrink-0" do %>
+                    class: "portal-btn portal-btn-primary text-sm shrink-0" do %>
                   Add and sign<span class="sr-only"> <%= doc.name %></span>
                 <% end %>
               <% end %>
@@ -182,19 +196,19 @@
 
     <!-- Continue -->
     <div class="flex items-center justify-between mt-6">
-      <span class="text-sm text-gray-500">
+      <span class="portal-hint text-sm tabular-nums">
         <% unless @all_documents_signed %>
           <%= @documents.count { |d| d[:consent]&.participant_portion_signed? } %> of <%= @documents.size %> signed
         <% end %>
       </span>
       <% if @all_documents_signed %>
         <%= form_with url: onboarding_step_path(step: "documents", event_id: current_event.id), method: :patch, data: { turbo: false } do %>
-          <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-6 rounded-lg transition-colors cursor-pointer">
+          <button type="submit" class="portal-btn portal-btn-primary">
             Continue to Review
           </button>
         <% end %>
       <% else %>
-        <button disabled class="bg-gray-200 text-gray-400 font-medium py-2 px-6 rounded-lg cursor-not-allowed">
+        <button disabled class="portal-btn portal-btn-primary">
           Continue to Review
         </button>
       <% end %>

--- a/app/views/onboarding/emergency.html.erb
+++ b/app/views/onboarding/emergency.html.erb
@@ -1,43 +1,45 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Emergency Information</h1>
-  <p class="text-gray-600 mb-2">Please provide one emergency contact who can be reached during the event.</p>
-  <p class="text-sm text-gray-600 mb-6">Fields marked with <span class="text-red-500">*</span> are required.</p>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Emergency Information</h1>
+    <p class="portal-body mt-2">Please provide one emergency contact who can be reached during the event.</p>
+    <p class="portal-hint text-sm mt-2">Fields marked with <span class="portal-required" aria-hidden="true">*</span> are required.</p>
+  </header>
 
   <%= form_with url: onboarding_step_path(step: @step, event_id: current_event.id), method: :patch, local: true, data: { turbo: false, controller: "phone-input autosave", autosave_notify_only_value: "true", action: "input->autosave#input change->autosave#change" } do |f| %>
     <%= render "autosave_status" %>
-    <div class="space-y-8">
-      <section>
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Primary Emergency Contact</h2>
+    <div class="space-y-6">
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-4">Primary Emergency Contact</h2>
 
         <% primary_contact = @emergency_contacts.find { |c| c.priority == 1 } || @participant_event.emergency_contacts.build(priority: 1) %>
-        <div class="space-y-4 bg-gray-50 rounded-md p-4">
+        <div class="space-y-4">
           <%= f.fields_for :emergency_contacts, primary_contact, index: 0 do |ec| %>
             <%= ec.hidden_field :priority, value: 1 %>
             <%= ec.hidden_field :id if primary_contact.persisted? %>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <%= ec.label :name, label_text("Full Name", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-                <%= ec.text_field :name, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+                <%= ec.label :name, label_text("Full Name", required: true), class: "portal-label" %>
+                <%= ec.text_field :name, class: "portal-input", required: true %>
               </div>
 
               <div>
-                <%= ec.label :relationship, label_text("Relationship", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-                <%= ec.select :relationship, [["Select relationship", ""], "Parent", "Spouse/Partner", "Sibling", "Friend", "Colleague", "Other"], {}, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+                <%= ec.label :relationship, label_text("Relationship", required: true), class: "portal-label" %>
+                <%= ec.select :relationship, [["Select relationship", ""], "Parent", "Spouse/Partner", "Sibling", "Friend", "Colleague", "Other"], {}, class: "portal-select", required: true %>
               </div>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <%= ec.label :phone, label_text("Phone Number", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-                <%= ec.telephone_field :phone, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+                <%= ec.label :phone, label_text("Phone Number", required: true), class: "portal-label" %>
+                <%= ec.telephone_field :phone, class: "portal-input", required: true %>
               </div>
 
               <div>
-                <%= ec.label :email, "Email", class: "block text-sm font-medium text-gray-700 mb-1" %>
-                <%= ec.email_field :email, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+                <%= ec.label :email, "Email", class: "portal-label" %>
+                <%= ec.email_field :email, class: "portal-input" %>
               </div>
             </div>
           <% end %>

--- a/app/views/onboarding/guardian.html.erb
+++ b/app/views/onboarding/guardian.html.erb
@@ -1,52 +1,57 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Guardian Information</h1>
-  <p class="text-sm text-gray-600 mb-6">Fields marked with <span class="text-red-500">*</span> are required.</p>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Guardian Information</h1>
+    <p class="portal-hint text-sm mt-2">Fields marked with <span class="portal-required" aria-hidden="true">*</span> are required.</p>
+  </header>
 
-  <div class="bg-blue-50 border border-blue-200 rounded-md p-4 mb-6">
-    <p class="text-sm text-blue-800">
+  <div class="portal-note portal-note-info mb-6">
+    <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.852l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/>
+    </svg>
+    <p class="portal-body text-sm">
       This information is required for participants under 18 years of age. A guardian will need to provide consent for your participation.
     </p>
   </div>
 
   <%= form_with url: onboarding_step_path(step: @step, event_id: current_event.id), method: :patch, local: true, data: { turbo: false, controller: "phone-input autosave", autosave_url_value: onboarding_step_path(step: @step, event_id: current_event.id), action: "input->autosave#input change->autosave#change" } do |f| %>
     <%= render "autosave_status" %>
-    <div class="space-y-6">
+    <div class="portal-card p-5 sm:p-6 space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <%= f.label :guardian_first_name, label_text("Guardian First Name", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.text_field :guardian_first_name, value: @guardian.legal_first_name, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+          <%= f.label :guardian_first_name, label_text("Guardian First Name", required: true), class: "portal-label" %>
+          <%= f.text_field :guardian_first_name, value: @guardian.legal_first_name, class: "portal-input", required: true %>
         </div>
 
         <div>
-          <%= f.label :guardian_last_name, label_text("Guardian Last Name", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.text_field :guardian_last_name, value: @guardian.legal_last_name, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+          <%= f.label :guardian_last_name, label_text("Guardian Last Name", required: true), class: "portal-label" %>
+          <%= f.text_field :guardian_last_name, value: @guardian.legal_last_name, class: "portal-input", required: true %>
         </div>
       </div>
 
       <div>
-        <%= f.label :guardian_email, label_text("Guardian Email", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.email_field :guardian_email, value: @guardian.email, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
-        <p class="mt-1 text-sm text-gray-500">We'll send consent forms and important updates to this email</p>
+        <%= f.label :guardian_email, label_text("Guardian Email", required: true), class: "portal-label" %>
+        <%= f.email_field :guardian_email, value: @guardian.email, class: "portal-input", required: true %>
+        <p class="mt-1 portal-hint text-sm">We'll send consent forms and important updates to this email</p>
       </div>
 
       <div>
-        <%= f.label :guardian_phone, label_text("Guardian Phone Number", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.telephone_field :guardian_phone, value: @guardian.phone, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+        <%= f.label :guardian_phone, label_text("Guardian Phone Number", required: true), class: "portal-label" %>
+        <%= f.telephone_field :guardian_phone, value: @guardian.phone, class: "portal-input", required: true %>
       </div>
 
       <div>
-        <%= f.label :guardian_relationship, label_text("Relationship to Participant", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.label :guardian_relationship, label_text("Relationship to Participant", required: true), class: "portal-label" %>
         <% standard_relationships = ["Parent", "Legal Guardian", "Grandparent", "Aunt/Uncle", "Sibling (18+)", "Other"] %>
         <% selected_relationship = standard_relationships.include?(@existing_gpe&.relationship) ? @existing_gpe&.relationship : (@existing_gpe&.relationship.present? ? "Other" : nil) %>
-        <%= f.select :guardian_relationship, [["Select relationship", ""]] + standard_relationships, { selected: selected_relationship }, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true, data: { action: "change->guardian-form#toggleOtherDetails" } %>
+        <%= f.select :guardian_relationship, [["Select relationship", ""]] + standard_relationships, { selected: selected_relationship }, class: "portal-select", required: true, data: { action: "change->guardian-form#toggleOtherDetails" } %>
       </div>
 
       <div id="other-relationship-details" class="hidden">
-        <%= f.label :guardian_relationship_other, label_text("Please specify relationship", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.label :guardian_relationship_other, label_text("Please specify relationship", required: true), class: "portal-label" %>
         <% other_relationship_value = @existing_gpe&.relationship unless %w[Parent Legal\ Guardian Grandparent Aunt/Uncle Sibling\ (18+)].include?(@existing_gpe&.relationship) %>
-        <%= f.text_field :guardian_relationship_other, value: other_relationship_value, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "e.g., Family friend, Coach, etc." %>
+        <%= f.text_field :guardian_relationship_other, value: other_relationship_value, class: "portal-input", placeholder: "e.g., Family friend, Coach, etc." %>
       </div>
 
       <%= f.hidden_field :onboarding_step, value: "guardian" %>

--- a/app/views/onboarding/health.html.erb
+++ b/app/views/onboarding/health.html.erb
@@ -1,143 +1,145 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Health & Dietary Information</h1>
-  <p class="text-sm text-gray-600 mb-6">All fields are optional. Fill in what applies to you.</p>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Health & Dietary Information</h1>
+    <p class="portal-hint text-sm mt-2">All fields are optional. Fill in what applies to you.</p>
+  </header>
 
   <%= form_with url: onboarding_step_path(step: @step, event_id: current_event.id), method: :patch, local: true, data: { turbo: false, controller: "autosave", autosave_url_value: onboarding_step_path(step: @step, event_id: current_event.id), action: "input->autosave#input change->autosave#change" } do |f| %>
     <%= render "autosave_status" %>
-    <div class="space-y-8">
-      <section>
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Medical Information</h2>
+    <div class="space-y-6">
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-4">Medical Information</h2>
 
         <div class="space-y-4">
           <div>
-            <%= f.label :allergies, "Allergies", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :allergies, value: @medical&.allergies, rows: 2, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "List any allergies (medications, environmental, etc.)" %>
+            <%= f.label :allergies, "Allergies", class: "portal-label" %>
+            <%= f.text_area :allergies, value: @medical&.allergies, rows: 2, class: "portal-textarea", placeholder: "List any allergies (medications, environmental, etc.)" %>
           </div>
 
           <div>
-            <%= f.label :medical_conditions, "Medical Conditions", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :medical_conditions, value: @medical&.medical_conditions, rows: 2, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Any conditions we should be aware of" %>
+            <%= f.label :medical_conditions, "Medical Conditions", class: "portal-label" %>
+            <%= f.text_area :medical_conditions, value: @medical&.medical_conditions, rows: 2, class: "portal-textarea", placeholder: "Any conditions we should be aware of" %>
           </div>
 
           <div>
-            <%= f.label :medications, "Current Medications", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :medications, value: @medical&.medications, rows: 2, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "List any medications you take regularly" %>
+            <%= f.label :medications, "Current Medications", class: "portal-label" %>
+            <%= f.text_area :medications, value: @medical&.medications, rows: 2, class: "portal-textarea", placeholder: "List any medications you take regularly" %>
           </div>
 
           <div>
-            <%= f.label :has_anaphylaxis_risk, class: "flex items-center gap-2 cursor-pointer" do %>
-              <%= f.check_box :has_anaphylaxis_risk, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @medical&.has_anaphylaxis_risk }, "1", "0" %>
-              <span class="text-sm font-medium text-gray-700">I am at risk of anaphylaxis</span>
+            <%= f.label :has_anaphylaxis_risk, class: "portal-check-row" do %>
+              <%= f.check_box :has_anaphylaxis_risk, { class: "portal-check mt-0.5", checked: @medical&.has_anaphylaxis_risk }, "1", "0" %>
+              <span class="text-sm font-medium">I am at risk of anaphylaxis</span>
             <% end %>
           </div>
 
           <div>
-            <%= f.label :requires_refrigeration, class: "flex items-center gap-2 cursor-pointer" do %>
-              <%= f.check_box :requires_refrigeration, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @medical&.requires_refrigeration }, "1", "0" %>
-              <span class="text-sm font-medium text-gray-700">I need refrigeration for medications</span>
+            <%= f.label :requires_refrigeration, class: "portal-check-row" do %>
+              <%= f.check_box :requires_refrigeration, { class: "portal-check mt-0.5", checked: @medical&.requires_refrigeration }, "1", "0" %>
+              <span class="text-sm font-medium">I need refrigeration for medications</span>
             <% end %>
           </div>
         </div>
       </section>
 
-      <section>
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Dietary Requirements</h2>
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-4">Dietary Requirements</h2>
 
         <div class="space-y-4">
           <div>
-            <%= f.label :diet_type, "Diet Type", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.select :diet_type, [["No specific diet", ""], ["Vegetarian", "vegetarian"], ["Vegan", "vegan"], ["Halal", "halal"], ["Kosher", "kosher"], ["Other", "other"]], { selected: @dietary&.diet_type }, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+            <%= f.label :diet_type, "Diet Type", class: "portal-label" %>
+            <%= f.select :diet_type, [["No specific diet", ""], ["Vegetarian", "vegetarian"], ["Vegan", "vegan"], ["Halal", "halal"], ["Kosher", "kosher"], ["Other", "other"]], { selected: @dietary&.diet_type }, class: "portal-select" %>
           </div>
 
           <div>
-            <%= f.label :intolerances, "Food Intolerances", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :intolerances, value: @dietary&.intolerances, rows: 2, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "e.g., lactose, gluten, nuts" %>
+            <%= f.label :intolerances, "Food Intolerances", class: "portal-label" %>
+            <%= f.text_area :intolerances, value: @dietary&.intolerances, rows: 2, class: "portal-textarea", placeholder: "e.g., lactose, gluten, nuts" %>
           </div>
 
           <div>
-            <%= f.label :life_threatening_allergies, "Life-Threatening Food Allergies", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :life_threatening_allergies, value: @dietary&.life_threatening_allergies, rows: 2, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "List any severe food allergies" %>
-            <p class="mt-1 text-sm text-gray-500">This helps our catering team take extra precautions</p>
+            <%= f.label :life_threatening_allergies, "Life-Threatening Food Allergies", class: "portal-label" %>
+            <%= f.text_area :life_threatening_allergies, value: @dietary&.life_threatening_allergies, rows: 2, class: "portal-textarea", placeholder: "List any severe food allergies" %>
+            <p class="mt-1 portal-hint text-sm">This helps our catering team take extra precautions</p>
           </div>
         </div>
       </section>
 
-      <section>
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Learning & Cognitive Needs</h2>
-        <p class="text-sm text-gray-500 mb-4">This helps us provide appropriate support and accommodations during the event.</p>
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-1">Learning & Cognitive Needs</h2>
+        <p class="portal-hint text-sm mb-4">This helps us provide appropriate support and accommodations during the event.</p>
 
         <div class="space-y-4">
           <fieldset>
-            <legend class="text-sm font-medium text-gray-700 mb-2">Do any of these apply to you?</legend>
-            <div class="space-y-2">
-              <%= f.label :has_adhd, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :has_adhd, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.has_adhd }, "1", "0" %>
-                <span class="text-sm text-gray-700">ADHD</span>
+            <legend class="portal-label mb-1">Do any of these apply to you?</legend>
+            <div>
+              <%= f.label :has_adhd, class: "portal-check-row" do %>
+                <%= f.check_box :has_adhd, { class: "portal-check mt-0.5", checked: @accessibility&.has_adhd }, "1", "0" %>
+                <span class="text-sm">ADHD</span>
               <% end %>
 
-              <%= f.label :has_dyslexia, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :has_dyslexia, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.has_dyslexia }, "1", "0" %>
-                <span class="text-sm text-gray-700">Dyslexia</span>
+              <%= f.label :has_dyslexia, class: "portal-check-row" do %>
+                <%= f.check_box :has_dyslexia, { class: "portal-check mt-0.5", checked: @accessibility&.has_dyslexia }, "1", "0" %>
+                <span class="text-sm">Dyslexia</span>
               <% end %>
 
-              <%= f.label :has_autism, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :has_autism, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.has_autism }, "1", "0" %>
-                <span class="text-sm text-gray-700">Autism</span>
+              <%= f.label :has_autism, class: "portal-check-row" do %>
+                <%= f.check_box :has_autism, { class: "portal-check mt-0.5", checked: @accessibility&.has_autism }, "1", "0" %>
+                <span class="text-sm">Autism</span>
               <% end %>
             </div>
           </fieldset>
 
           <div>
-            <%= f.label :neurodivergent_notes, "Additional Notes", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :neurodivergent_notes, value: @accessibility&.neurodivergent_notes, rows: 3, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Any specific accommodations or support that would help you (e.g., quiet space access, written instructions, extra time)" %>
+            <%= f.label :neurodivergent_notes, "Additional Notes", class: "portal-label" %>
+            <%= f.text_area :neurodivergent_notes, value: @accessibility&.neurodivergent_notes, rows: 3, class: "portal-textarea", placeholder: "Any specific accommodations or support that would help you (e.g., quiet space access, written instructions, extra time)" %>
           </div>
         </div>
       </section>
 
-      <section>
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Accessibility Needs</h2>
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-4">Accessibility Needs</h2>
 
         <div class="space-y-4">
           <fieldset>
-            <legend class="text-sm font-medium text-gray-700 mb-2">Mobility Needs</legend>
-            <div class="space-y-2">
-              <%= f.label :uses_wheelchair, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :uses_wheelchair, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.uses_wheelchair }, "1", "0" %>
-                <span class="text-sm text-gray-700">Wheelchair accessible room/venue</span>
+            <legend class="portal-label mb-1">Mobility Needs</legend>
+            <div>
+              <%= f.label :uses_wheelchair, class: "portal-check-row" do %>
+                <%= f.check_box :uses_wheelchair, { class: "portal-check mt-0.5", checked: @accessibility&.uses_wheelchair }, "1", "0" %>
+                <span class="text-sm">Wheelchair accessible room/venue</span>
               <% end %>
 
-              <%= f.label :step_free_required, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :step_free_required, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.step_free_required }, "1", "0" %>
-                <span class="text-sm text-gray-700">Step-free access required</span>
+              <%= f.label :step_free_required, class: "portal-check-row" do %>
+                <%= f.check_box :step_free_required, { class: "portal-check mt-0.5", checked: @accessibility&.step_free_required }, "1", "0" %>
+                <span class="text-sm">Step-free access required</span>
               <% end %>
             </div>
           </fieldset>
 
           <fieldset>
-            <legend class="text-sm font-medium text-gray-700 mb-2">Sensory Needs</legend>
-            <div class="space-y-2">
-              <%= f.label :needs_captioning, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :needs_captioning, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.needs_captioning }, "1", "0" %>
-                <span class="text-sm text-gray-700">Captioning/hearing assistance</span>
+            <legend class="portal-label mb-1">Sensory Needs</legend>
+            <div>
+              <%= f.label :needs_captioning, class: "portal-check-row" do %>
+                <%= f.check_box :needs_captioning, { class: "portal-check mt-0.5", checked: @accessibility&.needs_captioning }, "1", "0" %>
+                <span class="text-sm">Captioning/hearing assistance</span>
               <% end %>
 
-              <%= f.label :needs_large_print, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :needs_large_print, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.needs_large_print }, "1", "0" %>
-                <span class="text-sm text-gray-700">Large print materials</span>
+              <%= f.label :needs_large_print, class: "portal-check-row" do %>
+                <%= f.check_box :needs_large_print, { class: "portal-check mt-0.5", checked: @accessibility&.needs_large_print }, "1", "0" %>
+                <span class="text-sm">Large print materials</span>
               <% end %>
 
-              <%= f.label :needs_sign_language, class: "flex items-center gap-2 cursor-pointer" do %>
-                <%= f.check_box :needs_sign_language, { class: "w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500", checked: @accessibility&.needs_sign_language }, "1", "0" %>
-                <span class="text-sm text-gray-700">Sign language interpreter needed</span>
+              <%= f.label :needs_sign_language, class: "portal-check-row" do %>
+                <%= f.check_box :needs_sign_language, { class: "portal-check mt-0.5", checked: @accessibility&.needs_sign_language }, "1", "0" %>
+                <span class="text-sm">Sign language interpreter needed</span>
               <% end %>
             </div>
           </fieldset>
 
           <div>
-            <%= f.label :other_needs, "Other Accessibility or Communication Needs", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_area :other_needs, value: @accessibility&.other_needs, rows: 3, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Please describe any additional needs" %>
+            <%= f.label :other_needs, "Other Accessibility or Communication Needs", class: "portal-label" %>
+            <%= f.text_area :other_needs, value: @accessibility&.other_needs, rows: 3, class: "portal-textarea", placeholder: "Please describe any additional needs" %>
           </div>
         </div>
       </section>

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -1,3 +1,3 @@
 <div class="w-full max-w-2xl mx-auto text-center py-12">
-  <p class="text-gray-600">Redirecting to your current step...</p>
+  <p class="portal-body">Redirecting to your current step...</p>
 </div>

--- a/app/views/onboarding/profile.html.erb
+++ b/app/views/onboarding/profile.html.erb
@@ -1,116 +1,121 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Profile Information</h1>
-  <p class="text-sm text-gray-600 mb-6">Fields marked with <span class="text-red-500">*</span> are required.</p>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Profile Information</h1>
+    <p class="portal-hint text-sm mt-2">Fields marked with <span class="portal-required" aria-hidden="true">*</span> are required.</p>
+  </header>
 
   <%= form_with model: @participant, url: onboarding_step_path(step: @step, event_id: current_event.id), scope: :participant, method: :patch, local: true, multipart: true, data: { turbo: false, controller: "phone-input autosave", autosave_url_value: onboarding_step_path(step: @step, event_id: current_event.id), action: "input->autosave#input change->autosave#change" } do |f| %>
     <%= render "autosave_status" %>
-    <div class="space-y-6">
+    <div class="portal-card p-5 sm:p-6 space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <%= f.label :legal_first_name, label_text("Legal First Name", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.text_field :legal_first_name, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+          <%= f.label :legal_first_name, label_text("Legal First Name", required: true), class: "portal-label" %>
+          <%= f.text_field :legal_first_name, class: "portal-input", required: true %>
         </div>
 
         <div>
-          <%= f.label :legal_last_name, label_text("Legal Last Name", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.text_field :legal_last_name, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+          <%= f.label :legal_last_name, label_text("Legal Last Name", required: true), class: "portal-label" %>
+          <%= f.text_field :legal_last_name, class: "portal-input", required: true %>
         </div>
       </div>
 
       <div>
-        <%= f.label :preferred_name, "Preferred Name", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.text_field :preferred_name, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
-        <p class="mt-1 text-sm text-gray-500">Leave blank if same as legal first name</p>
+        <%= f.label :preferred_name, "Preferred Name", class: "portal-label" %>
+        <%= f.text_field :preferred_name, class: "portal-input" %>
+        <p class="mt-1 portal-hint text-sm">Leave blank if same as legal first name</p>
       </div>
 
       <div>
-        <%= f.label :date_of_birth, label_text("Date of Birth", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.date_field :date_of_birth, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+        <%= f.label :date_of_birth, label_text("Date of Birth", required: true), class: "portal-label" %>
+        <%= f.date_field :date_of_birth, class: "portal-input", required: true %>
       </div>
 
       <div>
-        <%= f.label :headshot, label_text("Headshot Photo", required: !@participant.headshot.attached?), class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.label :headshot, label_text("Headshot Photo", required: !@participant.headshot.attached?), class: "portal-label" %>
         <% if @participant.headshot.attached? && @participant.headshot.blob.persisted? %>
           <div class="mb-3 flex items-center gap-4">
-            <%= image_tag @participant.headshot, class: "w-24 h-24 rounded-full object-cover border border-gray-300" %>
-            <span class="text-sm text-gray-600">Current headshot</span>
+            <%= image_tag @participant.headshot, class: "w-24 h-24 rounded-full object-cover", style: "border: 1px solid var(--border-strong);" %>
+            <span class="portal-hint text-sm">Current headshot</span>
           </div>
         <% end %>
-        <%= f.file_field :headshot, accept: "image/jpeg,image/png,image/webp", class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100", required: !@participant.headshot.attached? %>
-        <div class="mt-2 p-3 bg-blue-50 border border-blue-200 rounded-md">
-          <p class="text-sm text-blue-800">
-            <strong>Why do we need this?</strong> Your headshot is required for safeguarding purposes to help event staff identify you. It is stored securely and only accessible to authorized event staff.
+        <%= f.file_field :headshot, accept: "image/jpeg,image/png,image/webp", class: "portal-file", required: !@participant.headshot.attached? %>
+        <div class="portal-note portal-note-info mt-2">
+          <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.852l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/>
+          </svg>
+          <p class="portal-body text-sm">
+            <strong class="portal-heading">Why do we need this?</strong> Your headshot is required for safeguarding purposes to help event staff identify you. It is stored securely and only accessible to authorized event staff.
           </p>
         </div>
-        <p class="mt-1 text-sm text-gray-500">Upload a clear photo of your face. Accepted formats: JPEG, PNG, WebP. Maximum size: 10MB.</p>
+        <p class="mt-1 portal-hint text-sm">Upload a clear photo of your face. Accepted formats: JPEG, PNG, WebP. Maximum size: 10MB.</p>
       </div>
 
       <div>
-        <%= f.label :email, label_text("Email", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.email_field :email, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+        <%= f.label :email, label_text("Email", required: true), class: "portal-label" %>
+        <%= f.email_field :email, class: "portal-input", required: true %>
       </div>
 
       <div>
-        <%= f.label :phone, label_text("Phone Number", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.telephone_field :phone, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true %>
+        <%= f.label :phone, label_text("Phone Number", required: true), class: "portal-label" %>
+        <%= f.telephone_field :phone, class: "portal-input", required: true %>
       </div>
 
       <div>
-        <%= f.label :pronouns, "Pronouns", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.text_field :pronouns, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "e.g., she/her, he/him, they/them" %>
+        <%= f.label :pronouns, "Pronouns", class: "portal-label" %>
+        <%= f.text_field :pronouns, class: "portal-input", placeholder: "e.g., she/her, he/him, they/them" %>
       </div>
 
       <div data-controller="address-autocomplete" data-address-autocomplete-fill-components-value="true" class="space-y-4">
         <div>
-          <%= f.label :address_line_1, label_text("Address Line 1", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.text_field :address_line_1, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true, data: { address_autocomplete_target: "input" } %>
+          <%= f.label :address_line_1, label_text("Address Line 1", required: true), class: "portal-label" %>
+          <%= f.text_field :address_line_1, class: "portal-input", required: true, data: { address_autocomplete_target: "input" } %>
         </div>
 
         <div>
-          <%= f.label :address_line_2, "Address Line 2", class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <%= f.text_field :address_line_2, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
-          <p class="mt-1 text-sm text-gray-500">Apartment, suite, unit, etc. (optional)</p>
+          <%= f.label :address_line_2, "Address Line 2", class: "portal-label" %>
+          <%= f.text_field :address_line_2, class: "portal-input" %>
+          <p class="mt-1 portal-hint text-sm">Apartment, suite, unit, etc. (optional)</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <%= f.label :city, label_text("City", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_field :city, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true, data: { address_autocomplete_target: "city" } %>
+            <%= f.label :city, label_text("City", required: true), class: "portal-label" %>
+            <%= f.text_field :city, class: "portal-input", required: true, data: { address_autocomplete_target: "city" } %>
           </div>
 
           <div>
-            <%= f.label :state, label_text("State / Province / Region", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_field :state, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true, data: { address_autocomplete_target: "state" } %>
+            <%= f.label :state, label_text("State / Province / Region", required: true), class: "portal-label" %>
+            <%= f.text_field :state, class: "portal-input", required: true, data: { address_autocomplete_target: "state" } %>
           </div>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <%= f.label :postal_code, label_text("Postal / ZIP Code", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_field :postal_code, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true, data: { address_autocomplete_target: "postalCode" } %>
+            <%= f.label :postal_code, label_text("Postal / ZIP Code", required: true), class: "portal-label" %>
+            <%= f.text_field :postal_code, class: "portal-input", required: true, data: { address_autocomplete_target: "postalCode" } %>
           </div>
 
           <div>
-            <%= f.label :country_of_residence, label_text("Country", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.select :country_of_residence, country_options_for_select(@participant.country_of_residence), {}, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", required: true, data: { address_autocomplete_target: "country" } %>
+            <%= f.label :country_of_residence, label_text("Country", required: true), class: "portal-label" %>
+            <%= f.select :country_of_residence, country_options_for_select(@participant.country_of_residence), {}, class: "portal-select", required: true, data: { address_autocomplete_target: "country" } %>
           </div>
         </div>
       </div>
 
       <div>
-        <%= f.label :tshirt_size, label_text("T-Shirt Size", required: true), class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.select :tshirt_size, [["Select size", ""], "XS", "S", "M", "L", "XL", "XXL", "XXXL"], {}, required: true, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= f.label :tshirt_size, label_text("T-Shirt Size", required: true), class: "portal-label" %>
+        <%= f.select :tshirt_size, [["Select size", ""], "XS", "S", "M", "L", "XL", "XXL", "XXXL"], {}, required: true, class: "portal-select" %>
       </div>
 
-      <div class="border-t pt-6 mt-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-4">About You</h2>
-        <p class="text-sm text-gray-600 mb-4">This helps organizers understand how you prefer to engage at events. Both fields are optional.</p>
+      <div class="portal-inset pt-6">
+        <h2 class="portal-heading text-base mb-1">About You</h2>
+        <p class="portal-hint text-sm mb-4">This helps organizers understand how you prefer to engage at events. Both fields are optional.</p>
 
         <div class="space-y-4">
           <div>
-            <%= f.label :engagement_preference, "How do you prefer to engage at events?", class: "block text-sm font-medium text-gray-700 mb-2" %>
+            <%= f.label :engagement_preference, "How do you prefer to engage at events?", class: "portal-label" %>
             <%= f.select :engagement_preference, [
               ["Select your preference (optional)", ""],
               ["Very social – I love group activities and meeting new people!", "very_social"],
@@ -118,15 +123,15 @@
               ["Balanced – A mix of social time and focused work", "balanced"],
               ["Mostly focused – I prefer to work on projects with occasional socializing", "mostly_focused"],
               ["Very focused – I'm happiest heads-down on my projects", "very_focused"]
-            ], {}, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+            ], {}, class: "portal-select" %>
           </div>
 
           <div>
-            <%= f.label :engagement_notes, "Anything else you'd like us to know about how you engage?", class: "block text-sm font-medium text-gray-700 mb-2" %>
-            <%= f.text_area :engagement_notes, rows: 3, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "e.g., I need quiet time in the mornings, I'm shy at first but warm up quickly..." %>
+            <%= f.label :engagement_notes, "Anything else you'd like us to know about how you engage?", class: "portal-label" %>
+            <%= f.text_area :engagement_notes, rows: 3, class: "portal-textarea", placeholder: "e.g., I need quiet time in the mornings, I'm shy at first but warm up quickly..." %>
           </div>
 
-          <p class="text-sm text-gray-500">There's no right answer – this helps us make sure everyone has a great experience.</p>
+          <p class="portal-hint text-sm">There's no right answer – this helps us make sure everyone has a great experience.</p>
         </div>
       </div>
 

--- a/app/views/onboarding/review.html.erb
+++ b/app/views/onboarding/review.html.erb
@@ -1,58 +1,59 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-6">Review Your Information</h1>
-
-  <p class="text-gray-600 mb-8">Please review your information below before submitting. Click any section to make changes.</p>
+  <header class="mb-8">
+    <h1 class="portal-title text-2xl">Review Your Information</h1>
+    <p class="portal-body mt-2">Please review your information below before submitting. Click any section to make changes.</p>
+  </header>
 
   <div class="space-y-6">
-    <section class="border rounded-lg p-4">
+    <section class="portal-card p-5 sm:p-6">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-lg font-semibold">Profile</h2>
-        <%= link_to "Edit", onboarding_step_path(step: "profile", event_id: current_event.id), class: "text-blue-600 hover:underline text-sm" %>
+        <h2 class="portal-heading text-lg">Profile</h2>
+        <%= link_to "Edit", onboarding_step_path(step: "profile", event_id: current_event.id), class: "portal-btn portal-btn-quiet text-sm" %>
       </div>
       <% if @participant&.headshot&.attached? && @participant.headshot.blob.persisted? %>
         <div class="mb-4">
-          <%= image_tag @participant.headshot, class: "w-20 h-20 rounded-full object-cover border border-gray-300" %>
+          <%= image_tag @participant.headshot, class: "w-20 h-20 rounded-full object-cover", style: "border: 1px solid var(--border-strong);" %>
         </div>
       <% end %>
       <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <div>
-          <dt class="text-gray-500">Legal Name</dt>
-          <dd><%= @participant&.full_name.presence || "—" %></dd>
+          <dt class="portal-hint">Legal Name</dt>
+          <dd class="portal-body"><%= @participant&.full_name.presence || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Preferred Name</dt>
-          <dd><%= @participant&.preferred_name.presence || "—" %></dd>
+          <dt class="portal-hint">Preferred Name</dt>
+          <dd class="portal-body"><%= @participant&.preferred_name.presence || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Date of Birth</dt>
-          <dd><%= @participant&.date_of_birth&.strftime("%B %d, %Y") || "—" %></dd>
+          <dt class="portal-hint">Date of Birth</dt>
+          <dd class="portal-body"><%= @participant&.date_of_birth&.strftime("%B %d, %Y") || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Email</dt>
-          <dd><%= @participant&.email.presence || "—" %></dd>
+          <dt class="portal-hint">Email</dt>
+          <dd class="portal-body"><%= @participant&.email.presence || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Phone</dt>
-          <dd><%= @participant&.phone.presence || "—" %></dd>
+          <dt class="portal-hint">Phone</dt>
+          <dd class="portal-body"><%= @participant&.phone.presence || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Pronouns</dt>
-          <dd><%= @participant&.pronouns.presence || "—" %></dd>
+          <dt class="portal-hint">Pronouns</dt>
+          <dd class="portal-body"><%= @participant&.pronouns.presence || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Location</dt>
-          <dd><%= [@participant&.city, @participant&.country_of_residence].compact.join(", ").presence || "—" %></dd>
+          <dt class="portal-hint">Location</dt>
+          <dd class="portal-body"><%= [@participant&.city, @participant&.country_of_residence].compact.join(", ").presence || "—" %></dd>
         </div>
       </dl>
     </section>
 
     <% if current_event.travel_enabled? %>
-    <section class="border rounded-lg p-4">
+    <section class="portal-card p-5 sm:p-6">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-lg font-semibold">Travel</h2>
-        <%= link_to "Edit", onboarding_step_path(step: "travel", event_id: current_event.id), class: "text-blue-600 hover:underline text-sm" %>
+        <h2 class="portal-heading text-lg">Travel</h2>
+        <%= link_to "Edit", onboarding_step_path(step: "travel", event_id: current_event.id), class: "portal-btn portal-btn-quiet text-sm" %>
       </div>
       <div class="space-y-4">
         <% if current_event.visa_options_enabled? %>
@@ -60,21 +61,21 @@
         <div class="mb-4">
           <dl class="text-sm">
             <div>
-              <dt class="text-gray-500">Visa Status</dt>
+              <dt class="portal-hint mb-1">Visa Status</dt>
               <dd>
                 <% case @travel_inbound&.visa_status %>
                 <% when "not_required" %>
-                  <span class="text-green-700">No visa required</span>
+                  <span class="portal-badge portal-badge-done">No visa required</span>
                 <% when "not_applied" %>
-                  <span class="text-yellow-700">Visa required - not yet applied</span>
+                  <span class="portal-badge portal-badge-pending">Visa required - not yet applied</span>
                 <% when "applied" %>
-                  <span class="text-blue-700">Visa application pending</span>
+                  <span class="portal-badge portal-badge-waiting">Visa application pending</span>
                 <% when "approved" %>
-                  <span class="text-green-700">Visa approved</span>
+                  <span class="portal-badge portal-badge-done">Visa approved</span>
                 <% when "denied" %>
-                  <span class="text-red-700">Visa denied</span>
+                  <span class="portal-badge portal-badge-pending">Visa denied</span>
                 <% else %>
-                  <span>—</span>
+                  <span class="portal-body">—</span>
                 <% end %>
               </dd>
             </div>
@@ -84,143 +85,143 @@
 
         <!-- Inbound -->
         <div>
-          <h3 class="text-sm font-medium text-gray-700 mb-2">Arrival (Getting to <%= current_event.location_city || "the event" %>)</h3>
+          <h3 class="portal-heading text-sm mb-2">Arrival (Getting to <%= current_event.location_city || "the event" %>)</h3>
           <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
             <div>
-              <dt class="text-gray-500">Mode</dt>
-              <dd><%= @travel_inbound&.mode&.titleize || "—" %></dd>
+              <dt class="portal-hint">Mode</dt>
+              <dd class="portal-body"><%= @travel_inbound&.mode&.titleize || "—" %></dd>
             </div>
             <% if @travel_inbound&.plane? %>
               <% @travel_inbound.travel_legs.each_with_index do |leg, i| %>
-                <div class="md:col-span-2 <%= 'border-t pt-2 mt-2' if i > 0 %>">
-                  <dt class="text-gray-500">Flight <%= i + 1 %></dt>
-                  <dd>
-                    <span class="font-medium"><%= leg.flight_code.presence || "—" %></span>
+                <div class="md:col-span-2 <%= 'portal-inset pt-2 mt-2' if i > 0 %>">
+                  <dt class="portal-hint">Flight <%= i + 1 %></dt>
+                  <dd class="portal-body">
+                    <span class="portal-heading"><%= leg.flight_code.presence || "—" %></span>
                     <%= "#{leg.departure_airport} → #{leg.arrival_airport}" if leg.departure_airport.present? || leg.arrival_airport.present? %>
                   </dd>
                 </div>
                 <div>
-                  <dt class="text-gray-500">Departure</dt>
-                  <dd><%= leg.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                  <dt class="portal-hint">Departure</dt>
+                  <dd class="portal-body"><%= leg.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
                 </div>
                 <div>
-                  <dt class="text-gray-500">Arrival</dt>
-                  <dd><%= leg.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                  <dt class="portal-hint">Arrival</dt>
+                  <dd class="portal-body"><%= leg.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
                 </div>
               <% end %>
               <% if @travel_inbound.is_unaccompanied_minor %>
                 <div class="md:col-span-2">
-                  <dd class="text-yellow-700 font-medium">⚠️ Travelling as unaccompanied minor</dd>
-                  <dd class="text-gray-500 text-xs mt-0.5">We'll review your UM booking proof and reach out with pickup/dropoff information within 2 weeks of the event.</dd>
+                  <dd class="font-medium" style="color: var(--warning-strong);">⚠️ Travelling as unaccompanied minor</dd>
+                  <dd class="portal-hint text-xs mt-0.5">We'll review your UM booking proof and reach out with pickup/dropoff information within 2 weeks of the event.</dd>
                 </div>
               <% end %>
             <% elsif @travel_inbound&.train? %>
               <div>
-                <dt class="text-gray-500">Route</dt>
-                <dd><%= [@travel_inbound.train_departure_station, @travel_inbound.train_arrival_station].compact.join(" → ").presence || "—" %></dd>
+                <dt class="portal-hint">Route</dt>
+                <dd class="portal-body"><%= [@travel_inbound.train_departure_station, @travel_inbound.train_arrival_station].compact.join(" → ").presence || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Arrival Time</dt>
-                <dd><%= @travel_inbound.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Arrival Time</dt>
+                <dd class="portal-body"><%= @travel_inbound.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
             <% elsif @travel_inbound&.bus? %>
               <div>
-                <dt class="text-gray-500">Route</dt>
-                <dd><%= [@travel_inbound.bus_departure_location, @travel_inbound.bus_arrival_location].compact.join(" → ").presence || "—" %></dd>
+                <dt class="portal-hint">Route</dt>
+                <dd class="portal-body"><%= [@travel_inbound.bus_departure_location, @travel_inbound.bus_arrival_location].compact.join(" → ").presence || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Departure</dt>
-                <dd><%= @travel_inbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Departure</dt>
+                <dd class="portal-body"><%= @travel_inbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Arrival</dt>
-                <dd><%= @travel_inbound.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Arrival</dt>
+                <dd class="portal-body"><%= @travel_inbound.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
             <% elsif @travel_inbound&.car? %>
               <div class="md:col-span-2">
-                <dt class="text-gray-500">Travelling From</dt>
-                <dd><%= @travel_inbound.origin_address.presence || "—" %></dd>
+                <dt class="portal-hint">Travelling From</dt>
+                <dd class="portal-body"><%= @travel_inbound.origin_address.presence || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Expected Arrival</dt>
-                <dd><%= @travel_inbound.expected_arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Expected Arrival</dt>
+                <dd class="portal-body"><%= @travel_inbound.expected_arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
             <% elsif @travel_inbound&.other? %>
               <div class="md:col-span-2">
-                <dt class="text-gray-500">Details</dt>
-                <dd class="whitespace-pre-wrap"><%= @travel_inbound.other_details.presence || "—" %></dd>
+                <dt class="portal-hint">Details</dt>
+                <dd class="portal-body whitespace-pre-wrap"><%= @travel_inbound.other_details.presence || "—" %></dd>
               </div>
             <% end %>
           </dl>
         </div>
 
         <!-- Outbound -->
-        <div class="border-t pt-4">
-          <h3 class="text-sm font-medium text-gray-700 mb-2">Departure (Leaving <%= current_event.location_city || "the event" %>)</h3>
+        <div class="portal-inset pt-4">
+          <h3 class="portal-heading text-sm mb-2">Departure (Leaving <%= current_event.location_city || "the event" %>)</h3>
           <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
             <div>
-              <dt class="text-gray-500">Mode</dt>
-              <dd><%= @travel_outbound&.mode&.titleize || "—" %></dd>
+              <dt class="portal-hint">Mode</dt>
+              <dd class="portal-body"><%= @travel_outbound&.mode&.titleize || "—" %></dd>
             </div>
             <% if @travel_outbound&.plane? %>
               <% @travel_outbound.travel_legs.each_with_index do |leg, i| %>
-                <div class="md:col-span-2 <%= 'border-t pt-2 mt-2' if i > 0 %>">
-                  <dt class="text-gray-500">Flight <%= i + 1 %></dt>
-                  <dd>
-                    <span class="font-medium"><%= leg.flight_code.presence || "—" %></span>
+                <div class="md:col-span-2 <%= 'portal-inset pt-2 mt-2' if i > 0 %>">
+                  <dt class="portal-hint">Flight <%= i + 1 %></dt>
+                  <dd class="portal-body">
+                    <span class="portal-heading"><%= leg.flight_code.presence || "—" %></span>
                     <%= "#{leg.departure_airport} → #{leg.arrival_airport}" if leg.departure_airport.present? || leg.arrival_airport.present? %>
                   </dd>
                 </div>
                 <div>
-                  <dt class="text-gray-500">Departure</dt>
-                  <dd><%= leg.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                  <dt class="portal-hint">Departure</dt>
+                  <dd class="portal-body"><%= leg.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
                 </div>
                 <div>
-                  <dt class="text-gray-500">Arrival</dt>
-                  <dd><%= leg.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                  <dt class="portal-hint">Arrival</dt>
+                  <dd class="portal-body"><%= leg.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
                 </div>
               <% end %>
               <% if @travel_outbound.is_unaccompanied_minor %>
                 <div class="md:col-span-2">
-                  <dd class="text-yellow-700 font-medium">⚠️ Travelling as unaccompanied minor</dd>
-                  <dd class="text-gray-500 text-xs mt-0.5">We'll review your UM booking proof and reach out with pickup/dropoff information within 2 weeks of the event.</dd>
+                  <dd class="font-medium" style="color: var(--warning-strong);">⚠️ Travelling as unaccompanied minor</dd>
+                  <dd class="portal-hint text-xs mt-0.5">We'll review your UM booking proof and reach out with pickup/dropoff information within 2 weeks of the event.</dd>
                 </div>
               <% end %>
             <% elsif @travel_outbound&.train? %>
               <div>
-                <dt class="text-gray-500">Route</dt>
-                <dd><%= [@travel_outbound.train_departure_station, @travel_outbound.train_arrival_station].compact.join(" → ").presence || "—" %></dd>
+                <dt class="portal-hint">Route</dt>
+                <dd class="portal-body"><%= [@travel_outbound.train_departure_station, @travel_outbound.train_arrival_station].compact.join(" → ").presence || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Departure Time</dt>
-                <dd><%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Departure Time</dt>
+                <dd class="portal-body"><%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
             <% elsif @travel_outbound&.bus? %>
               <div>
-                <dt class="text-gray-500">Route</dt>
-                <dd><%= [@travel_outbound.bus_departure_location, @travel_outbound.bus_arrival_location].compact.join(" → ").presence || "—" %></dd>
+                <dt class="portal-hint">Route</dt>
+                <dd class="portal-body"><%= [@travel_outbound.bus_departure_location, @travel_outbound.bus_arrival_location].compact.join(" → ").presence || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Departure</dt>
-                <dd><%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Departure</dt>
+                <dd class="portal-body"><%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Arrival</dt>
-                <dd><%= @travel_outbound.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Arrival</dt>
+                <dd class="portal-body"><%= @travel_outbound.arrival_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
             <% elsif @travel_outbound&.car? %>
               <div class="md:col-span-2">
-                <dt class="text-gray-500">Travelling To</dt>
-                <dd><%= @travel_outbound.origin_address.presence || "—" %></dd>
+                <dt class="portal-hint">Travelling To</dt>
+                <dd class="portal-body"><%= @travel_outbound.origin_address.presence || "—" %></dd>
               </div>
               <div>
-                <dt class="text-gray-500">Departure Time</dt>
-                <dd><%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
+                <dt class="portal-hint">Departure Time</dt>
+                <dd class="portal-body"><%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") || "—" %></dd>
               </div>
             <% elsif @travel_outbound&.other? %>
               <div class="md:col-span-2">
-                <dt class="text-gray-500">Details</dt>
-                <dd class="whitespace-pre-wrap"><%= @travel_outbound.other_details.presence || "—" %></dd>
+                <dt class="portal-hint">Details</dt>
+                <dd class="portal-body whitespace-pre-wrap"><%= @travel_outbound.other_details.presence || "—" %></dd>
               </div>
             <% end %>
           </dl>
@@ -229,60 +230,60 @@
     </section>
     <% end %>
 
-    <section class="border rounded-lg p-4">
+    <section class="portal-card p-5 sm:p-6">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-lg font-semibold">Accommodation</h2>
-        <%= link_to "Edit", onboarding_step_path(step: "accommodation", event_id: current_event.id), class: "text-blue-600 hover:underline text-sm" %>
+        <h2 class="portal-heading text-lg">Accommodation</h2>
+        <%= link_to "Edit", onboarding_step_path(step: "accommodation", event_id: current_event.id), class: "portal-btn portal-btn-quiet text-sm" %>
       </div>
       <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <div>
-          <dt class="text-gray-500">Gender Identity</dt>
-          <dd><%= @accommodation&.gender_identity&.titleize || "—" %></dd>
+          <dt class="portal-hint">Gender Identity</dt>
+          <dd class="portal-body"><%= @accommodation&.gender_identity&.titleize || "—" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Preferred Roommate Genders</dt>
-          <dd><%= @accommodation&.preferred_roommate_genders&.map(&:titleize)&.join(", ").presence || "—" %></dd>
+          <dt class="portal-hint">Preferred Roommate Genders</dt>
+          <dd class="portal-body"><%= @accommodation&.preferred_roommate_genders&.map(&:titleize)&.join(", ").presence || "—" %></dd>
         </div>
         <div class="md:col-span-2">
-          <dt class="text-gray-500">Roommate Preferences</dt>
-          <dd><%= @accommodation&.roommate_preferences.presence || "—" %></dd>
+          <dt class="portal-hint">Roommate Preferences</dt>
+          <dd class="portal-body"><%= @accommodation&.roommate_preferences.presence || "—" %></dd>
         </div>
       </dl>
     </section>
 
-    <section class="border rounded-lg p-4">
+    <section class="portal-card p-5 sm:p-6">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-lg font-semibold">Health & Dietary</h2>
-        <%= link_to "Edit", onboarding_step_path(step: "health", event_id: current_event.id), class: "text-blue-600 hover:underline text-sm" %>
+        <h2 class="portal-heading text-lg">Health & Dietary</h2>
+        <%= link_to "Edit", onboarding_step_path(step: "health", event_id: current_event.id), class: "portal-btn portal-btn-quiet text-sm" %>
       </div>
       <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <div>
-          <dt class="text-gray-500">Allergies</dt>
-          <dd><%= @medical&.allergies.presence || "None" %></dd>
+          <dt class="portal-hint">Allergies</dt>
+          <dd class="portal-body"><%= @medical&.allergies.presence || "None" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Medical Conditions</dt>
-          <dd><%= @medical&.medical_conditions.presence || "None" %></dd>
+          <dt class="portal-hint">Medical Conditions</dt>
+          <dd class="portal-body"><%= @medical&.medical_conditions.presence || "None" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Diet Type</dt>
-          <dd><%= @dietary&.diet_type&.titleize || "No specific diet" %></dd>
+          <dt class="portal-hint">Diet Type</dt>
+          <dd class="portal-body"><%= @dietary&.diet_type&.titleize || "No specific diet" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Food Intolerances</dt>
-          <dd><%= @dietary&.intolerances.presence || "None" %></dd>
+          <dt class="portal-hint">Food Intolerances</dt>
+          <dd class="portal-body"><%= @dietary&.intolerances.presence || "None" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Anaphylaxis Risk</dt>
-          <dd><%= @medical&.has_anaphylaxis_risk ? "Yes" : "No" %></dd>
+          <dt class="portal-hint">Anaphylaxis Risk</dt>
+          <dd class="portal-body"><%= @medical&.has_anaphylaxis_risk ? "Yes" : "No" %></dd>
         </div>
         <div>
-          <dt class="text-gray-500">Refrigeration Needed</dt>
-          <dd><%= @medical&.requires_refrigeration ? "Yes" : "No" %></dd>
+          <dt class="portal-hint">Refrigeration Needed</dt>
+          <dd class="portal-body"><%= @medical&.requires_refrigeration ? "Yes" : "No" %></dd>
         </div>
         <div class="md:col-span-2">
-          <dt class="text-gray-500">Learning & Cognitive Needs</dt>
-          <dd>
+          <dt class="portal-hint">Learning & Cognitive Needs</dt>
+          <dd class="portal-body">
             <% needs = [] %>
             <% needs << "ADHD" if @accessibility&.has_adhd %>
             <% needs << "Dyslexia" if @accessibility&.has_dyslexia %>
@@ -291,8 +292,8 @@
           </dd>
         </div>
         <div class="md:col-span-2">
-          <dt class="text-gray-500">Accessibility Needs</dt>
-          <dd>
+          <dt class="portal-hint">Accessibility Needs</dt>
+          <dd class="portal-body">
             <% accessibility = [] %>
             <% accessibility << "Wheelchair accessible" if @accessibility&.uses_wheelchair %>
             <% accessibility << "Step-free access" if @accessibility&.step_free_required %>
@@ -306,28 +307,28 @@
     </section>
 
     <% if @guardians&.any? %>
-      <section class="border rounded-lg p-4">
+      <section class="portal-card p-5 sm:p-6">
         <div class="flex justify-between items-center mb-4">
-          <h2 class="text-lg font-semibold">Guardian</h2>
-          <%= link_to "Edit", onboarding_step_path(step: "guardian", event_id: current_event.id), class: "text-blue-600 hover:underline text-sm" %>
+          <h2 class="portal-heading text-lg">Guardian</h2>
+          <%= link_to "Edit", onboarding_step_path(step: "guardian", event_id: current_event.id), class: "portal-btn portal-btn-quiet text-sm" %>
         </div>
         <% @guardians.each do |gpe| %>
           <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
             <div>
-              <dt class="text-gray-500">Name</dt>
-              <dd><%= gpe.guardian&.full_name || "—" %></dd>
+              <dt class="portal-hint">Name</dt>
+              <dd class="portal-body"><%= gpe.guardian&.full_name || "—" %></dd>
             </div>
             <div>
-              <dt class="text-gray-500">Relationship</dt>
-              <dd><%= gpe.relationship.presence || "—" %></dd>
+              <dt class="portal-hint">Relationship</dt>
+              <dd class="portal-body"><%= gpe.relationship.presence || "—" %></dd>
             </div>
             <div>
-              <dt class="text-gray-500">Email</dt>
-              <dd><%= gpe.guardian&.email.presence || "—" %></dd>
+              <dt class="portal-hint">Email</dt>
+              <dd class="portal-body"><%= gpe.guardian&.email.presence || "—" %></dd>
             </div>
             <div>
-              <dt class="text-gray-500">Phone</dt>
-              <dd><%= gpe.guardian&.phone.presence || "—" %></dd>
+              <dt class="portal-hint">Phone</dt>
+              <dd class="portal-body"><%= gpe.guardian&.phone.presence || "—" %></dd>
             </div>
           </dl>
         <% end %>
@@ -335,28 +336,28 @@
     <% end %>
 
     <% if @emergency_contacts&.any? %>
-      <section class="border rounded-lg p-4">
+      <section class="portal-card p-5 sm:p-6">
         <div class="flex justify-between items-center mb-4">
-          <h2 class="text-lg font-semibold">Emergency Contact</h2>
-          <%= link_to "Edit", onboarding_step_path(step: "emergency", event_id: current_event.id), class: "text-blue-600 hover:underline text-sm" %>
+          <h2 class="portal-heading text-lg">Emergency Contact</h2>
+          <%= link_to "Edit", onboarding_step_path(step: "emergency", event_id: current_event.id), class: "portal-btn portal-btn-quiet text-sm" %>
         </div>
         <% @emergency_contacts.each do |contact| %>
           <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-sm">
             <div>
-              <dt class="text-gray-500">Name</dt>
-              <dd><%= contact.name.presence || "—" %></dd>
+              <dt class="portal-hint">Name</dt>
+              <dd class="portal-body"><%= contact.name.presence || "—" %></dd>
             </div>
             <div>
-              <dt class="text-gray-500">Relationship</dt>
-              <dd><%= contact.relationship.presence || "—" %></dd>
+              <dt class="portal-hint">Relationship</dt>
+              <dd class="portal-body"><%= contact.relationship.presence || "—" %></dd>
             </div>
             <div>
-              <dt class="text-gray-500">Phone</dt>
-              <dd><%= contact.phone.presence || "—" %></dd>
+              <dt class="portal-hint">Phone</dt>
+              <dd class="portal-body"><%= contact.phone.presence || "—" %></dd>
             </div>
             <div>
-              <dt class="text-gray-500">Email</dt>
-              <dd><%= contact.email.presence || "—" %></dd>
+              <dt class="portal-hint">Email</dt>
+              <dd class="portal-body"><%= contact.email.presence || "—" %></dd>
             </div>
           </dl>
         <% end %>
@@ -365,38 +366,38 @@
   </div>
 
   <%= form_with url: complete_onboarding_path(event_id: current_event.id), method: :post, local: true, data: { turbo: false } do |f| %>
-    <div class="mt-8 pt-6 border-t">
+    <div class="mt-8 pt-6 portal-inset">
       <!-- Code of Conduct Section -->
       <section class="mb-8">
-        <h2 class="text-lg font-semibold mb-4">Code of Conduct &amp; Safeguarding Agreement</h2>
-        <p class="text-sm text-gray-600 mb-4">
+        <h2 class="portal-heading text-lg mb-2">Code of Conduct &amp; Safeguarding Agreement</h2>
+        <p class="portal-hint text-sm mb-4">
           Please read and agree to the Hack Club Code of Conduct and Safeguarding Policy before submitting your registration.
         </p>
 
-        <div class="border rounded-lg bg-gray-50 mb-4" data-controller="tabs" data-tabs-active-class="bg-white text-gray-900 border-gray-200 border-b-white -mb-px" data-tabs-inactive-class="text-gray-500 border-transparent hover:text-gray-700">
-          <div class="flex border-b border-gray-200" role="tablist" aria-label="Policy summaries">
+        <div class="portal-card mb-4" data-controller="tabs" data-tabs-active-class="portal-tab-active" data-tabs-inactive-class="portal-tab-inactive">
+          <div class="flex portal-inset-bottom" role="tablist" aria-label="Policy summaries">
             <button type="button" role="tab" data-tabs-target="tab" data-action="click->tabs#select keydown->tabs#keydown"
-                    class="px-4 py-2.5 text-sm font-medium border border-b-2 rounded-t-lg focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500">
+                    class="portal-tab">
               Code of Conduct
             </button>
             <button type="button" role="tab" data-tabs-target="tab" data-action="click->tabs#select keydown->tabs#keydown"
-                    class="px-4 py-2.5 text-sm font-medium border border-b-2 rounded-t-lg focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500">
+                    class="portal-tab">
               Safeguarding
             </button>
           </div>
 
           <!-- Code of Conduct TL;DR -->
           <div data-tabs-target="panel" role="tabpanel" class="p-4 max-h-64 overflow-y-auto text-sm">
-            <h3 class="font-semibold text-gray-900 mb-2">TL;DR</h3>
-            <ul class="list-disc list-inside text-gray-700 mb-4 space-y-1">
+            <h3 class="portal-heading mb-2">TL;DR</h3>
+            <ul class="list-disc list-inside portal-body mb-4 space-y-1">
               <li>Treat everyone with respect and kindness.</li>
               <li>Be thoughtful in how you communicate.</li>
               <li>Don't be destructive or inflammatory.</li>
-              <li>If you encounter an issue, please mail <a href="mailto:conduct@hackclub.com" class="text-blue-600 hover:underline">conduct@hackclub.com</a>.</li>
+              <li>If you encounter an issue, please mail <a href="mailto:conduct@hackclub.com" class="portal-link">conduct@hackclub.com</a>.</li>
             </ul>
 
-            <h3 class="font-semibold text-gray-900 mb-2">Hacker Values</h3>
-            <ul class="list-disc list-inside text-gray-700 mb-4 space-y-1">
+            <h3 class="portal-heading mb-2">Hacker Values</h3>
+            <ul class="list-disc list-inside portal-body mb-4 space-y-1">
               <li><strong>Be friendly and welcoming</strong></li>
               <li><strong>Be patient</strong> – Remember that people have varying communication styles and that not everyone is using their native language.</li>
               <li><strong>Be thoughtful</strong> – Productive communication requires effort. Think about how your words will be interpreted.</li>
@@ -404,9 +405,9 @@
               <li><strong>Be charitable</strong> – Interpret the arguments of others in good faith, do not seek to disagree.</li>
             </ul>
 
-            <h3 class="font-semibold text-gray-900 mb-2">Unwelcome Behavior</h3>
-            <p class="text-gray-700 mb-2">These actions are explicitly forbidden in Hack Club spaces:</p>
-            <ul class="list-disc list-inside text-gray-700 mb-4 space-y-1">
+            <h3 class="portal-heading mb-2">Unwelcome Behavior</h3>
+            <p class="portal-body mb-2">These actions are explicitly forbidden in Hack Club spaces:</p>
+            <ul class="list-disc list-inside portal-body mb-4 space-y-1">
               <li>Insulting, demeaning, hateful, or threatening remarks</li>
               <li>Discrimination based on age, nationality, race, disability, gender, sexuality, religion, or similar personal characteristic</li>
               <li>Bullying or systematic harassment</li>
@@ -414,20 +415,20 @@
               <li>Posting spam-like content that disrupts the environment of the community</li>
             </ul>
 
-            <h3 class="font-semibold text-gray-900 mb-2">Enforcement</h3>
-            <p class="text-gray-700 mb-2">
+            <h3 class="portal-heading mb-2">Enforcement</h3>
+            <p class="portal-body mb-2">
               Unacceptable behavior will not be tolerated. You will be warned and asked to stop. Repeated offenses may result in a temporary or permanent ban from the community and events.
             </p>
 
-            <p class="text-gray-500 text-xs mt-4">
-              <a href="https://hackclub.com/conduct/" target="_blank" class="text-blue-600 hover:underline">Read the full Code of Conduct →</a>
+            <p class="portal-meta text-xs mt-4">
+              <a href="https://hackclub.com/conduct/" target="_blank" class="portal-link">Read the full Code of Conduct →</a>
             </p>
           </div>
 
           <!-- Safeguarding Policy TL;DR -->
           <div data-tabs-target="panel" role="tabpanel" class="p-4 max-h-64 overflow-y-auto text-sm hidden">
-            <h3 class="font-semibold text-gray-900 mb-2">TL;DR</h3>
-            <ul class="list-disc list-inside text-gray-700 mb-4 space-y-1">
+            <h3 class="portal-heading mb-2">TL;DR</h3>
+            <ul class="list-disc list-inside portal-body mb-4 space-y-1">
               <li>Everyone is treated with dignity and respect — keeping minors safe is the top priority.</li>
               <li>No drugs, alcohol, tobacco, or being under the influence at events.</li>
               <li>No sexual, violent, or discriminatory content, and no harassment.</li>
@@ -435,76 +436,76 @@
               <li>See something wrong? Tell an organizer or safeguarding officer right away — reports are confidential and protected.</li>
             </ul>
 
-            <h3 class="font-semibold text-gray-900 mb-2">Getting Help</h3>
-            <ul class="list-disc list-inside text-gray-700 mb-4 space-y-1">
+            <h3 class="portal-heading mb-2">Getting Help</h3>
+            <ul class="list-disc list-inside portal-body mb-4 space-y-1">
               <li>Emergency line: <strong>1-855-625-HACK</strong></li>
-              <li>Email <a href="mailto:safeguarding@hackclub.com" class="text-blue-600 hover:underline">safeguarding@hackclub.com</a></li>
+              <li>Email <a href="mailto:safeguarding@hackclub.com" class="portal-link">safeguarding@hackclub.com</a></li>
               <li>Your event's safeguarding officer (contact info is posted at the event).</li>
             </ul>
 
-            <p class="text-gray-500 text-xs mt-4">
-              <a href="https://hackclub.com/safeguarding" target="_blank" class="text-blue-600 hover:underline">Read the full Safeguarding Policy →</a>
+            <p class="portal-meta text-xs mt-4">
+              <a href="https://hackclub.com/safeguarding" target="_blank" class="portal-link">Read the full Safeguarding Policy →</a>
             </p>
           </div>
         </div>
 
-        <div class="bg-white border rounded-lg p-4">
+        <div class="portal-card p-4">
           <div class="mb-4">
-            <%= f.label :code_of_conduct_accepted, class: "flex items-start gap-3 cursor-pointer" do %>
-              <%= f.check_box :code_of_conduct_accepted, class: "w-4 h-4 mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500", required: true, id: "code_of_conduct_accepted" %>
-              <span class="text-sm text-gray-700">
-                I have read and agree to abide by the <a href="https://hackclub.com/conduct/" target="_blank" class="text-blue-600 hover:underline">Hack Club Code of Conduct</a> and <a href="https://hackclub.com/safeguarding" target="_blank" class="text-blue-600 hover:underline">Safeguarding Policy</a>.
+            <%= f.label :code_of_conduct_accepted, class: "portal-check-row" do %>
+              <%= f.check_box :code_of_conduct_accepted, class: "portal-check mt-0.5", required: true, id: "code_of_conduct_accepted" %>
+              <span class="text-sm">
+                I have read and agree to abide by the <a href="https://hackclub.com/conduct/" target="_blank" class="portal-link">Hack Club Code of Conduct</a> and <a href="https://hackclub.com/safeguarding" target="_blank" class="portal-link">Safeguarding Policy</a>.
               </span>
             <% end %>
           </div>
 
-          <div class="border-t pt-4">
-            <label for="code_of_conduct_signature" class="block text-sm font-medium text-gray-700 mb-2">
-              Digital Signature <span class="text-red-500">*</span>
+          <div class="portal-inset pt-4">
+            <label for="code_of_conduct_signature" class="portal-label">
+              Digital Signature <span class="portal-required" aria-hidden="true">*</span>
             </label>
-            <p class="text-xs text-gray-500 mb-2">
+            <p class="portal-hint text-xs mb-2">
               Type your full legal name below to digitally sign this agreement.
             </p>
-            <%= f.text_field :code_of_conduct_signature, 
+            <%= f.text_field :code_of_conduct_signature,
                 id: "code_of_conduct_signature",
                 required: true,
                 placeholder: @participant&.full_name,
-                class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 font-medium",
+                class: "portal-input font-medium",
                 autocomplete: "off" %>
-            <p class="text-xs text-gray-400 mt-1">
+            <p class="portal-meta text-xs mt-1">
               By typing your name, you acknowledge this constitutes a legally binding electronic signature.
             </p>
           </div>
         </div>
 
         <a href="https://hackclub.com/safety" target="_blank"
-           class="mt-4 flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 hover:bg-blue-100 transition-colors">
-          <svg class="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+           class="portal-note portal-note-info mt-4">
+          <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
           </svg>
           <span>
-            <span class="block text-sm font-medium text-gray-900">Need help or want to read the policies?</span>
-            <span class="block text-sm text-gray-600">Visit our safety hub for the full Code of Conduct, Safeguarding Policy, and how to report a concern.</span>
+            <span class="block portal-heading text-sm">Need help or want to read the policies?</span>
+            <span class="block portal-body text-sm">Visit our safety hub for the full Code of Conduct, Safeguarding Policy, and how to report a concern.</span>
           </span>
         </a>
       </section>
 
       <!-- Terms acceptance -->
-      <div class="bg-gray-50 rounded-md p-4 mb-6">
-        <%= f.label :terms_accepted, class: "flex items-start gap-3 cursor-pointer" do %>
-          <%= f.check_box :terms_accepted, class: "w-4 h-4 mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500", required: true %>
-          <span class="text-sm text-gray-700">
+      <div class="portal-panel p-4 mb-6">
+        <%= f.label :terms_accepted, class: "portal-check-row" do %>
+          <%= f.check_box :terms_accepted, class: "portal-check mt-0.5", required: true %>
+          <span class="text-sm">
             I confirm that the information provided is accurate and complete. I agree to the event terms and conditions.
           </span>
         <% end %>
       </div>
 
-      <div class="flex gap-3">
+      <div class="flex flex-col sm:flex-row gap-3">
         <% if @step_index && @step_index > 0 %>
-          <%= link_to "Back", onboarding_step_path(step: @steps[@step_index - 1], event_id: current_event.id), 
-              class: "w-1/4 bg-white text-gray-700 border border-gray-300 px-6 py-3 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 font-medium text-center" %>
+          <%= link_to "Back", onboarding_step_path(step: @steps[@step_index - 1], event_id: current_event.id),
+              class: "portal-btn portal-btn-secondary w-full sm:w-auto sm:min-w-28" %>
         <% end %>
-        <%= f.submit "Submit Registration", class: "flex-1 bg-green-600 text-white px-6 py-3 rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 font-medium cursor-pointer" %>
+        <%= f.submit "Submit Registration", class: "portal-btn portal-btn-primary flex-1" %>
       </div>
     </div>
   <% end %>

--- a/app/views/onboarding/travel.html.erb
+++ b/app/views/onboarding/travel.html.erb
@@ -1,20 +1,22 @@
 <div class="w-full max-w-2xl mx-auto">
   <%= render "wizard_nav" %>
 
-  <h1 class="text-2xl font-bold mb-2">Travel Information</h1>
-  <p class="text-sm text-gray-600 mb-6">Fields marked with <span class="text-red-500">*</span> are required.</p>
+  <header class="mb-6">
+    <h1 class="portal-title text-2xl">Travel Information</h1>
+    <p class="portal-hint text-sm mt-2">Fields marked with <span class="portal-required" aria-hidden="true">*</span> are required.</p>
+  </header>
 
   <%= form_with url: onboarding_step_path(step: @step, event_id: current_event.id), method: :patch, local: true, multipart: true, data: { turbo: false, controller: "travel-form autosave", autosave_url_value: onboarding_step_path(step: @step, event_id: current_event.id), action: "input->autosave#input change->autosave#change" } do |f| %>
     <%= render "autosave_status" %>
-    <div class="space-y-8">
+    <div class="space-y-6">
       <% if current_event.visa_options_enabled? %>
       <!-- Visa Information -->
-      <section class="bg-white rounded-lg shadow-sm border p-6">
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Visa Requirements</h2>
-        
+      <section class="portal-card p-5 sm:p-6">
+        <h2 class="portal-heading text-base mb-4">Visa Requirements</h2>
+
         <div>
-          <label for="visa_status" class="block text-sm font-medium text-gray-700 mb-1">What is your visa status for <%= current_event.location_country || "the event location" %>?</label>
-          <select name="travel_inbound[visa_status]" id="visa_status" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <label for="visa_status" class="portal-label">What is your visa status for <%= current_event.location_country || "the event location" %>?</label>
+          <select name="travel_inbound[visa_status]" id="visa_status" class="portal-select">
             <option value="not_required" <%= "selected" if @travel_inbound&.not_required? %>>I don't need a visa (citizen or visa-exempt nationality)</option>
             <option value="pending" <%= "selected" if @travel_inbound&.pending? %>>I need a visa but haven't applied yet</option>
             <option value="applied" <%= "selected" if @travel_inbound&.applied? %>>I've applied for a visa and am waiting for approval</option>
@@ -23,22 +25,27 @@
           </select>
         </div>
         <% if current_event.visa_application_url.present? %>
-          <div class="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-md text-sm text-blue-900">
-            <p class="mb-2">If you need a visa letter to support your application, request one through our visa letter system.</p>
-            <%= link_to "Request a visa letter →", current_event.visa_application_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium" %>
+          <div class="portal-note portal-note-info mt-4">
+            <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.852l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"/>
+            </svg>
+            <div class="text-sm">
+              <p class="portal-body mb-2">If you need a visa letter to support your application, request one through our visa letter system.</p>
+              <%= link_to "Request a visa letter →", current_event.visa_application_url, target: "_blank", rel: "noopener noreferrer", class: "portal-btn portal-btn-secondary" %>
+            </div>
           </div>
         <% end %>
       </section>
       <% end %>
 
       <!-- Inbound Travel -->
-      <section class="bg-white rounded-lg shadow-sm border p-6" data-travel-form-target="inboundSection">
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Arrival Travel (Getting to <%= current_event.location_city || "the event" %>)</h2>
+      <section class="portal-card p-5 sm:p-6" data-travel-form-target="inboundSection">
+        <h2 class="portal-heading text-base mb-4">Arrival Travel (Getting to <%= current_event.location_city || "the event" %>)</h2>
 
         <div class="space-y-4">
           <div>
-            <label for="travel_inbound_mode" class="block text-sm font-medium text-gray-700 mb-1">How are you travelling to <%= current_event.location_city || "the event" %>? <span class="text-red-500">*</span></label>
-            <select name="travel_inbound[mode]" id="travel_inbound_mode" data-action="change->travel-form#updateFields" data-travel-form-target="inboundMode" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+            <label for="travel_inbound_mode" class="portal-label">How are you travelling to <%= current_event.location_city || "the event" %>? <span class="portal-required" aria-hidden="true">*</span></label>
+            <select name="travel_inbound[mode]" id="travel_inbound_mode" data-action="change->travel-form#updateFields" data-travel-form-target="inboundMode" class="portal-select" required>
               <option value="">Select travel mode</option>
               <option value="plane" <%= "selected" if @travel_inbound&.plane? %>>Flight</option>
               <option value="train" <%= "selected" if @travel_inbound&.train? %>>Train</option>
@@ -52,24 +59,24 @@
           <div data-travel-form-target="inboundPlane" class="<%= 'hidden' unless @travel_inbound&.plane? %>">
             <div class="space-y-4">
               <div class="flex items-center justify-between mb-2">
-                <h3 class="font-medium text-gray-900">Flight Legs</h3>
-                <button type="button" data-action="click->travel-form#addLeg" data-direction="inbound" class="text-sm text-blue-600 hover:text-blue-800 font-medium">+ Add Connection</button>
+                <h3 class="portal-heading text-sm">Flight Legs</h3>
+                <button type="button" data-action="click->travel-form#addLeg" data-direction="inbound" class="portal-btn portal-btn-quiet text-sm">+ Add Connection</button>
               </div>
-              
+
               <div data-travel-form-target="inboundLegs" class="space-y-4">
                 <% legs = @travel_inbound&.travel_legs.presence || [TravelLeg.new(position: 0)] %>
                 <% legs.each_with_index do |leg, index| %>
                   <%= render "shared/flight_leg_fields", leg: leg, index: index, direction: "inbound", show_remove: index > 0, default_date: @default_inbound_date %>
                 <% end %>
               </div>
-              
+
               <div class="mt-4">
-                <label class="flex items-center gap-2 cursor-pointer">
+                <label class="portal-check-row">
                   <input type="hidden" name="travel_inbound[is_unaccompanied_minor]" value="0">
-                  <input type="checkbox" name="travel_inbound[is_unaccompanied_minor]" value="1" <%= "checked" if @travel_inbound&.is_unaccompanied_minor %> class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" data-travel-form-target="umCheckbox" data-action="change->travel-form#toggleUmSection">
-                  <span class="text-sm font-medium text-gray-700">Booked as an unaccompanied minor with the airline</span>
+                  <input type="checkbox" name="travel_inbound[is_unaccompanied_minor]" value="1" <%= "checked" if @travel_inbound&.is_unaccompanied_minor %> class="portal-check mt-0.5" data-travel-form-target="umCheckbox" data-action="change->travel-form#toggleUmSection">
+                  <span class="text-sm font-medium">Booked as an unaccompanied minor with the airline</span>
                 </label>
-                <p class="ml-6 text-sm text-gray-500">Check this only if you have formally registered as an unaccompanied minor (UM) with your airline. This is a specific airline service for under-18s travelling alone that requires advance booking and additional fees.</p>
+                <p class="ml-8 portal-hint text-sm">Check this only if you have formally registered as an unaccompanied minor (UM) with your airline. This is a specific airline service for under-18s travelling alone that requires advance booking and additional fees.</p>
               </div>
             </div>
           </div>
@@ -79,17 +86,17 @@
             <div class="space-y-4">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Departure Station</label>
-                  <input type="text" name="travel_inbound[train_departure_station]" value="<%= @travel_inbound&.train_departure_station %>" placeholder="e.g. London St Pancras" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Departure Station</label>
+                  <input type="text" name="travel_inbound[train_departure_station]" value="<%= @travel_inbound&.train_departure_station %>" placeholder="e.g. London St Pancras" class="portal-input">
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Station</label>
-                  <input type="text" name="travel_inbound[train_arrival_station]" value="<%= @travel_inbound&.train_arrival_station %>" placeholder="e.g. Wien Hauptbahnhof" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Arrival Station</label>
+                  <input type="text" name="travel_inbound[train_arrival_station]" value="<%= @travel_inbound&.train_arrival_station %>" placeholder="e.g. Wien Hauptbahnhof" class="portal-input">
                 </div>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Time in <%= current_event.location_city || "the event" %></label>
-                <input type="datetime-local" name="travel_inbound[arrival_time]" value="<%= @travel_inbound&.arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <label class="portal-label">Arrival Time in <%= current_event.location_city || "the event" %></label>
+                <input type="datetime-local" name="travel_inbound[arrival_time]" value="<%= @travel_inbound&.arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="portal-input">
               </div>
             </div>
           </div>
@@ -99,22 +106,22 @@
             <div class="space-y-4">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Departure Location</label>
-                  <input type="text" name="travel_inbound[bus_departure_location]" value="<%= @travel_inbound&.bus_departure_location %>" placeholder="Bus station or city" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Departure Location</label>
+                  <input type="text" name="travel_inbound[bus_departure_location]" value="<%= @travel_inbound&.bus_departure_location %>" placeholder="Bus station or city" class="portal-input">
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Location</label>
-                  <input type="text" name="travel_inbound[bus_arrival_location]" value="<%= @travel_inbound&.bus_arrival_location %>" placeholder="<%= current_event.location_city || "the event" %> bus station" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Arrival Location</label>
+                  <input type="text" name="travel_inbound[bus_arrival_location]" value="<%= @travel_inbound&.bus_arrival_location %>" placeholder="<%= current_event.location_city || "the event" %> bus station" class="portal-input">
                 </div>
               </div>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Departure Time</label>
-                  <input type="datetime-local" name="travel_inbound[departure_time]" value="<%= @travel_inbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Departure Time</label>
+                  <input type="datetime-local" name="travel_inbound[departure_time]" value="<%= @travel_inbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="portal-input">
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Time</label>
-                  <input type="datetime-local" name="travel_inbound[arrival_time]" value="<%= @travel_inbound&.arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Arrival Time</label>
+                  <input type="datetime-local" name="travel_inbound[arrival_time]" value="<%= @travel_inbound&.arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="portal-input">
                 </div>
               </div>
             </div>
@@ -124,12 +131,12 @@
           <div data-travel-form-target="inboundCar" class="<%= 'hidden' unless @travel_inbound&.car? %>">
             <div class="space-y-4">
               <div data-controller="address-autocomplete">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Where are you travelling from?</label>
-                <textarea name="travel_inbound[origin_address]" rows="2" placeholder="Full address or city" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" data-address-autocomplete-target="input"><%= @travel_inbound&.origin_address %></textarea>
+                <label class="portal-label">Where are you travelling from?</label>
+                <textarea name="travel_inbound[origin_address]" rows="2" placeholder="Full address or city" class="portal-textarea" data-address-autocomplete-target="input"><%= @travel_inbound&.origin_address %></textarea>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Expected Arrival Time in <%= current_event.location_city || "the event" %></label>
-                <input type="datetime-local" name="travel_inbound[expected_arrival_time]" value="<%= @travel_inbound&.expected_arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <label class="portal-label">Expected Arrival Time in <%= current_event.location_city || "the event" %></label>
+                <input type="datetime-local" name="travel_inbound[expected_arrival_time]" value="<%= @travel_inbound&.expected_arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_inbound_date ? "#{@default_inbound_date}T00:00" : nil) %>" class="portal-input">
               </div>
             </div>
           </div>
@@ -137,21 +144,21 @@
           <!-- Other Fields -->
           <div data-travel-form-target="inboundOther" class="<%= 'hidden' unless @travel_inbound&.other? %>">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Please describe your travel arrangements</label>
-              <textarea name="travel_inbound[other_details]" rows="4" placeholder="Please provide details about how you'll be getting to <%= current_event.location_city || "the event" %>, including timing and any relevant information" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"><%= @travel_inbound&.other_details %></textarea>
+              <label class="portal-label">Please describe your travel arrangements</label>
+              <textarea name="travel_inbound[other_details]" rows="4" placeholder="Please provide details about how you'll be getting to <%= current_event.location_city || "the event" %>, including timing and any relevant information" class="portal-textarea"><%= @travel_inbound&.other_details %></textarea>
             </div>
           </div>
         </div>
       </section>
 
       <!-- Outbound Travel -->
-      <section class="bg-white rounded-lg shadow-sm border p-6" data-travel-form-target="outboundSection">
-        <h2 class="text-lg font-semibold mb-4 pb-2 border-b">Departure Travel (Leaving <%= current_event.location_city || "the event" %>)</h2>
+      <section class="portal-card p-5 sm:p-6" data-travel-form-target="outboundSection">
+        <h2 class="portal-heading text-base mb-4">Departure Travel (Leaving <%= current_event.location_city || "the event" %>)</h2>
 
         <div class="space-y-4">
           <div>
-            <label for="travel_outbound_mode" class="block text-sm font-medium text-gray-700 mb-1">How are you leaving <%= current_event.location_city || "the event" %>? <span class="text-red-500">*</span></label>
-            <select name="travel_outbound[mode]" id="travel_outbound_mode" data-action="change->travel-form#updateFields" data-travel-form-target="outboundMode" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+            <label for="travel_outbound_mode" class="portal-label">How are you leaving <%= current_event.location_city || "the event" %>? <span class="portal-required" aria-hidden="true">*</span></label>
+            <select name="travel_outbound[mode]" id="travel_outbound_mode" data-action="change->travel-form#updateFields" data-travel-form-target="outboundMode" class="portal-select" required>
               <option value="">Select travel mode</option>
               <option value="plane" <%= "selected" if @travel_outbound&.plane? %>>Flight</option>
               <option value="train" <%= "selected" if @travel_outbound&.train? %>>Train</option>
@@ -165,24 +172,24 @@
           <div data-travel-form-target="outboundPlane" class="<%= 'hidden' unless @travel_outbound&.plane? %>">
             <div class="space-y-4">
               <div class="flex items-center justify-between mb-2">
-                <h3 class="font-medium text-gray-900">Flight Legs</h3>
-                <button type="button" data-action="click->travel-form#addLeg" data-direction="outbound" class="text-sm text-blue-600 hover:text-blue-800 font-medium">+ Add Connection</button>
+                <h3 class="portal-heading text-sm">Flight Legs</h3>
+                <button type="button" data-action="click->travel-form#addLeg" data-direction="outbound" class="portal-btn portal-btn-quiet text-sm">+ Add Connection</button>
               </div>
-              
+
               <div data-travel-form-target="outboundLegs" class="space-y-4">
                 <% legs = @travel_outbound&.travel_legs.presence || [TravelLeg.new(position: 0)] %>
                 <% legs.each_with_index do |leg, index| %>
                   <%= render "shared/flight_leg_fields", leg: leg, index: index, direction: "outbound", show_remove: index > 0, default_date: @default_outbound_date %>
                 <% end %>
               </div>
-              
+
               <div class="mt-4">
-                <label class="flex items-center gap-2 cursor-pointer">
+                <label class="portal-check-row">
                   <input type="hidden" name="travel_outbound[is_unaccompanied_minor]" value="0">
-                  <input type="checkbox" name="travel_outbound[is_unaccompanied_minor]" value="1" <%= "checked" if @travel_outbound&.is_unaccompanied_minor %> class="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" data-travel-form-target="umCheckbox" data-action="change->travel-form#toggleUmSection">
-                  <span class="text-sm font-medium text-gray-700">Booked as an unaccompanied minor with the airline</span>
+                  <input type="checkbox" name="travel_outbound[is_unaccompanied_minor]" value="1" <%= "checked" if @travel_outbound&.is_unaccompanied_minor %> class="portal-check mt-0.5" data-travel-form-target="umCheckbox" data-action="change->travel-form#toggleUmSection">
+                  <span class="text-sm font-medium">Booked as an unaccompanied minor with the airline</span>
                 </label>
-                <p class="ml-6 text-sm text-gray-500">Check this only if you have formally registered as an unaccompanied minor (UM) with your airline. This is a specific airline service for under-18s travelling alone that requires advance booking and additional fees.</p>
+                <p class="ml-8 portal-hint text-sm">Check this only if you have formally registered as an unaccompanied minor (UM) with your airline. This is a specific airline service for under-18s travelling alone that requires advance booking and additional fees.</p>
               </div>
             </div>
           </div>
@@ -192,17 +199,17 @@
             <div class="space-y-4">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Departure Station</label>
-                  <input type="text" name="travel_outbound[train_departure_station]" value="<%= @travel_outbound&.train_departure_station %>" placeholder="e.g. Wien Hauptbahnhof" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Departure Station</label>
+                  <input type="text" name="travel_outbound[train_departure_station]" value="<%= @travel_outbound&.train_departure_station %>" placeholder="e.g. Wien Hauptbahnhof" class="portal-input">
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Station</label>
-                  <input type="text" name="travel_outbound[train_arrival_station]" value="<%= @travel_outbound&.train_arrival_station %>" placeholder="e.g. London St Pancras" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Arrival Station</label>
+                  <input type="text" name="travel_outbound[train_arrival_station]" value="<%= @travel_outbound&.train_arrival_station %>" placeholder="e.g. London St Pancras" class="portal-input">
                 </div>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Departure Time from <%= current_event.location_city || "the event" %></label>
-                <input type="datetime-local" name="travel_outbound[departure_time]" value="<%= @travel_outbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <label class="portal-label">Departure Time from <%= current_event.location_city || "the event" %></label>
+                <input type="datetime-local" name="travel_outbound[departure_time]" value="<%= @travel_outbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="portal-input">
               </div>
             </div>
           </div>
@@ -212,22 +219,22 @@
             <div class="space-y-4">
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Departure Location</label>
-                  <input type="text" name="travel_outbound[bus_departure_location]" value="<%= @travel_outbound&.bus_departure_location %>" placeholder="<%= current_event.location_city || "the event" %> bus station" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Departure Location</label>
+                  <input type="text" name="travel_outbound[bus_departure_location]" value="<%= @travel_outbound&.bus_departure_location %>" placeholder="<%= current_event.location_city || "the event" %> bus station" class="portal-input">
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Location</label>
-                  <input type="text" name="travel_outbound[bus_arrival_location]" value="<%= @travel_outbound&.bus_arrival_location %>" placeholder="Your destination" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Arrival Location</label>
+                  <input type="text" name="travel_outbound[bus_arrival_location]" value="<%= @travel_outbound&.bus_arrival_location %>" placeholder="Your destination" class="portal-input">
                 </div>
               </div>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Departure Time</label>
-                  <input type="datetime-local" name="travel_outbound[departure_time]" value="<%= @travel_outbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Departure Time</label>
+                  <input type="datetime-local" name="travel_outbound[departure_time]" value="<%= @travel_outbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="portal-input">
                 </div>
                 <div>
-                  <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Time</label>
-                  <input type="datetime-local" name="travel_outbound[arrival_time]" value="<%= @travel_outbound&.arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <label class="portal-label">Arrival Time</label>
+                  <input type="datetime-local" name="travel_outbound[arrival_time]" value="<%= @travel_outbound&.arrival_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="portal-input">
                 </div>
               </div>
             </div>
@@ -237,12 +244,12 @@
           <div data-travel-form-target="outboundCar" class="<%= 'hidden' unless @travel_outbound&.car? %>">
             <div class="space-y-4">
               <div data-controller="address-autocomplete">
-                <label class="block text-sm font-medium text-gray-700 mb-1">Where are you travelling to?</label>
-                <textarea name="travel_outbound[origin_address]" rows="2" placeholder="Full address or city" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" data-address-autocomplete-target="input"><%= @travel_outbound&.origin_address %></textarea>
+                <label class="portal-label">Where are you travelling to?</label>
+                <textarea name="travel_outbound[origin_address]" rows="2" placeholder="Full address or city" class="portal-textarea" data-address-autocomplete-target="input"><%= @travel_outbound&.origin_address %></textarea>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Expected Departure Time from <%= current_event.location_city || "the event" %></label>
-                <input type="datetime-local" name="travel_outbound[departure_time]" value="<%= @travel_outbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <label class="portal-label">Expected Departure Time from <%= current_event.location_city || "the event" %></label>
+                <input type="datetime-local" name="travel_outbound[departure_time]" value="<%= @travel_outbound&.departure_time&.strftime('%Y-%m-%dT%H:%M') || (@default_outbound_date ? "#{@default_outbound_date}T00:00" : nil) %>" class="portal-input">
               </div>
             </div>
           </div>
@@ -250,8 +257,8 @@
           <!-- Other Fields -->
           <div data-travel-form-target="outboundOther" class="<%= 'hidden' unless @travel_outbound&.other? %>">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Please describe your travel arrangements</label>
-              <textarea name="travel_outbound[other_details]" rows="4" placeholder="Please provide details about how you'll be leaving <%= current_event.location_city || "the event" %>, including timing and any relevant information" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"><%= @travel_outbound&.other_details %></textarea>
+              <label class="portal-label">Please describe your travel arrangements</label>
+              <textarea name="travel_outbound[other_details]" rows="4" placeholder="Please provide details about how you'll be leaving <%= current_event.location_city || "the event" %>, including timing and any relevant information" class="portal-textarea"><%= @travel_outbound&.other_details %></textarea>
             </div>
           </div>
         </div>
@@ -259,23 +266,27 @@
 
       <!-- Unaccompanied Minor Verification -->
       <% um_declared = @travel_inbound&.is_unaccompanied_minor || @travel_outbound&.is_unaccompanied_minor %>
-      <section class="bg-amber-50 rounded-lg shadow-sm border border-amber-200 p-6 <%= 'hidden' unless um_declared %>" data-travel-form-target="umSection">
-        <h2 class="text-lg font-semibold mb-2 text-amber-900">Unaccompanied Minor Verification <span class="text-red-500">*</span></h2>
-        <p class="text-sm text-amber-900 mb-2">
+      <section class="portal-card p-5 sm:p-6 <%= 'hidden' unless um_declared %>"
+               style="background-color: color-mix(in oklab, var(--warning) 12%, var(--bg-elev)); border-color: color-mix(in oklab, var(--warning) 30%, var(--bg-elev));"
+               data-travel-form-target="umSection">
+        <h2 class="portal-heading text-base mb-2">Unaccompanied Minor Verification <span class="portal-required" aria-hidden="true">*</span></h2>
+        <p class="portal-body text-sm mb-2">
           The unaccompanied minor (UM) service is a <strong>paid airline service</strong> where airline staff chaperone a child through the airport and flight. It is <strong>not</strong> the same as simply being under 18 and travelling alone — it must be booked with your airline in advance.
         </p>
-        <p class="text-sm text-amber-900 mb-4">
+        <p class="portal-body text-sm mb-4">
           Since you've told us you're booked as an unaccompanied minor, please upload proof of your UM booking with the airline (e.g. a booking confirmation or receipt showing the unaccompanied minor service). <strong>You won't be able to continue without this.</strong> We'll review it, and once your onboarding is submitted we'll reach out with pickup/dropoff information within 2 weeks of the event.
         </p>
         <% if @participant_event.um_proof.attached? %>
-          <div class="mb-3 flex items-center gap-2 text-sm text-green-800 bg-green-50 border border-green-200 rounded-md px-3 py-2">
-            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-            <span>Uploaded: <span class="font-medium"><%= @participant_event.um_proof.filename %></span> — upload a new file below to replace it.</span>
+          <div class="portal-note portal-note-success mb-3">
+            <svg class="portal-note-icon" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/>
+            </svg>
+            <p class="portal-body text-sm">Uploaded: <strong class="portal-heading"><%= @participant_event.um_proof.filename %></strong> — upload a new file below to replace it.</p>
           </div>
         <% end %>
         <div>
-          <label for="um_proof" class="block text-sm font-medium text-amber-900 mb-1">Proof of UM booking (image or PDF)</label>
-          <input type="file" name="um_proof" id="um_proof" accept="image/jpeg,image/png,image/webp,image/heic,application/pdf" class="block w-full text-sm text-gray-700 file:mr-3 file:px-3 file:py-2 file:rounded-md file:border-0 file:bg-amber-600 file:text-white file:cursor-pointer hover:file:bg-amber-500">
+          <label for="um_proof" class="portal-label">Proof of UM booking (image or PDF)</label>
+          <input type="file" name="um_proof" id="um_proof" accept="image/jpeg,image/png,image/webp,image/heic,application/pdf" class="portal-file">
         </div>
       </section>
 
@@ -286,38 +297,38 @@
 
 <!-- Leg Template for JavaScript -->
 <template id="leg-template">
-  <div class="border border-gray-200 rounded-lg p-4 relative"
+  <div class="portal-panel p-4 relative" style="border: 1px solid var(--border);"
        data-travel-form-target="legTemplate"
        data-autosave-skip>
-    <button type="button" data-action="click->travel-form#removeLeg" class="absolute top-2 right-2 text-gray-400 hover:text-red-600">
+    <button type="button" data-action="click->travel-form#removeLeg" class="portal-btn portal-btn-quiet p-1 absolute top-2 right-2" aria-label="Remove connection">
       <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
     </button>
-    <div class="text-sm font-medium text-gray-500 mb-3 leg-number">Leg</div>
+    <div class="portal-hint text-sm font-medium mb-3 leg-number">Leg</div>
     <input type="hidden" class="leg-position" name="" value="">
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Flight Code <span class="text-red-500">*</span></label>
-        <input type="text" class="leg-flight-code w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="e.g. LH1234">
+        <label class="portal-label">Flight Code <span class="portal-required" aria-hidden="true">*</span></label>
+        <input type="text" class="leg-flight-code portal-input" placeholder="e.g. LH1234">
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Confirmation Code</label>
-        <input type="text" class="leg-confirmation-code w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="Booking reference">
+        <label class="portal-label">Confirmation Code</label>
+        <input type="text" class="leg-confirmation-code portal-input" placeholder="Booking reference">
       </div>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
       <div data-controller="airport-autocomplete" class="relative">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Departure Airport <span class="text-red-500">*</span></label>
-        <input type="text" class="leg-departure-airport w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="e.g. LHR" autocomplete="off" data-airport-autocomplete-target="input" data-action="input->airport-autocomplete#search keydown->airport-autocomplete#onKeydown blur->airport-autocomplete#onBlur">
-        <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+        <label class="portal-label">Departure Airport <span class="portal-required" aria-hidden="true">*</span></label>
+        <input type="text" class="leg-departure-airport portal-input" placeholder="e.g. LHR" autocomplete="off" data-airport-autocomplete-target="input" data-action="input->airport-autocomplete#search keydown->airport-autocomplete#onKeydown blur->airport-autocomplete#onBlur">
+        <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 portal-card shadow-lg max-h-60 overflow-y-auto">
           <div data-airport-autocomplete-target="results"></div>
         </div>
       </div>
       <div data-controller="airport-autocomplete" class="relative">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Airport <span class="text-red-500">*</span></label>
-        <input type="text" class="leg-arrival-airport w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="e.g. VIE" autocomplete="off" data-airport-autocomplete-target="input" data-action="input->airport-autocomplete#search keydown->airport-autocomplete#onKeydown blur->airport-autocomplete#onBlur">
-        <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+        <label class="portal-label">Arrival Airport <span class="portal-required" aria-hidden="true">*</span></label>
+        <input type="text" class="leg-arrival-airport portal-input" placeholder="e.g. VIE" autocomplete="off" data-airport-autocomplete-target="input" data-action="input->airport-autocomplete#search keydown->airport-autocomplete#onKeydown blur->airport-autocomplete#onBlur">
+        <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 portal-card shadow-lg max-h-60 overflow-y-auto">
           <div data-airport-autocomplete-target="results"></div>
         </div>
       </div>
@@ -325,14 +336,14 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Departure Time <span class="text-red-500">*</span> <span class="font-normal text-gray-500">(local airport time)</span></label>
-        <input type="datetime-local" class="leg-departure-time w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" name="">
-        <select class="leg-departure-tz mt-1 w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" name=""><%= travel_leg_time_zone_options %></select>
+        <label class="portal-label">Departure Time <span class="portal-required" aria-hidden="true">*</span> <span class="portal-meta font-normal">(local airport time)</span></label>
+        <input type="datetime-local" class="leg-departure-time portal-input" name="">
+        <select class="leg-departure-tz portal-select mt-1 text-sm" name=""><%= travel_leg_time_zone_options %></select>
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Time <span class="text-red-500">*</span> <span class="font-normal text-gray-500">(local airport time)</span></label>
-        <input type="datetime-local" class="leg-arrival-time w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" name="">
-        <select class="leg-arrival-tz mt-1 w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" name=""><%= travel_leg_time_zone_options %></select>
+        <label class="portal-label">Arrival Time <span class="portal-required" aria-hidden="true">*</span> <span class="portal-meta font-normal">(local airport time)</span></label>
+        <input type="datetime-local" class="leg-arrival-time portal-input" name="">
+        <select class="leg-arrival-tz portal-select mt-1 text-sm" name=""><%= travel_leg_time_zone_options %></select>
       </div>
     </div>
   </div>

--- a/app/views/onboarding/waiver.html.erb
+++ b/app/views/onboarding/waiver.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full max-w-3xl mx-auto">
   <div class="mb-6 text-center">
-    <p class="text-sm text-gray-500">Registering for</p>
-    <h2 class="text-lg font-semibold text-gray-900"><%= current_event.name %></h2>
+    <p class="portal-meta text-sm">Registering for</p>
+    <h2 class="portal-heading text-lg"><%= current_event.name %></h2>
   </div>
 
   <% if @waiver_preparing %>
@@ -10,34 +10,36 @@
     <% end %>
     <%= render "shared/document_preparing", title: "Getting your waiver ready to sign" %>
     <div class="mt-6 text-center">
-      <%= link_to "Back to Dashboard", dashboard_path, class: "text-blue-600 hover:underline" %>
+      <%= link_to "Back to Dashboard", dashboard_path, class: "portal-link" %>
     </div>
   <% elsif @waiver_paused %>
-    <h1 class="text-2xl font-bold mb-4">Waiver Not Available Yet</h1>
-    <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
-      <svg class="mx-auto h-12 w-12 text-yellow-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-      </svg>
-      <p class="text-gray-700 text-lg mb-2">You're not able to sign your waiver yet.</p>
-      <p class="text-gray-500">We'll send you an email when this is ready.</p>
+    <h1 class="portal-title text-2xl mb-4">Waiver Not Available Yet</h1>
+    <div class="portal-card p-6 sm:p-8 text-center">
+      <span class="portal-medallion portal-medallion-warn mx-auto mb-4">
+        <svg class="size-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+        </svg>
+      </span>
+      <p class="portal-heading text-lg mb-2">You're not able to sign your waiver yet.</p>
+      <p class="portal-hint">We'll send you an email when this is ready.</p>
     </div>
     <div class="mt-6 text-center">
-      <%= link_to "Back to Dashboard", dashboard_path, class: "text-blue-600 hover:underline" %>
+      <%= link_to "Back to Dashboard", dashboard_path, class: "portal-link" %>
     </div>
   <% else %>
-    <h1 class="text-2xl font-bold mb-4">Sign Your Waiver</h1>
+    <h1 class="portal-title text-2xl mb-4">Sign Your Waiver</h1>
 
     <% if @participant_event.requires_guardian? %>
-      <p class="text-gray-600 mb-6">
+      <p class="portal-body mb-6">
         Please review and sign your portion of the waiver below. Once you've signed, we'll send the waiver to your parent/guardian for their signature.
       </p>
     <% else %>
-      <p class="text-gray-600 mb-6">
+      <p class="portal-body mb-6">
         Please review and sign the waiver below to complete your registration.
       </p>
     <% end %>
 
-    <div class="border rounded-lg overflow-hidden bg-white shadow-sm mb-6">
+    <div class="portal-card overflow-hidden mb-6">
       <docuseal-form
         id="docusealForm"
         data-src="<%= @signing_url %>"
@@ -45,19 +47,19 @@
       </docuseal-form>
     </div>
 
-    <div class="text-center text-sm text-gray-500">
-      <p>Having trouble? <a href="<%= @signing_url %>" target="_blank" class="text-blue-600 hover:underline">Open in a new tab</a></p>
+    <div class="text-center text-sm portal-hint">
+      <p>Having trouble? <a href="<%= @signing_url %>" target="_blank" class="portal-link">Open in a new tab</a></p>
     </div>
 
     <% pending_docs = @participant_event.pending_custom_documents.select(&:participant_signs?) %>
     <% if pending_docs.any? %>
-      <div class="mt-6 bg-gray-50 border border-gray-200 rounded-lg p-4">
-        <h3 class="text-sm font-medium text-gray-900 mb-2">After the waiver, you'll also need to sign:</h3>
-        <ul class="text-sm text-gray-600 space-y-1">
+      <div class="portal-card p-4 mt-6">
+        <h3 class="portal-heading text-sm mb-2">After the waiver, you'll also need to sign:</h3>
+        <ul class="text-sm space-y-1">
           <% pending_docs.each do |doc| %>
             <li class="flex items-center gap-2">
-              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-              <%= link_to doc.name, dashboard_sign_document_path(@participant_event, doc), class: "text-blue-600 hover:underline" %>
+              <svg class="w-4 h-4 shrink-0" style="color: var(--text-muted);" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+              <%= link_to doc.name, dashboard_sign_document_path(@participant_event, doc), class: "portal-link" %>
             </li>
           <% end %>
         </ul>

--- a/app/views/shared/_flight_leg_fields.html.erb
+++ b/app/views/shared/_flight_leg_fields.html.erb
@@ -7,39 +7,39 @@
     <pre class="mt-2 bg-gray-900 text-gray-100 p-4 rounded-lg overflow-auto text-wrap"><code class="text-sm font-mono"><%= leg.to_json %></code></pre>
   </details>
 <% end %>
-<div class="border border-gray-200 rounded-lg p-4 relative"
+<div class="portal-panel p-4 relative" style="border: 1px solid var(--border);"
      data-travel-form-target="legTemplate"
      data-autosave-skip>
   <% if show_remove %>
-    <button type="button" data-action="click->travel-form#removeLeg" class="absolute top-2 right-2 text-gray-400 hover:text-red-600">
+    <button type="button" data-action="click->travel-form#removeLeg" class="portal-btn portal-btn-quiet p-1 absolute top-2 right-2" aria-label="Remove connection">
       <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
     </button>
   <% end %>
   <div class="flex items-center justify-between mb-3">
-    <div class="text-sm font-medium text-gray-500">Leg <%= index + 1 %></div>
+    <div class="portal-hint text-sm font-medium">Leg <%= index + 1 %></div>
   </div>
   <input type="hidden" name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][id]" value="<%= leg.id %>">
   <input type="hidden" name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][position]" value="<%= index %>">
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Flight Code <span class="text-red-500">*</span></label>
+      <label class="portal-label">Flight Code <span class="portal-required" aria-hidden="true">*</span></label>
       <input type="text"
              name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][flight_code]"
              value="<%= leg.flight_code %>"
              placeholder="e.g. LH1234"
              required
-             class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+             class="portal-input">
     </div>
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Confirmation Code</label>
-      <input type="text" name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][confirmation_code]" value="<%= leg.confirmation_code %>" placeholder="Booking reference" class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      <label class="portal-label">Confirmation Code</label>
+      <input type="text" name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][confirmation_code]" value="<%= leg.confirmation_code %>" placeholder="Booking reference" class="portal-input">
     </div>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
     <div data-controller="airport-autocomplete" class="relative">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Departure Airport <span class="text-red-500">*</span></label>
+      <label class="portal-label">Departure Airport <span class="portal-required" aria-hidden="true">*</span></label>
       <input type="text"
              name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][departure_airport]"
              value="<%= leg.departure_airport %>"
@@ -48,13 +48,13 @@
              autocomplete="off"
              data-airport-autocomplete-target="input"
              data-action="input->airport-autocomplete#search keydown->airport-autocomplete#onKeydown blur->airport-autocomplete#onBlur"
-             class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
-      <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+             class="portal-input">
+      <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 portal-card shadow-lg max-h-60 overflow-y-auto">
         <div data-airport-autocomplete-target="results"></div>
       </div>
     </div>
     <div data-controller="airport-autocomplete" class="relative">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Airport <span class="text-red-500">*</span></label>
+      <label class="portal-label">Arrival Airport <span class="portal-required" aria-hidden="true">*</span></label>
       <input type="text"
              name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][arrival_airport]"
              value="<%= leg.arrival_airport %>"
@@ -63,8 +63,8 @@
              autocomplete="off"
              data-airport-autocomplete-target="input"
              data-action="input->airport-autocomplete#search keydown->airport-autocomplete#onKeydown blur->airport-autocomplete#onBlur"
-             class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
-      <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-y-auto">
+             class="portal-input">
+      <div data-airport-autocomplete-target="dropdown" class="hidden absolute z-50 w-full mt-1 portal-card shadow-lg max-h-60 overflow-y-auto">
         <div data-airport-autocomplete-target="results"></div>
       </div>
     </div>
@@ -72,26 +72,26 @@
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Departure Time <span class="text-red-500">*</span> <span class="font-normal text-gray-500">(local airport time)</span></label>
+      <label class="portal-label">Departure Time <span class="portal-required" aria-hidden="true">*</span> <span class="portal-meta font-normal">(local airport time)</span></label>
       <input type="datetime-local"
              name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][departure_time]"
              value="<%= flight_local_input_value(leg.departure_time, leg.departure_airport, default_date: default_date) %>"
              required
-             class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+             class="portal-input">
       <select name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][departure_time_zone]"
-              class="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              class="portal-select mt-1 text-sm">
         <%= travel_leg_time_zone_options %>
       </select>
     </div>
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Arrival Time <span class="text-red-500">*</span> <span class="font-normal text-gray-500">(local airport time)</span></label>
+      <label class="portal-label">Arrival Time <span class="portal-required" aria-hidden="true">*</span> <span class="portal-meta font-normal">(local airport time)</span></label>
       <input type="datetime-local"
              name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][arrival_time]"
              value="<%= flight_local_input_value(leg.arrival_time, leg.arrival_airport, default_date: default_date) %>"
              required
-             class="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+             class="portal-input">
       <select name="travel_<%= direction %>[travel_legs_attributes][<%= index %>][arrival_time_zone]"
-              class="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              class="portal-select mt-1 text-sm">
         <%= travel_leg_time_zone_options %>
       </select>
     </div>


### PR DESCRIPTION
Converts the whole participant onboarding flow (profile, health, guardian, emergency, accommodation, travel, documents, waiver, review) plus `shared/_flight_leg_fields` from hardcoded gray/blue Tailwind to the token-driven `portal-*` component layer, so it matches the guardian portal and renders correctly in all eight themes and dark mode.

## Highlights
- `_wizard_nav` mirrors `guardian_portal/_step_nav`: compact "step N of M" + progress bar on phones, marker rail (completed steps link back) on sm+
- Step buttons use `portal-btn-primary`/`-secondary` (deepened-red rule instead of blue)
- Documents checklist gets portal step markers and `portal-badge` statuses; paused/missing-guardian states become `portal-note-warn`
- Review page sections are `portal-card`s with quiet edit buttons; visa status rendered as badges
- New `.portal-tab` / `.portal-tab-active` classes (the only CSS addition) for the Code of Conduct tabs, wired to the existing `tabs` Stimulus controller
- `shared/_flight_leg_fields` converted too (also rendered by admin travel and dashboard edit-travel, where the token classes render fine)

## Verification
- All touched templates compile through Rails' ERB handler
- Tailwind rebuilt cleanly with the new classes
- 115 request specs pass locally (onboarding documents/UM/profile-autosave, optional + physical custom documents, admin participants)