### PR TITLE
Fix unresponsive MCP authorize button; add Connections section to profile

### DIFF
--- a/app/controllers/concerns/toolchest_redirect_form_action.rb
+++ b/app/controllers/concerns/toolchest_redirect_form_action.rb
@@ -1,0 +1,36 @@
+# The MCP OAuth consent screen posts back to the app, and the server then
+# 302s to the client's redirect_uri (poke.com, claude.ai, ...). Browsers
+# enforce the consent page's form-action across that whole redirect chain,
+# and MCP clients register arbitrary callback hosts, so the global allowlist
+# in the CSP initializer can't name them. Instead, consent-flow responses
+# append the one redirect_uri origin toolchest has already validated against
+# the client's registration (validate_client! halts with a 400 on any
+# mismatch before this before_action runs).
+module ToolchestRedirectFormAction
+  extend ActiveSupport::Concern
+
+  included do
+    content_security_policy do |policy|
+      source = redirect_uri_form_action_source
+      if source
+        existing = policy.directives["form-action"] || []
+        policy.form_action(*existing, source)
+      end
+    end
+  end
+
+  private
+
+  def redirect_uri_form_action_source
+    uri = URI.parse(params[:redirect_uri].to_s)
+    if %w[http https].include?(uri.scheme) && uri.host.present?
+      port = (":#{uri.port}" unless uri.port == uri.default_port)
+      "#{uri.scheme}://#{uri.host}#{port}"
+    elsif uri.scheme.present?
+      # Native clients can register custom-scheme callbacks (cursor://...).
+      "#{uri.scheme}:"
+    end
+  rescue URI::InvalidURIError
+    nil
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -31,6 +31,23 @@ class DashboardController < ApplicationController
       .map { |assignments| [ assignments.first.event, assignments.all?(&:hidden_from_public_profile) ] }
       .sort_by { |event, _hidden| event.starts_at || Time.current }
       .reverse
+    @mcp_connections = mcp_connections
+  end
+
+  # Disconnect an MCP client: revoke every live token and pending grant this
+  # user holds for the application. The application row itself stays (it's a
+  # global client registration, not per-user).
+  def revoke_mcp_connection
+    application = Toolchest::OauthApplication.find_by(id: params[:id])
+
+    if application
+      Toolchest::OauthAccessToken.revoke_all_for(application, current_user.id)
+      Toolchest::OauthAccessGrant.revoke_all_for(application, current_user.id)
+      redirect_to dashboard_profile_path(anchor: "connections"),
+        notice: "#{application.name} has been disconnected."
+    else
+      redirect_to dashboard_profile_path(anchor: "connections"), alert: "Connection not found."
+    end
   end
 
   def update_public_profile
@@ -365,6 +382,27 @@ class DashboardController < ApplicationController
       .update_all(hidden_from_public_profile: false)
     eligible_scope.where(event_id: eligible_event_ids - visible_event_ids)
       .update_all(hidden_from_public_profile: true)
+  end
+
+  # Live MCP connections for the signed-in user, one row per client
+  # application. Mirrors toolchest's own authorized-applications semantics:
+  # a connection counts as live while any token for the app is unrevoked
+  # (access tokens expire in hours, but the client keeps refreshing them).
+  def mcp_connections
+    tokens = Toolchest::OauthAccessToken
+      .where(resource_owner_id: current_user.id.to_s, revoked_at: nil)
+      .includes(:application)
+
+    tokens.group_by(&:application).filter_map do |application, app_tokens|
+      next unless application
+
+      {
+        application: application,
+        scopes: app_tokens.flat_map(&:scopes_array).uniq.sort,
+        connected_at: app_tokens.map(&:created_at).min,
+        last_used_at: app_tokens.map(&:updated_at).max
+      }
+    end.sort_by { |connection| connection[:connected_at] }.reverse
   end
 
   def require_participant

--- a/app/views/dashboard/profile.html.erb
+++ b/app/views/dashboard/profile.html.erb
@@ -34,6 +34,12 @@
         </svg>
         Public profile
       </a>
+      <a href="#connections" class="flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium text-(--text) hover:bg-(--bg-elev-2) hover:text-(--text-strong) transition-colors">
+        <svg class="size-4 text-(--text-muted)" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"/>
+        </svg>
+        Connections
+      </a>
       <a href="#appearance" class="flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium text-(--text) hover:bg-(--bg-elev-2) hover:text-(--text-strong) transition-colors">
         <svg class="size-4 text-(--text-muted)" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
@@ -264,6 +270,57 @@
             </div>
           <% end %>
         </div>
