### PR TITLE
Fix wallet device registration race (ATTEND-7R)

### DIFF
--- a/config/initializers/passkit_extensions.rb
+++ b/config/initializers/passkit_extensions.rb
@@ -71,9 +71,27 @@ module PasskitPassesControllerExtensions
   end
 end
 
+# Concurrent registrations for the same device race find_or_create_by!:
+# the loser fails Passkit::Device's uniqueness validation with RecordInvalid,
+# which find_or_create_by! doesn't recover from (it only rescues the
+# db-level RecordNotUnique). Retrying once finds the winner's row. (ATTEND-7R)
+module PasskitRegistrationsControllerExtensions
+  def register_device
+    retried = false
+    begin
+      super
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      raise if retried
+      retried = true
+      retry
+    end
+  end
+end
+
 Rails.application.config.after_initialize do
   next if ENV["SECRET_KEY_BASE_DUMMY"]
 
   Passkit::Generator.prepend(PasskitGeneratorExtensions)
   Passkit::Api::V1::PassesController.prepend(PasskitPassesControllerExtensions)
+  Passkit::Api::V1::RegistrationsController.prepend(PasskitRegistrationsControllerExtensions)
 end

--- a/db/migrate/20260824090000_add_unique_index_to_passkit_devices_identifier.rb
+++ b/db/migrate/20260824090000_add_unique_index_to_passkit_devices_identifier.rb
@@ -1,0 +1,48 @@
+class AddUniqueIndexToPasskitDevicesIdentifier < ActiveRecord::Migration[8.0]
+  def up
+    # Dedupe first: concurrent wallet registrations could insert the same
+    # identifier twice (ATTEND-7R), so the index would fail to build if any
+    # duplicates already exist. Keep the newest device per identifier (it has
+    # the freshest push_token), repoint registrations at it, drop the rest.
+    duplicate_ids = select_rows(<<~SQL)
+      SELECT identifier, (array_agg(id ORDER BY updated_at DESC, id DESC))[1] AS keeper_id
+      FROM passkit_devices
+      WHERE identifier IS NOT NULL
+      GROUP BY identifier
+      HAVING COUNT(*) > 1
+    SQL
+
+    duplicate_ids.each do |identifier, keeper_id|
+      loser_ids = select_values(
+        "SELECT id FROM passkit_devices WHERE identifier = #{quote(identifier)} AND id != #{quote(keeper_id)}"
+      )
+      next if loser_ids.empty?
+
+      quoted_losers = loser_ids.map { |id| quote(id) }.join(", ")
+
+      # Drop registrations that would become duplicates of one the keeper
+      # already has, then move the remainder over.
+      execute(<<~SQL)
+        DELETE FROM passkit_registrations lr
+        USING passkit_registrations kr
+        WHERE lr.passkit_device_id IN (#{quoted_losers})
+          AND kr.passkit_device_id = #{quote(keeper_id)}
+          AND kr.passkit_pass_id = lr.passkit_pass_id
+      SQL
+
+      execute(<<~SQL)
+        UPDATE passkit_registrations
+        SET passkit_device_id = #{quote(keeper_id)}
+        WHERE passkit_device_id IN (#{quoted_losers})
+      SQL
+
+      execute("DELETE FROM passkit_devices WHERE id IN (#{quoted_losers})")
+    end
+
+    add_index :passkit_devices, :identifier, unique: true
+  end
+
+  def down
+    remove_index :passkit_devices, :identifier
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -876,6 +876,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_15_120000) do
     t.string "identifier"
     t.string "push_token"
     t.datetime "updated_at", null: false
+    t.index ["identifier"], name: "index_passkit_devices_on_identifier", unique: true
   end
 
   create_table "passkit_logs", force: :cascade do |t|

--- a/spec/requests/passkit_registrations_spec.rb
+++ b/spec/requests/passkit_registrations_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe "Passkit device registrations", type: :request do
     )
   end
   let(:device_id) { SecureRandom.hex(16) }
-  let(:headers) { {"Authorization" => "ApplePass #{pass.authentication_token}"} }
+  let(:headers) { { "Authorization" => "ApplePass #{pass.authentication_token}" } }
 
   def register
     post "/passkit/api/v1/devices/#{device_id}/registrations/pass.com.hackclub.attend/#{pass.serial_number}",
