### PR TITLE
Link the debug footer's git ref to its GitHub commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
 # See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
 
-# Ignore git directory.
-/.git/
+# Keep /.git/ in the build context: the build stage reads the commit sha from
+# it for the debug footer's REVISION file, then deletes it before the final
+# image is assembled.
 /.gitignore
 
 # Ignore bundler config.

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,15 +43,17 @@ RUN bundle install && \
     # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495
     bundle exec bootsnap precompile -j 1 --gemfile
 
-# Git revision for debug footer (passed as build arg since .git is excluded)
+# Fallback revision for builds whose context has no .git directory
 ARG GIT_REVISION=unknown
 ENV GIT_REVISION=${GIT_REVISION}
 
 # Copy application code
 COPY . .
 
-# Write git revision for debug footer
-RUN echo "${GIT_REVISION}" > REVISION
+# Write git revision for debug footer, then drop .git so it never reaches the
+# final image
+RUN if [ -d .git ]; then git rev-parse HEAD > REVISION; else echo "${GIT_REVISION}" > REVISION; fi && \
+    rm -rf .git
 
 # Precompile bootsnap code for faster boot times.
 # -j 1 disable parallel compilation to avoid a QEMU bug: https://github.com/rails/bootsnap/issues/495

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,16 +36,19 @@ module ApplicationHelper
       rails_version: rails_version,
       ruby_version: ruby_version,
       commit: build_info[:commit],
+      commit_url: build_info[:commit_url],
       built_at: build_info[:built_at]
     }
   end
 
+  GITHUB_REPO_URL = "https://github.com/hackclub/attend"
+
   def git_build_info
     revision_file = Rails.root.join("REVISION")
-    commit = if revision_file.exist?
-      revision_file.read.strip[0, 7]
+    revision = if revision_file.exist?
+      revision_file.read.strip.presence
     elsif Rails.env.development?
-      `git rev-parse --short HEAD 2>/dev/null`.strip.presence
+      `git rev-parse HEAD 2>/dev/null`.strip.presence
     end
 
     built_at = if revision_file.exist?
@@ -54,7 +57,13 @@ module ApplicationHelper
       Time.current
     end
 
-    { commit: commit, built_at: built_at }
+    sha = revision if revision&.match?(/\A\h{7,40}\z/)
+
+    {
+      commit: sha ? sha[0, 7] : revision,
+      commit_url: sha && "#{GITHUB_REPO_URL}/commit/#{sha}",
+      built_at: built_at
+    }
   end
 
   def google_maps_api_key

--- a/app/views/shared/_debug_footer.html.erb
+++ b/app/views/shared/_debug_footer.html.erb
@@ -3,7 +3,11 @@
     <% if info[:commit].present? && info[:built_at].present? %>
       <div class="mt-1 text-[10px] text-[#5a6473]">
         Built <%= time_ago_in_words(info[:built_at]) %> ago
-        <span class="font-mono">(<%= info[:commit] %>)</span>
+        <% if info[:commit_url] %>
+          <a href="<%= info[:commit_url] %>" target="_blank" rel="noopener" class="font-mono hover:underline">(<%= info[:commit] %>)</a>
+        <% else %>
+          <span class="font-mono">(<%= info[:commit] %>)</span>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
the admin debug footer showed `Built X minutes ago (unknown)` in production because Orchard's builder never passes the `GIT_REVISION` build arg the Dockerfile expected — the `REVISION` file was always baked as `unknown`.

Orchard *does* `git clone` the repo into the build workspace though, so the sha is available if we let `.git` into the build context:

- **.dockerignore**: stop excluding `/.git/` so the build stage can read it
- **Dockerfile**: write `REVISION` from `git rev-parse HEAD` when `.git` is a directory (Orchard's clone), keep the `GIT_REVISION` build-arg fallback otherwise, and `rm -rf .git` in the same layer so it never reaches the final image (a worktree's `.git` file is skipped by the `-d` check, which is correct — it would dangle inside a container)
- **footer**: the short sha now links to `https://github.com/hackclub/attend/commit/<sha>`; values that don't look like a sha (e.g. `unknown`) render as plain text with no link