### PR TITLE
Sync the design.json sidecar with DESIGN.md's Deepened Red Rule

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-08-13T16:43:40Z",
+  "generatedAt": "2026-08-22T15:33:38Z",
   "title": "Design System: Attend",
   "extensions": {
     "colorMeta": {
@@ -228,7 +228,7 @@
       },
       {
         "name": "The Deepened Red Rule",
-        "body": "#ec3750 on white measures 4.02:1 — below WCAG AA's 4.5:1 for normal text. WCAG's large-text exemption (3:1) starts at 18.66px bold or 24px regular, which no button in Attend reaches, so the type cannot buy its way out. The colour moves instead: wherever white text sits on red, the fill is #d42f46 (4.89:1), hovering to #b82840. #ec3750 keeps every use that carries no text on it — dots, bars, icon fills, borders, tints, and the progress bar. The two reds are one perceptual step apart; nobody sees the difference, and every white label clears AA.",
+        "body": "#ec3750 on white measures 4.02:1 — below WCAG AA's 4.5:1 for normal text. WCAG's large-text exemption (3:1) starts at 18.66px bold or 24px regular, which no button in Attend reaches, so the type cannot buy its way out. The colour moves instead: wherever white text sits on red, the fill is #d42f46 (4.89:1), hovering to #b82840. #ec3750 keeps every use that carries no text on it — dots, bars, icon fills, borders, tints, and the progress bar. The two reds are one perceptual step apart; nobody sees the difference, and every white label clears AA. Themes whose own --accent already clears their --accent-on (all six Catppuccin/Dracula/Nord variants) inherit this for free; dark and solarized-dark declare --accent-fill / --accent-fill-hover because theirs do not.",
         "section": "colors"
       },
       {


### PR DESCRIPTION
The `.impeccable/design.json` sidecar was generated mid-way through the text-white fix (#28), so it already carried the Theme Foreground Rule but missed the sentence that commit appended to **The Deepened Red Rule**: the six pastel-accent themes (Catppuccin ×4, Dracula, Nord) clear AA on their own `--accent`/`--accent-on` pair, while `dark` and `solarized-dark` declare `--accent-fill` / `--accent-fill-hover`.

Also bumps `generatedAt`, which clears the stale-sidecar hint. No changes to DESIGN.md or any app code.