### PR TITLE
Make Attend installable as a mobile PWA

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,24 @@ module ApplicationHelper
     "solarized-dark"         => "Solarized Dark"
   }.freeze
 
+  # Mirrors --bg-app in themes.css; <meta name="theme-color"> can't read CSS
+  # variables, so the browser-chrome color has to be rendered server-side.
+  THEME_COLORS = {
+    "light"                  => "#f9fafc",
+    "dark"                   => "#0f1115",
+    "catppuccin-latte"       => "#eff1f5",
+    "catppuccin-frappe"      => "#303446",
+    "catppuccin-macchiato"   => "#24273a",
+    "catppuccin-mocha"       => "#1e1e2e",
+    "dracula"                => "#282a36",
+    "nord"                   => "#2e3440",
+    "solarized-dark"         => "#002b36"
+  }.freeze
+
+  def current_theme_color
+    THEME_COLORS.fetch(current_theme, "#f9fafc")
+  end
+
   def current_theme
     raw = current_user.respond_to?(:theme) && current_user&.theme.presence
     raw ||= cookies[:attend_theme].presence

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,7 @@ import "controllers"
 import { startToggleHidden } from "utils/toggle_hidden"
 
 startToggleHidden()
+
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/service-worker", { scope: "/" })
+}

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="Attend">
+    <meta name="theme-color" content="<%= current_theme_color %>">
+    <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
 
     <title><%= content_for(:title) || "Admin – Attend – Hack Club" %></title>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Attend">
+    <meta name="theme-color" content="<%= current_theme_color %>">
+    <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
 
     <title><%= content_for(:title) || "Attend – Hack Club" %></title>
 

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="Attend">
+    <meta name="theme-color" content="<%= current_theme_color %>">
+    <link rel="manifest" href="<%= pwa_manifest_path(format: :json) %>">
 
     <title><%= content_for(:title) || "Support Chat – Attend – Hack Club" %></title>
 

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,7 @@
 {
-  "name": "Attend",
+  "name": "Attend – Hack Club",
+  "short_name": "Attend",
+  "description": "Hack Club event registration, travel, and check-in.",
   "icons": [
     {
       "src": "/icon-192.png",
@@ -18,10 +20,10 @@
       "purpose": "maskable"
     }
   ],
+  "id": "/",
   "start_url": "/",
-  "display": "standalone",
   "scope": "/",
-  "description": "Attend.",
-  "theme_color": "red",
-  "background_color": "red"
+  "display": "standalone",
+  "theme_color": "<%= current_theme_color %>",
+  "background_color": "<%= current_theme_color %>"
 }

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -1,3 +1,9 @@
+// Deliberately no fetch handler: every request goes straight to the network,
+// so Turbo pages can never go stale behind a cache. This worker exists so the
+// app is installable and ready for Web Push later.
+self.addEventListener("install", () => self.skipWaiting())
+self.addEventListener("activate", (event) => event.waitUntil(clients.claim()))
+
 // Add a service worker for processing Web Push notifications:
 //
 // self.addEventListener("push", async (event) => {


### PR DESCRIPTION
Wires up the Rails 8 PWA scaffolding that existed but was never linked into the pages.

- Link the manifest and register the service worker from all three layouts (application, admin, support); add the missing standalone/app-capable meta tags to admin and support
- Clean up the manifest: real name/short_name/description, and `theme_color`/`background_color` rendered server-side from the active theme's `--bg-app` (it previously said `"theme_color": "red"`)
- Add a matching `theme-color` meta tag so browser chrome follows the user's theme
- Keep the service worker fetch-handler-free — every request goes straight to the network so Turbo pages can never go stale behind a cache; install/activate handlers only, ready for Web Push later

Verified locally: `/manifest.json` renders with correct content-type and picks up the `attend_theme` cookie (dark → `#0f1115` in both manifest and meta tag), `/service-worker` serves as `text/javascript`, icons already existed in `public/`.

Result: Android Chrome offers a real install prompt; iOS "Add to Home Screen" opens Attend standalone full-screen.