-      params: {pushToken: "token-123"}.to_json,
+      params: { pushToken: "token-123" }.to_json,
       headers: headers.merge("CONTENT_TYPE" => "application/json")
   end
 

--- a/spec/requests/passkit_registrations_spec.rb
+++ b/spec/requests/passkit_registrations_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "Passkit device registrations", type: :request do
+  let(:pass) do
+    Passkit::Pass.create!(
+      klass: "Passkit::EventTicket",
+      serial_number: SecureRandom.uuid,
+      authentication_token: SecureRandom.hex(16)
+    )
+  end
+  let(:device_id) { SecureRandom.hex(16) }
+  let(:headers) { {"Authorization" => "ApplePass #{pass.authentication_token}"} }
+
+  def register
+    post "/passkit/api/v1/devices/#{device_id}/registrations/pass.com.hackclub.attend/#{pass.serial_number}",
+      params: {pushToken: "token-123"}.to_json,
+      headers: headers.merge("CONTENT_TYPE" => "application/json")
+  end
+
+  it "registers a new device" do
+    register
+
+    expect(response).to have_http_status(:created)
+    expect(Passkit::Device.find_by(identifier: device_id)).to be_present
+  end
+
+  it "returns ok when the device is already registered" do
+    register
+    register
+
+    expect(response).to have_http_status(:ok)
+    expect(Passkit::Registration.where(passkit_pass_id: pass.id).count).to eq(1)
+  end
+
+  it "recovers when a concurrent registration wins the uniqueness race (ATTEND-7R)" do
+    # Simulate the race: the first find_or_create_by! loses to a concurrent
+    # request whose row commits between our find and create, raising
+    # RecordInvalid from the gem's uniqueness validation.
+    calls = 0
+    allow(Passkit::Device).to receive(:find_or_create_by!).and_wrap_original do |original, *args, &block|
+      calls += 1
+      if calls == 1
+        Passkit::Device.create!(identifier: device_id, push_token: "winner-token")
+        record = Passkit::Device.new(identifier: device_id)
+        record.errors.add(:identifier, :taken)
+        raise ActiveRecord::RecordInvalid, record
+      end
+      original.call(*args, &block)
+    end
+
+    register
+
+    expect(response).to have_http_status(:created)
+    expect(Passkit::Device.where(identifier: device_id).count).to eq(1)
+    expect(Passkit::Registration.where(passkit_pass_id: pass.id).count).to eq(1)
+  end
+
+  it "does not retry forever when the failure is not transient" do
+    allow(Passkit::Device).to receive(:find_or_create_by!) do
+      record = Passkit::Device.new
+      record.errors.add(:identifier, :taken)
+      raise ActiveRecord::RecordInvalid, record
+    end
+
+    register
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(Passkit::Device).to have_received(:find_or_create_by!).twice
+  end
+end


### PR DESCRIPTION
## What

Fixes [ATTEND-7R](https://hack-club-hcb.sentry.io/issues/7610306310/): `ActiveRecord::RecordInvalid: Validation failed: Identifier has already been taken` in `Passkit::Api::V1::RegistrationsController#create` (10 occurrences since July 14).

## Why

When an iPhone registers a wallet pass for push updates, concurrent registration requests from the same device race the passkit gem's `Passkit::Device.find_or_create_by!`. The loser fails the gem's *validation-level* uniqueness check on `identifier`, raising `RecordInvalid` — which `find_or_create_by!` doesn't recover from, since it only rescues the db-level `RecordNotUnique`. Our `passkit_devices` table also had no unique index, so a tight race could insert duplicate device rows.

## How

- **Retry patch** in `config/initializers/passkit_extensions.rb` (existing prepend pattern): `register_device` retries once on `RecordInvalid`/`RecordNotUnique`, so the loser finds the winner's row and returns 201 as intended.
- **Migration** adds a unique index on `passkit_devices.identifier`, deduping any existing duplicates first (repointing registrations at the newest device per identifier) so the index build can't fail and crash-loop the deploy.

## Testing

New request specs cover: fresh registration, already-registered (200), the simulated race (recovers, single device row), and non-transient failures (retries exactly once, no infinite loop).

Fixes ATTEND-7R