### PR TITLE
Prevent removing series owners/organizers at the event level

### DIFF
--- a/app/controllers/admin/event_setup_controller.rb
+++ b/app/controllers/admin/event_setup_controller.rb
@@ -81,6 +81,13 @@ module Admin
 
     def remove_team_member
       @event_role_assignment = @event.event_role_assignments.find(params[:assignment_id])
+
+      if @event_role_assignment.inherited_from_series?
+        redirect_to admin_event_setup_team_path(@event),
+          alert: "#{@event_role_assignment.user.email} is a series #{@event_role_assignment.series_role} — their access is inherited from the series, so they can't be removed here."
+        return
+      end
+
       @event_role_assignment.destroy
       redirect_to admin_event_setup_team_path(@event), notice: "Staff member removed."
     end

--- a/app/controllers/admin/event_staff_controller.rb
+++ b/app/controllers/admin/event_staff_controller.rb
@@ -41,6 +41,12 @@ module Admin
     end
 
     def destroy
+      if @event_role_assignment.inherited_from_series?
+        redirect_to admin_event_staff_index_path(current_event),
+          alert: "#{@event_role_assignment.user.email} is a series #{@event_role_assignment.series_role} — their access is inherited from the series, so they can't be removed here. Manage them from the series members page."
+        return
+      end
+
       @event_role_assignment.destroy
       redirect_to admin_event_staff_index_path(current_event), notice: "Staff member removed."
     end

--- a/app/models/event_role_assignment.rb
+++ b/app/models/event_role_assignment.rb
@@ -75,4 +75,18 @@ class EventRoleAssignment < ApplicationRecord
   validates :user_id, presence: true
   validates :event_id, presence: true
   validates :role, presence: true, uniqueness: { scope: %i[user_id event_id] }
+
+  # Series owners and organizers act as event admins on every event in their
+  # series, so their access to this event is inherited from the series rather
+  # than granted by this row. Inherited members are managed from the series
+  # members page and can't be removed at the event level.
+  def inherited_from_series?
+    series_role.present?
+  end
+
+  def series_role
+    return nil if event.event_series_id.blank?
+
+    SeriesRoleAssignment.find_by(user_id: user_id, event_series_id: event.event_series_id)&.role
+  end
 end

--- a/app/views/admin/event_setup/team.html.erb
+++ b/app/views/admin/event_setup/team.html.erb
@@ -15,7 +15,13 @@
               <p class="text-sm font-medium text-gray-900"><%= assignment.user.email %></p>
               <p class="text-xs text-gray-500"><%= EventRoleAssignment::ROLE_DETAILS.dig(assignment.role, :label) || assignment.role.humanize %></p>
             </div>
-            <%= button_to "Remove", admin_event_setup_team_member_path(@event, assignment), method: :delete, class: "text-sm text-gray-400 hover:text-red-600 font-medium cursor-pointer", form: { data: { turbo_confirm: "Remove #{assignment.user.email} from #{@event.name}?" } } %>
+            <% if assignment.inherited_from_series? %>
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800" title="Series <%= assignment.series_role %>s act as event admins on every event in the series. Manage them from the series members page.">
+                Inherited from series
+              </span>
+            <% else %>
+              <%= button_to "Remove", admin_event_setup_team_member_path(@event, assignment), method: :delete, class: "text-sm text-gray-400 hover:text-red-600 font-medium cursor-pointer", form: { data: { turbo_confirm: "Remove #{assignment.user.email} from #{@event.name}?" } } %>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/admin/event_staff/index.html.erb
+++ b/app/views/admin/event_staff/index.html.erb
@@ -37,7 +37,13 @@
                 <%= assignment.created_at.strftime("%B %d, %Y") %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                <%= button_to "Remove", admin_event_staff_path(current_event, assignment), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to remove #{assignment.user.email} from this event?" } %>
+                <% if assignment.inherited_from_series? %>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800" title="Series <%= assignment.series_role %>s act as event admins on every event in the series. Manage them from the series members page.">
+                    Inherited from series
+                  </span>
+                <% else %>
+                  <%= button_to "Remove", admin_event_staff_path(current_event, assignment), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to remove #{assignment.user.email} from this event?" } %>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/spec/requests/admin/event_setup_spec.rb
+++ b/spec/requests/admin/event_setup_spec.rb
@@ -172,6 +172,31 @@ RSpec.describe "Admin::EventSetup", type: :request do
     end
   end
 
