### PR TITLE
Require a Hack Club support email on every event

### DIFF
--- a/app/controllers/admin/event_setup_controller.rb
+++ b/app/controllers/admin/event_setup_controller.rb
@@ -97,6 +97,12 @@ module Admin
     end
 
     def complete
+      if @event.support_email.blank?
+        redirect_to edit_admin_event_path(@event),
+          alert: "Set a support email (@hackclub.com or @events.hackclub.com) before finishing setup — it's the from and reply-to address on every participant and guardian email."
+        return
+      end
+
       @event.update!(setup_completed_at: Time.current) unless @event.setup_complete?
       redirect_to admin_event_dashboard_path(@event), notice: "#{@event.name} is ready to go!"
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -94,6 +94,25 @@ class Event < ApplicationRecord
   ].freeze
 
   validates :name, presence: true
+
+  # Support email is the from/reply-to on every participant- and guardian-facing
+  # email, so it has to be an address we actually control. Required from setup
+  # onwards; older events created before this rule keep passing validation until
+  # someone edits the field (hence allow_blank on the format check).
+  SUPPORT_EMAIL_DOMAINS = %w[hackclub.com events.hackclub.com].freeze
+  SUPPORT_EMAIL_FORMAT = /\A[^@\s]+@(?:#{SUPPORT_EMAIL_DOMAINS.map { |d| Regexp.escape(d) }.join("|")})\z/i
+
+  normalizes :support_email, with: ->(v) { v.strip.downcase.presence }
+
+  validates :support_email, presence: true, on: :create
+  validates :support_email, presence: true, on: :update, if: :support_email_changed?
+  validates :support_email,
+            format: {
+              with: SUPPORT_EMAIL_FORMAT,
+              message: "must be a #{SUPPORT_EMAIL_DOMAINS.map { |d| "@#{d}" }.join(" or ")} address"
+            },
+            allow_blank: true
+
   validates :slug, presence: true,
                    uniqueness: true,
                    format: { with: /\A[a-z0-9-]+\z/, message: "must be lowercase with no spaces (dashes allowed)" },

--- a/app/toolboxes/events_toolbox.rb
+++ b/app/toolboxes/events_toolbox.rb
@@ -34,7 +34,7 @@ class EventsToolbox < ApplicationToolbox
     param :location_city, :string, "City", optional: true
     param :location_country, :string, "Country", optional: true
     param :venue_name, :string, "Venue", optional: true
-    param :support_email, :string, "Support email", optional: true
+    param :support_email, :string, "Support email (@hackclub.com or @events.hackclub.com)"
   end
   def create
     @event = Event.new(params.permit(*WRITABLE).to_h)
@@ -53,7 +53,7 @@ class EventsToolbox < ApplicationToolbox
     param :location_city, :string, "City", optional: true
     param :location_country, :string, "Country", optional: true
     param :venue_name, :string, "Venue", optional: true
-    param :support_email, :string, "Support email", optional: true
+    param :support_email, :string, "Support email (@hackclub.com or @events.hackclub.com)", optional: true
     param :travel_enabled, :boolean, "Enable travel collection", optional: true
     param :accommodation_enabled, :boolean, "Enable accommodation", optional: true
     param :groups_enabled, :boolean, "Enable groups", optional: true

--- a/app/views/admin/event_setup/review.html.erb
+++ b/app/views/admin/event_setup/review.html.erb
@@ -15,7 +15,7 @@
       <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
         <div><dt class="text-gray-500 inline">Name:</dt> <dd class="inline text-gray-900"><%= @event.name %></dd></div>
         <div><dt class="text-gray-500 inline">Slug:</dt> <dd class="inline text-gray-900 font-mono"><%= @event.slug %></dd></div>
-        <div><dt class="text-gray-500 inline">Support email:</dt> <dd class="inline text-gray-900"><%= @event.support_email.presence || "team@hackclub.com (default)" %></dd></div>
+        <div><dt class="text-gray-500 inline">Support email:</dt> <dd class="inline <%= @event.support_email.present? ? "text-gray-900" : "text-amber-700 font-medium" %>"><%= @event.support_email.presence || "Not set — required" %></dd></div>
         <div><dt class="text-gray-500 inline">Timezone:</dt> <dd class="inline text-gray-900"><%= @event.timezone.presence || "Not set" %></dd></div>
       </dl>
     </div>
@@ -105,6 +105,13 @@
       <% end %>
     </div>
   </div>
+
+  <% if @event.support_email.blank? %>
+    <p class="mt-4 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-3 py-2">
+      This event needs a support email before setup can be finished — it's the from and reply-to address on participant and guardian emails.
+      Set a @hackclub.com or @events.hackclub.com address from <%= link_to "event settings", edit_admin_event_path(@event), class: "font-medium underline" %>.
+    </p>
+  <% end %>
 
   <div class="mt-6 flex flex-col sm:flex-row justify-end gap-3">
     <%= button_to "Finish setup", admin_event_setup_complete_path(@event), method: :post, class: "w-full sm:w-auto bg-[#d42f46] hover:bg-[#b82840] text-white font-semibold py-2 px-6 rounded-lg transition-colors cursor-pointer" %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -171,8 +171,8 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
         <%= f.label :support_email, "Support Email", class: "block text-sm font-medium text-gray-700" %>
-        <%= f.email_field :support_email, class: "mt-1 block w-full rounded-md border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", placeholder: "team@hackclub.com" %>
-        <p class="mt-1 text-sm text-gray-500">Used in guardian invitation emails. Defaults to team@hackclub.com if not set.</p>
+        <%= f.email_field :support_email, required: true, class: "mt-1 block w-full rounded-md border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", placeholder: "team@hackclub.com" %>
+        <p class="mt-1 text-sm text-gray-500">Used as the from and reply-to address on participant and guardian emails. Must be a @hackclub.com or @events.hackclub.com address.</p>
       </div>
     </div>
   </div>

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -47,8 +47,8 @@
         </div>
         <div>
           <%= f.label :support_email, "Support Email", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.email_field :support_email, class: "mt-1 block w-full rounded-md border-gray-300 focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", placeholder: "team@hackclub.com" %>
-          <p class="mt-1 text-sm text-gray-500">Used in guardian invitation emails. Defaults to team@hackclub.com if not set.</p>
+          <%= f.email_field :support_email, required: true, class: "mt-1 block w-full rounded-md border-gray-300 focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", placeholder: "team@hackclub.com" %>
+          <p class="mt-1 text-sm text-gray-500">Required. Sends and receives replies for participant and guardian emails — must be a @hackclub.com or @events.hackclub.com address.</p>
         </div>
         <div>
           <%= f.label :timezone, class: "block text-sm font-medium text-gray-700" %>

--- a/spec/models/event_series_spec.rb
+++ b/spec/models/event_series_spec.rb
@@ -87,13 +87,17 @@ RSpec.describe EventSeries, type: :model do
       expect(event.effective_support_email).to eq("own@hackclub.com")
     end
 
+    # New events must set a support email, so blank-support-email events only
+    # exist as legacy rows — hence update_column rather than the factory.
     it "falls back to the series contact email" do
-      event = create(:event, event_series: series, support_email: nil)
+      event = create(:event, event_series: series)
+      event.update_column(:support_email, nil)
       expect(event.effective_support_email).to eq("series@hackclub.com")
     end
 
     it "defaults to team@hackclub.com when neither is set" do
-      event = create(:event, support_email: nil)
+      event = create(:event)
+      event.update_column(:support_email, nil)
       expect(event.effective_support_email).to eq("team@hackclub.com")
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,50 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
+  describe "support email validation" do
+    it "requires a support email on create" do
+      event = build(:event, support_email: nil)
+      expect(event).not_to be_valid
+      expect(event.errors[:support_email]).to include("can't be blank")
+    end
+
+    it "accepts @hackclub.com and @events.hackclub.com addresses" do
+      expect(build(:event, support_email: "sunbeam@hackclub.com")).to be_valid
+      expect(build(:event, support_email: "sunbeam@events.hackclub.com")).to be_valid
+    end
+
+    it "rejects addresses on any other domain" do
+      event = build(:event, support_email: "sunbeam@gmail.com")
+      expect(event).not_to be_valid
+      expect(event.errors[:support_email])
+        .to include("must be a @hackclub.com or @events.hackclub.com address")
+    end
+
+    it "rejects lookalike domains" do
+      %w[sunbeam@nothackclub.com sunbeam@hackclub.com.evil.com sunbeam@sub.events.hackclub.com]
+        .each do |address|
+          expect(build(:event, support_email: address)).not_to be_valid
+        end
+    end
+
+    it "strips and downcases the address" do
+      event = create(:event, support_email: "  Sunbeam@HackClub.com ")
+      expect(event.support_email).to eq("sunbeam@hackclub.com")
+    end
+
+    it "lets legacy events without a support email still be saved" do
+      event = create(:event)
+      event.update_column(:support_email, nil)
+      expect(event.reload.update(name: "Renamed")).to be(true)
+    end
+
+    it "does not let an existing support email be cleared" do
+      event = create(:event)
+      expect(event.update(support_email: "")).to be(false)
+      expect(event.errors[:support_email]).to include("can't be blank")
+    end
+  end
+
   describe "#airtable_sync_stale?" do
     def configured_event(**attrs)
       build(

--- a/spec/requests/admin/event_series_spec.rb
+++ b/spec/requests/admin/event_series_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Admin::EventSeries", type: :request do
       sign_in organizer
 
       post admin_events_path, params: {
-        event: { name: "Sunbeam Berlin Spec", event_series_id: series.id }
+        event: { name: "Sunbeam Berlin Spec", event_series_id: series.id, support_email: "berlin@events.hackclub.com" }
       }
 
       event = Event.find_by(name: "Sunbeam Berlin Spec")

--- a/spec/requests/admin/event_setup_spec.rb
+++ b/spec/requests/admin/event_setup_spec.rb
@@ -10,11 +10,28 @@ RSpec.describe "Admin::EventSetup", type: :request do
 
   describe "POST /admin/events (step 1)" do
     it "creates a draft event and redirects into the wizard" do
-      post admin_events_path, params: { event: { name: "Wizard Con", slug: "wizard-con" } }
+      post admin_events_path, params: { event: { name: "Wizard Con", slug: "wizard-con", support_email: "wizard@hackclub.com" } }
 
       created = Event.find_by(slug: "wizard-con")
       expect(created.setup_complete?).to be(false)
       expect(response).to redirect_to(admin_event_setup_schedule_path(created))
+    end
+
+    it "rejects a draft without a support email" do
+      post admin_events_path, params: { event: { name: "No Mail Con", slug: "no-mail-con" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(Event.find_by(slug: "no-mail-con")).to be_nil
+    end
+
+    it "rejects a support email outside the Hack Club domains" do
+      post admin_events_path, params: {
+        event: { name: "Outside Con", slug: "outside-con", support_email: "hi@gmail.com" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(Event.find_by(slug: "outside-con")).to be_nil
+      expect(response.body).to include("@hackclub.com or @events.hackclub.com")
     end
   end
 
@@ -198,6 +215,15 @@ RSpec.describe "Admin::EventSetup", type: :request do
   end
 
   describe "POST complete" do
+    it "refuses to finish setup while the support email is missing" do
+      event.update_column(:support_email, nil)
+
+      post admin_event_setup_complete_path(event)
+
+      expect(response).to redirect_to(edit_admin_event_path(event))
+      expect(event.reload.setup_complete?).to be(false)
+    end
+
     it "marks setup complete and lands on the event dashboard" do
       post admin_event_setup_complete_path(event)
 


### PR DESCRIPTION
Every participant- and guardian-facing email goes out from the event's support email, so it needs to be an address we actually control.

- `Event` validates `support_email` presence on create (and on update when the field changes, so you can't clear one), plus format against `hackclub.com` / `events.hackclub.com`. Value is stripped and downcased. Legacy events with a blank value still save so unrelated updates don't break.
- Step 1 of the setup wizard and the event settings form mark the field required and explain the domain rule; the review step flags a missing address and `EventSetupController#complete` refuses to finish setup without one.
- `events.create` in the MCP toolbox no longer treats `support_email` as optional.

`Event#effective_support_email` and its series/global fallbacks are unchanged.

Note: `EventSeries#contact_email` still accepts any domain and is the fallback From address for series events — left alone for now.

## Testing
Full suite passes locally (1049 examples). New specs cover the domain rule, presence, normalization, the legacy-blank case, rejected creates, and the blocked setup completion.