+      </section>
+
+      <!-- Connections -->
+      <section id="connections" class="scroll-mt-8">
+        <h2 class="border-b border-(--border-soft) pb-3 text-xl font-semibold text-(--text-strong)">Connections</h2>
+        <p class="mt-3 text-sm text-(--text-muted)">
+          Apps connected to your Attend account through
+          <a href="https://attend.hackclub.com/mcp" class="font-medium text-(--text-link) hover:underline">MCP</a>.
+          They act as you, limited to the scopes you approved. Disconnecting one signs it out immediately.
+        </p>
+
+        <% if @mcp_connections.any? %>
+          <div class="mt-4 overflow-hidden rounded-2xl border border-(--border-card) bg-(--bg-elev)">
+            <ul class="divide-y divide-(--border-soft)">
+              <% @mcp_connections.each do |connection| %>
+                <li class="px-6 py-4">
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div class="min-w-0">
+                      <p class="text-sm font-semibold text-(--text-strong)"><%= connection[:application].name %></p>
+                      <p class="mt-0.5 text-xs text-(--text-muted)">
+                        Connected <%= connection[:connected_at].strftime("%b %-d, %Y") %>
+                        <% if connection[:last_used_at] %>
+                          · Last active <%= time_ago_in_words(connection[:last_used_at]) %> ago
+                        <% end %>
+                      </p>
+                      <% if connection[:scopes].any? %>
+                        <div class="mt-2 flex flex-wrap gap-1.5">
+                          <% connection[:scopes].each do |scope| %>
+                            <% sensitive = scope.start_with?("medical:", "safeguarding:") %>
+                            <span class="inline-flex rounded-md px-1.5 py-0.5 font-mono text-[11px] <%= sensitive ? "bg-(--warning)/15 text-(--warning)" : "bg-(--bg-elev-2) text-(--text-muted)" %>">
+                              <%= scope %>
+                            </span>
+                          <% end %>
+                        </div>
+                      <% end %>
+                    </div>
+                    <%= button_to "Disconnect",
+                        dashboard_mcp_connection_path(connection[:application]),
+                        method: :delete,
+                        data: { turbo_confirm: "Disconnect #{connection[:application].name}? It will lose access to your Attend account immediately." },
+                        class: "shrink-0 rounded-lg border border-(--border-card) px-3 py-1.5 text-sm font-medium text-(--danger) hover:bg-(--danger)/10 transition-colors cursor-pointer" %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% else %>
+          <div class="mt-4 rounded-2xl border border-dashed border-(--border-card) bg-(--bg-elev) px-6 py-8 text-center text-sm text-(--text-muted)">
+            Nothing is connected to your account.
+          </div>
+        <% end %>
       </section>
 
       <!-- Appearance -->

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -34,6 +34,16 @@ Rails.application.configure do
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w[script-src]
 
+  # The MCP OAuth consent screen needs form-action to also cover the client's
+  # registered redirect_uri — same redirect-chain enforcement as the HCA note
+  # above, but the hosts are per-client, so it's appended per request instead
+  # of listed here. See ToolchestRedirectFormAction.
+  config.to_prepare do
+    unless Toolchest::Oauth::AuthorizationsController < ToolchestRedirectFormAction
+      Toolchest::Oauth::AuthorizationsController.include(ToolchestRedirectFormAction)
+    end
+  end
+
   # Enforced, not report-only. script-src has no `unsafe-inline`, so injected
   # markup can't run: an <img onerror=...> smuggled into a participant's name
   # is inert even if some future template forgets to escape it. Keeping this

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
   get "dashboard", to: "dashboard#index"
   get "dashboard/profile", to: "dashboard#profile", as: :dashboard_profile
   patch "dashboard/public_profile", to: "dashboard#update_public_profile", as: :dashboard_public_profile
+  delete "dashboard/mcp_connections/:id", to: "dashboard#revoke_mcp_connection", as: :dashboard_mcp_connection
   post "theme", to: "themes#update", as: :update_theme
   get "dashboard/events/:id", to: "dashboard#show", as: :dashboard_event
   get "dashboard/events/:id/google_wallet", to: "dashboard#google_wallet", as: :dashboard_google_wallet

--- a/spec/requests/dashboard_mcp_connections_spec.rb
+++ b/spec/requests/dashboard_mcp_connections_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# The Connections section on /dashboard/profile lists the MCP clients a user
+# has authorized (one row per application, scopes merged across tokens) and
+# lets them disconnect one, which revokes every live token and grant.
+RSpec.describe "Dashboard MCP connections", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+  let!(:participant) { create(:participant, user: user) }
+
+  let(:application) do
+    Toolchest::OauthApplication.create!(
+      name: "Poke",
+      redirect_uri: "https://poke.example.com/api/v1/mcp/callback"
+    )
+  end
+
+  before { sign_in user }
+
+  def create_token(scopes:, resource_owner: user)
+    Toolchest::OauthAccessToken.create_for(
+      application: application,
+      resource_owner_id: resource_owner.id,
+      scopes: scopes
+    )
+  end
+
+  describe "GET /dashboard/profile" do
+    it "lists a connected application with its merged scopes" do
+      create_token(scopes: "events:read")
+      create_token(scopes: "events:read participants:read")
+
+      get dashboard_profile_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Connections")
+      expect(response.body).to include("Poke")
+      expect(response.body).to include("events:read")
+      expect(response.body).to include("participants:read")
+    end
+
+    it "does not list revoked connections or other users' connections" do
+      create_token(scopes: "events:read").revoke!
+      other_user = create(:user)
+      create_token(scopes: "events:read", resource_owner: other_user)
+
+      get dashboard_profile_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Nothing is connected to your account.")
+    end
+  end
+
+  describe "DELETE /dashboard/mcp_connections/:id" do
+    it "revokes the user's tokens and grants for the application" do
+      token = create_token(scopes: "events:read")
+      grant = Toolchest::OauthAccessGrant.create_for(
+        application: application,
+        resource_owner_id: user.id,
+        redirect_uri: application.redirect_uri,
+        scopes: "events:read"
+      )
+      other_user = create(:user)
+      other_token = create_token(scopes: "events:read", resource_owner: other_user)
+
+      delete dashboard_mcp_connection_path(application)
+
+      expect(response).to redirect_to(dashboard_profile_path(anchor: "connections"))
+      expect(token.reload).to be_revoked
+      expect(grant.reload).to be_revoked
+      expect(other_token.reload).not_to be_revoked
+    end
+
+    it "handles an unknown application id" do
+      delete dashboard_mcp_connection_path(id: 999_999)
+
+      expect(response).to redirect_to(dashboard_profile_path(anchor: "connections"))
+      expect(flash[:alert]).to eq("Connection not found.")
+    end
+  end
+end