+  describe "DELETE remove_team_member" do
+    let(:staff_user) { create(:user) }
+
+    it "removes a regular staff member" do
+      assignment = create(:event_role_assignment, event: event, user: staff_user, role: "event_admin")
+
+      expect {
+        delete admin_event_setup_team_member_path(event, assignment)
+      }.to change(EventRoleAssignment, :count).by(-1)
+    end
+
+    it "refuses to remove a series member whose access is inherited" do
+      series = create(:event_series)
+      event.update!(event_series: series)
+      create(:series_role_assignment, user: staff_user, event_series: series, role: "organizer")
+      assignment = create(:event_role_assignment, event: event, user: staff_user, role: "event_admin")
+
+      expect {
+        delete admin_event_setup_team_member_path(event, assignment)
+      }.not_to change(EventRoleAssignment, :count)
+
+      expect(flash[:alert]).to include("inherited from the series")
+    end
+  end
+
   describe "POST complete" do
     it "marks setup complete and lands on the event dashboard" do
       post admin_event_setup_complete_path(event)

--- a/spec/requests/admin/event_staff_spec.rb
+++ b/spec/requests/admin/event_staff_spec.rb
@@ -41,4 +41,49 @@ RSpec.describe "Admin::EventStaff", type: :request do
       }.not_to have_enqueued_mail(EventStaffMailer, :added_to_event)
     end
   end
+
+  describe "DELETE destroy" do
+    let(:staff_user) { create(:user) }
+
+    it "removes a regular staff member" do
+      assignment = create(:event_role_assignment, event: event, user: staff_user, role: "event_admin")
+
+      expect {
+        delete admin_event_staff_path(event_slug: event.slug, id: assignment.id)
+      }.to change(EventRoleAssignment, :count).by(-1)
+    end
+
+    context "when the staff member is a series owner or organizer" do
+      let(:series) { create(:event_series) }
+      let(:event) { create(:event, event_series: series) }
+
+      %w[owner organizer].each do |series_role|
+        it "refuses to remove a series #{series_role} whose access is inherited" do
+          create(:series_role_assignment, user: staff_user, event_series: series, role: series_role)
+          assignment = create(:event_role_assignment, event: event, user: staff_user, role: "event_admin")
+
+          expect {
+            delete admin_event_staff_path(event_slug: event.slug, id: assignment.id)
+          }.not_to change(EventRoleAssignment, :count)
+
+          expect(response).to redirect_to(admin_event_staff_index_path(event_slug: event.slug))
+          expect(flash[:alert]).to include("inherited from the series")
+        end
+      end
+    end
+  end
+
+  describe "GET index" do
+    it "shows an inherited badge instead of a remove button for series members" do
+      series = create(:event_series)
+      event.update!(event_series: series)
+      member = create(:user)
+      create(:series_role_assignment, user: member, event_series: series, role: "owner")
+      create(:event_role_assignment, event: event, user: member, role: "event_admin")
+
+      get admin_event_staff_index_path(event_slug: event.slug)
+
+      expect(response.body).to include("Inherited from series")
+    end
+  end
 end


### PR DESCRIPTION
## What

Series owners and organizers act as event admins on every event in their series — their access is **inherited**, not granted by an `event_role_assignment` row. But when one of them has an explicit row (e.g. auto-created when they create an event), the Event Staff page and the setup Team step showed a working **Remove** button. Removing the row wouldn't revoke their inherited access, so the button was misleading at best.

## Changes

- `EventRoleAssignment#inherited_from_series?` / `#series_role` — checks whether the assignment's user holds a series role on the event's series
- `Admin::EventStaffController#destroy` and `Admin::EventSetupController#remove_team_member` now refuse to remove inherited members with an explanatory alert, so it's enforced server-side regardless of how the request arrives
- Both views show an amber "Inherited from series" badge instead of the remove button

The series members page is unchanged — that remains the one place to manage series membership (owner-gated).

## Tests

Request specs covering the guard for both owner and organizer roles on both endpoints, plus regular staff removal still working and the badge rendering. 42 examples, 0 failures across the touched spec files.