### PR TITLE
Fix 500 on the MCP OAuth consent screen for users with avatars

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -81,7 +81,7 @@
               <% end %>
               <%= link_to dashboard_profile_path, class: "group flex items-center gap-2 rounded-full border border-[#e0e6ed] py-1 pl-1 pr-3 hover:border-[#ec3750] transition-colors", aria: { label: "Profile settings" } do %>
                 <% if current_user.avatar_displayable? %>
-                  <%= image_tag current_user.avatar.variant(resize_to_fill: [ 48, 48 ]), alt: "", class: "size-6 rounded-full object-cover" %>
+                  <%= image_tag main_app.url_for(current_user.avatar.variant(resize_to_fill: [ 48, 48 ])), alt: "", class: "size-6 rounded-full object-cover" %>
                 <% else %>
                   <span class="flex size-6 items-center justify-center rounded-full bg-[#ec3750]/10 text-xs font-semibold text-[#ec3750]"><%= current_user.initials %></span>
                 <% end %>
@@ -126,7 +126,7 @@
           <div class="border-t border-[#e0e6ed] px-4 py-3 space-y-1">
             <%= link_to dashboard_profile_path, class: "flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[#f9fafc]" do %>
               <% if current_user.avatar_displayable? %>
-                <%= image_tag current_user.avatar.variant(resize_to_fill: [ 64, 64 ]), alt: "", class: "size-8 rounded-full object-cover" %>
+                <%= image_tag main_app.url_for(current_user.avatar.variant(resize_to_fill: [ 64, 64 ])), alt: "", class: "size-8 rounded-full object-cover" %>
               <% else %>
                 <span class="flex size-8 items-center justify-center rounded-full bg-[#ec3750]/10 text-sm font-semibold text-[#ec3750]"><%= current_user.initials %></span>
               <% end %>

--- a/spec/requests/toolchest_oauth_consent_spec.rb
+++ b/spec/requests/toolchest_oauth_consent_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+# The MCP OAuth consent screen is rendered by a toolchest *engine* controller
+# inside the app's application layout. Engine view contexts resolve
+# polymorphic URLs against the engine's route set, which lacks Active
+# Storage's resolve mappings — so `image_tag user.avatar.variant(...)` in the
+# layout 500'd for any user with an avatar (ATTEND-9X). The layout now routes
+# avatar variants through `main_app.url_for`.
+RSpec.describe "Toolchest OAuth consent screen", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) do
+    create(:user).tap do |u|
+      u.avatar.attach(
+        io: File.open(file_fixture("headshot.png")),
+        filename: "headshot.png",
+        content_type: "image/png"
+      )
+      u.save!
+    end
+  end
+
+  let(:application) do
+    Toolchest::OauthApplication.create!(
+      name: "Poke",
+      redirect_uri: "https://poke.example.com/api/v1/mcp/callback"
+    )
+  end
+
+  it "renders for a user with an avatar" do
+    sign_in user
+
+    get "/mcp/oauth/authorize", params: {
+      response_type: "code",
+      client_id: application.uid,
+      redirect_uri: application.redirect_uri,
+      code_challenge: "x" * 43,
+      code_challenge_method: "S256",
+      state: "abc123",
+      scope: "events:read events:write"
+    }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Poke")
+  end
+end


### PR DESCRIPTION
## What

Adding Attend as an MCP 500'd on the consent screen (`/mcp/oauth/authorize`) — Sentry [ATTEND-9X](https://hack-club-hcb.sentry.io/issues/ATTEND-9X).

## Why

The consent page is rendered by a toolchest *engine* controller inside the app's `layouts/application`. Engine view contexts resolve polymorphic URLs against the engine's route set, which lacks Active Storage's `resolve` mappings — so `image_tag current_user.avatar.variant(...)` in the layout raised `undefined method 'to_model' for ActiveStorage::VariantWithRecord` for any user with an avatar. Toolchest's route delegation only covers named `_path`/`_url` helpers, not polymorphic resolution.

## Fix

Route the layout's two avatar variants through `main_app.url_for(...)`, which resolves against the main app's route set in both engine and main-app contexts.

Regression spec included: it fails on the old layout and passes with the fix.

Fixes ATTEND-9X