--- a/spec/requests/toolchest_oauth_consent_spec.rb
+++ b/spec/requests/toolchest_oauth_consent_spec.rb
@@ -27,10 +27,8 @@ RSpec.describe "Toolchest OAuth consent screen", type: :request do
     )
   end
 
-  it "renders for a user with an avatar" do
-    sign_in user
-
-    get "/mcp/oauth/authorize", params: {
+  def consent_params(overrides = {})
+    {
       response_type: "code",
       client_id: application.uid,
       redirect_uri: application.redirect_uri,
@@ -38,9 +36,53 @@ RSpec.describe "Toolchest OAuth consent screen", type: :request do
       code_challenge_method: "S256",
       state: "abc123",
       scope: "events:read events:write"
-    }
+    }.merge(overrides)
+  end
+
+  it "renders for a user with an avatar" do
+    sign_in user
+
+    get "/mcp/oauth/authorize", params: consent_params
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include("Poke")
+  end
+
+  # The Authorize button posts back to the app, which 302s to the client's
+  # redirect_uri. Browsers enforce the consent page's form-action across that
+  # redirect chain, so the validated redirect origin has to be in the header
+  # or clicking Authorize silently does nothing (ATTEND: Poke connect bug).
+  it "allowlists the client's redirect_uri origin in form-action" do
+    sign_in user
+
+    get "/mcp/oauth/authorize", params: consent_params
+
+    form_action = response.headers["Content-Security-Policy"][/form-action[^;]*/]
+    expect(form_action).to include("'self'")
+    expect(form_action).to include("https://poke.example.com")
+  end
+
+  it "does not leak the redirect origin into other pages' form-action" do
+    sign_in user
+
+    get "/dashboard/profile"
+
+    form_action = response.headers["Content-Security-Policy"][/form-action[^;]*/]
+    expect(form_action).not_to include("poke.example.com")
+  end
+
+  it "issues a code and redirects to the client when the user authorizes" do
+    sign_in user
+
+    post "/mcp/oauth/authorize", params: consent_params(
+      scope: [ "events:read", "events:write" ],
+      original_scope: "events:read events:write"
+    )
+
+    expect(response).to have_http_status(:found)
+    location = response.headers["Location"]
+    expect(location).to start_with("https://poke.example.com/api/v1/mcp/callback?")
+    expect(location).to include("state=abc123")
+    expect(location).to match(/code=[\w-]+/)
   end
 end


### PR DESCRIPTION
## what

**1. the Authorize button on the MCP OAuth consent screen did nothing when clicked.**

CSP bug, not a JS bug: `form-action` is locked to self + docuseal + auth.hackclub.com, and browsers enforce form-action across the whole redirect chain of a form submission. The Authorize POST goes to `/mcp/oauth/authorize` (allowed), but the server 302s to the client's callback (e.g. `https://poke.com/api/v1/mcp/callback`), which the browser silently blocks — same failure mode the initializer already documents for HCA sign-in. MCP clients register arbitrary callback hosts, so a static allowlist can't cover them.

Fix: new `ToolchestRedirectFormAction` concern, included into the toolchest engine's authorize controller via `to_prepare`. It appends only the request's `redirect_uri` origin to form-action, and it runs after toolchest's `validate_client!` (which 400s on any redirect_uri not matching the client's registration), so only registered origins are ever allowlisted. Custom-scheme callbacks for native clients are handled too.

**2. a Connections section on /dashboard/profile** (new nav entry alongside Account / Public profile / Appearance) showing each MCP client connected to your account — connected date, last activity, granted scopes as chips (medical/safeguarding highlighted) — with a Disconnect button that revokes all of that app's tokens and grants for you via the toolchest models' `revoke_all_for`.

## testing

- new request specs: consent page's form-action includes the client origin, doesn't leak onto other pages, full authorize POST → code redirect works
- new request specs for the connections list + revoke (revoked/other-user tokens excluded; disconnect doesn't touch other users' tokens; unknown app id handled)
- existing CSP spec (24 examples) and public-profile spec still green