### PR TITLE
Hide accommodation tab and overview card when accommodation is disabled

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -251,11 +251,15 @@ module Admin
 
     def accommodation
       authorize @participant_event, :view_accommodation?
+      return redirect_to admin_event_participant_path(current_event, @participant_event), alert: "Accommodation is disabled for this event." unless current_event.accommodation_enabled?
+
       @accommodation = @participant_event.accommodation || @participant_event.build_accommodation
     end
 
     def update_accommodation
       authorize @participant_event, :update_accommodation?
+      return redirect_to admin_event_participant_path(current_event, @participant_event), alert: "Accommodation is disabled for this event." unless current_event.accommodation_enabled?
+
       @accommodation = @participant_event.accommodation || @participant_event.build_accommodation
 
       if @accommodation.update(accommodation_params)

--- a/app/views/admin/participants/_header.html.erb
+++ b/app/views/admin/participants/_header.html.erb
@@ -82,8 +82,10 @@
       <%= link_to "Travel", travel_admin_event_participant_path(current_event, @participant_event),
           class: "py-3 px-1 border-b-2 #{action_name == 'travel' ? 'border-[#ec3750] text-[#ec3750]' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>
     <% end %>
-    <%= link_to "Accommodation", accommodation_admin_event_participant_path(current_event, @participant_event),
-        class: "py-3 px-1 border-b-2 #{action_name == 'accommodation' ? 'border-[#ec3750] text-[#ec3750]' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>
+    <% if current_event.accommodation_enabled? %>
+      <%= link_to "Accommodation", accommodation_admin_event_participant_path(current_event, @participant_event),
+          class: "py-3 px-1 border-b-2 #{action_name == 'accommodation' ? 'border-[#ec3750] text-[#ec3750]' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>
+    <% end %>
     <% if policy(@participant_event.medical || Medical.new(participant_event: @participant_event)).show? %>
       <%= link_to "Medical", medical_admin_event_participant_path(current_event, @participant_event),
           class: "py-3 px-1 border-b-2 #{action_name == 'medical' ? 'border-[#ec3750] text-[#ec3750]' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -118,6 +118,7 @@
         <% end %>
       </section>
 
+      <% if current_event.accommodation_enabled? %>
       <section class="bg-white rounded-lg border border-gray-200 p-6">
         <div class="flex justify-between items-center mb-4">
           <h2 class="text-lg font-semibold">Accommodation</h2>
@@ -162,6 +163,7 @@
           <p class="text-gray-500">No accommodation information provided.</p>
         <% end %>
       </section>
+      <% end %>
 
       <% if policy(@medical || Medical.new(participant_event: @participant_event)).show? %>
         <section class="bg-white rounded-lg border border-gray-200 p-6">
@@ -382,10 +384,12 @@
             <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @travel_outbound ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
             <span class="text-sm">Outbound Travel</span>
           </li>
-          <li class="flex items-center gap-2">
-            <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @accommodation ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
-            <span class="text-sm">Accommodation</span>
-          </li>
+          <% if current_event.accommodation_enabled? %>
+            <li class="flex items-center gap-2">
+              <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @accommodation ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
+              <span class="text-sm">Accommodation</span>
+            </li>
+          <% end %>
           <li class="flex items-center gap-2">
             <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @medical ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
             <span class="text-sm">Medical</span>

--- a/spec/requests/admin/participants_spec.rb
+++ b/spec/requests/admin/participants_spec.rb
@@ -43,6 +43,36 @@ RSpec.describe "Admin::Participants", type: :request do
     end
   end
 
+  describe "accommodation when disabled for the event" do
+    let(:participant_event) { create(:participant_event, event: event) }
+
+    before { sign_in global_admin }
+
+    it "hides the Accommodation tab on the participant page" do
+      get admin_event_participant_path(event, participant_event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(accommodation_admin_event_participant_path(event, participant_event))
+    end
+
+    it "redirects direct visits to the accommodation page" do
+      get accommodation_admin_event_participant_path(event, participant_event)
+
+      expect(response).to redirect_to(admin_event_participant_path(event, participant_event))
+      expect(flash[:alert]).to include("Accommodation is disabled")
+    end
+
+    it "shows the tab and page when accommodation is enabled" do
+      event.update!(accommodation_enabled: true)
+
+      get admin_event_participant_path(event, participant_event)
+      expect(response.body).to include(accommodation_admin_event_participant_path(event, participant_event))
+
+      get accommodation_admin_event_participant_path(event, participant_event)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "POST sync_slack_channel" do
     include ActiveJob::TestHelper
 


### PR DESCRIPTION
The Travel tab was gated on `travel_enabled?` but the Accommodation tab, the overview card, and the onboarding-progress row rendered unconditionally when accommodation was disabled for an event.

- Gate the Accommodation tab in `_header.html.erb` on `current_event.accommodation_enabled?`
- Gate the accommodation card and onboarding-progress row on the participant overview page
- Redirect direct visits to the accommodation view/update actions with an alert when the module is disabled
- Request specs for tab hidden, direct-visit redirect, and re-enabled behavior