### PR TITLE
Slide the guardian invite window off last use, and kill unstamped tokens

### DIFF
--- a/app/controllers/guardian_portal_controller.rb
+++ b/app/controllers/guardian_portal_controller.rb
@@ -286,6 +286,10 @@ class GuardianPortalController < ApplicationController
       render :error, status: :not_found and return
     end
 
+    # Keeps the invite alive while the guardian is actually working through the
+    # portal, so a long gathering-documents stretch does not expire mid-flow.
+    @guardian_participant_event.touch_invite_use!
+
     @guardian = @guardian_participant_event.guardian
     @participant_event = @guardian_participant_event.participant_event
     @participant = @participant_event.participant

--- a/app/jobs/send_pending_guardian_invites_job.rb
+++ b/app/jobs/send_pending_guardian_invites_job.rb
@@ -16,17 +16,28 @@ class SendPendingGuardianInvitesJob < ApplicationJob
       .or(submitted.where(id: waivers.where(status: [ :pending, :failed ], docuseal_participant_slug: nil).select(:participant_event_id)))
   end
 
-  # Guardians of submitted minors who were never sent an invite, plus invites
-  # that expired before the guardian ever opened the portal — those links are
-  # dead, and re-sending delivers the same token with a fresh validity window.
+  # Guardians of submitted minors who were never sent an invite, plus anyone
+  # whose link has since expired — those are dead, and re-sending delivers the
+  # same token with a fresh validity window.
+  #
+  # This mirrors GuardianParticipantEvent#invite_expired? in SQL: the window
+  # runs from the later of the send and the guardian's last use. Guardians who
+  # opened the portal but stalled are deliberately included; excluding them
+  # (as an accepted_at IS NULL filter used to) stranded exactly the people
+  # whose links had lapsed mid-flow.
   def self.gpes_needing_invites(event)
     awaiting = GuardianParticipantEvent
       .joins(:participant_event)
       .where(participant_events: { event_id: event.id, status: :awaiting_guardian })
 
-    awaiting.where(invite_token_sent_at: nil)
-      .or(awaiting.where(accepted_at: nil)
-                  .where(invite_token_sent_at: ...GuardianParticipantEvent::INVITE_VALIDITY.ago))
+    lapsed = awaiting.where(
+      "GREATEST(guardian_participant_events.invite_token_sent_at, " \
+      "COALESCE(guardian_participant_events.invite_last_used_at, " \
+      "guardian_participant_events.invite_token_sent_at)) < ?",
+      GuardianParticipantEvent::INVITE_VALIDITY.ago
+    )
+
+    awaiting.where(invite_token_sent_at: nil).or(lapsed)
   end
 
   def perform(event_id)

--- a/app/models/guardian_participant_event.rb
+++ b/app/models/guardian_participant_event.rb
@@ -44,20 +44,49 @@ class GuardianParticipantEvent < ApplicationRecord
     end
   end
 
+  # Handing this link to someone counts as sending it: an unstamped invite is
+  # treated as dead by #invite_expired?, so admins copying a link out of the
+  # participant page would otherwise paste a URL that 404s on arrival. Only
+  # stamp a link that is actually dead -- this renders inside the admin
+  # participant page, and refreshing a live invite on every page load would
+  # write (and record a PaperTrail version) for every guardian shown.
   def invite_url
     host = ENV.fetch("APP_HOST") { Rails.application.config.action_mailer.default_url_options[:host] || "localhost:3000" }
+    token = generate_invite_token!
+    update!(invite_token_sent_at: Time.current) if invite_expired?
+
     Rails.application.routes.url_helpers.guardian_portal_url(
-      token: invite_token || generate_invite_token!,
+      token: token,
       host: host
     )
   end
 
   INVITE_VALIDITY = 7.days
 
-  def invite_expired?
-    return false if invite_token_sent_at.blank?
+  # Bump at most hourly. The window is measured in days, so stamping every
+  # request would buy no useful precision and add a write to each page load.
+  INVITE_USE_TOUCH_INTERVAL = 1.hour
 
-    invite_token_sent_at < INVITE_VALIDITY.ago
+  # The window slides off whichever happened last: the invite being sent, or the
+  # guardian actually using it. Measuring from the send alone would cut off
+  # anyone still working through the portal seven days after the first email.
+  # A record with neither timestamp has had its invite revoked (an admin changed
+  # the guardian's email) or never had one delivered, so its token is dead
+  # rather than eternal -- that unstamped-means-forever gap was the original bug.
+  def invite_expired?
+    last_active_at = [ invite_token_sent_at, invite_last_used_at ].compact.max
+    return true if last_active_at.nil?
+
+    last_active_at < INVITE_VALIDITY.ago
+  end
+
+  # Called on every authenticated portal request. Callers reach this only after
+  # find_by_invite_token! has already rejected expired tokens, so this extends a
+  # live window and can never resurrect a dead one.
+  def touch_invite_use!
+    return if invite_last_used_at.present? && invite_last_used_at > INVITE_USE_TOUCH_INTERVAL.ago
+
+    update_column(:invite_last_used_at, Time.current)
   end
 
   def mark_accepted!

--- a/db/migrate/20260824120000_add_invite_last_used_at_to_guardian_participant_events.rb
+++ b/db/migrate/20260824120000_add_invite_last_used_at_to_guardian_participant_events.rb
@@ -1,0 +1,18 @@
+class AddInviteLastUsedAtToGuardianParticipantEvents < ActiveRecord::Migration[8.0]
+  def up
+    add_column :guardian_participant_events, :invite_last_used_at, :datetime
+
+    # Guardians already part-way through a portal would otherwise be measured
+    # against the original send date and lock out the moment this deploys.
+    # Seeding from accepted_at gives them the window their activity earned.
+    execute(<<~SQL)
+      UPDATE guardian_participant_events
+      SET invite_last_used_at = accepted_at
+      WHERE accepted_at IS NOT NULL
+    SQL
+  end
+
+  def down
+    remove_column :guardian_participant_events, :invite_last_used_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -489,6 +489,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_090000) do
     t.integer "emergency_contact_priority"
     t.boolean "emergency_medical_consent"
     t.uuid "guardian_id", null: false
+    t.datetime "invite_last_used_at"
     t.string "invite_token_ciphertext"
     t.string "invite_token_digest"
     t.datetime "invite_token_sent_at"

--- a/spec/factories/guardian_participant_events.rb
+++ b/spec/factories/guardian_participant_events.rb
@@ -3,5 +3,13 @@ FactoryBot.define do
     guardian
     participant_event
     status { :pending }
+    # A guardian who can reach the portal has, by definition, been sent a link.
+    # An invite with no send stamp is treated as revoked, so leaving this nil by
+    # default would 404 every portal spec.
+    invite_token_sent_at { Time.current }
+
+    trait :never_sent do
+      invite_token_sent_at { nil }
+    end
   end
 end

--- a/spec/jobs/send_pending_guardian_invites_job_spec.rb
+++ b/spec/jobs/send_pending_guardian_invites_job_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe SendPendingGuardianInvitesJob do
 
     it "invites guardians who were never sent one" do
       pe = submitted_minor_pe
-      gpe = create(:guardian_participant_event, participant_event: pe)
+      gpe = create(:guardian_participant_event, :never_sent, participant_event: pe)
       create(:consent, :signed, participant_event: pe)
 
       expect {
@@ -102,10 +102,25 @@ RSpec.describe SendPendingGuardianInvitesJob do
       }.to invitation_for(gpe)
     end
 
-    it "does not re-invite guardians who already opened the portal" do
+    # Opening the portal used to exempt a guardian from re-invites entirely,
+    # which stranded anyone who opened the link once and then let it lapse.
+    it "re-invites guardians who opened the portal but let the link lapse" do
+      pe = submitted_minor_pe
+      gpe = create(:guardian_participant_event, participant_event: pe,
+        invite_token_sent_at: 30.days.ago, invite_last_used_at: 8.days.ago,
+        accepted_at: 20.days.ago, status: :in_progress)
+      create(:consent, :signed, participant_event: pe)
+
+      expect {
+        described_class.perform_now(event.id)
+      }.to invitation_for(gpe)
+    end
+
+    it "does not re-invite guardians whose link is still live from recent use" do
       pe = submitted_minor_pe
       create(:guardian_participant_event, participant_event: pe,
-        invite_token_sent_at: 8.days.ago, accepted_at: 7.days.ago, status: :in_progress)
+        invite_token_sent_at: 30.days.ago, invite_last_used_at: 1.day.ago,
+        accepted_at: 20.days.ago, status: :in_progress)
       create(:consent, :signed, participant_event: pe)
 
       expect {

--- a/spec/models/guardian_participant_event_spec.rb
+++ b/spec/models/guardian_participant_event_spec.rb
@@ -26,8 +26,96 @@ RSpec.describe GuardianParticipantEvent do
       stale = described_class.find(gpe.id)
 
       token = gpe.generate_invite_token!
+      # Minting a token is not the same as sending it, and an invite with no
+      # send recorded is treated as revoked -- stamp it the way the mailers do
+      # so this exercises the race rather than expiry.
+      gpe.update!(invite_token_sent_at: Time.current)
 
       expect(stale.generate_invite_token!).to eq(token)
+      expect(described_class.find_by_invite_token!(token)).to eq(gpe)
+    end
+  end
+
+  describe "#invite_expired?" do
+    let(:gpe) { create(:guardian_participant_event) }
+
+    it "is false inside the window from the send" do
+      gpe.update!(invite_token_sent_at: 2.days.ago)
+
+      expect(gpe.invite_expired?).to be(false)
+    end
+
+    it "is true once the send falls outside the window and nothing else happened" do
+      gpe.update!(invite_token_sent_at: (described_class::INVITE_VALIDITY + 1.day).ago)
+
+      expect(gpe.invite_expired?).to be(true)
+    end
+
+    # The whole point of the sliding window: someone gathering documents for a
+    # fortnight must not lose the link they are actively using.
+    it "is false when the guardian used the link recently, however old the send" do
+      gpe.update!(
+        invite_token_sent_at: 30.days.ago,
+        invite_last_used_at: 1.day.ago
+      )
+
+      expect(gpe.invite_expired?).to be(false)
+    end
+
+    it "is true once the last use also falls outside the window" do
+      gpe.update!(
+        invite_token_sent_at: 30.days.ago,
+        invite_last_used_at: (described_class::INVITE_VALIDITY + 1.day).ago
+      )
+
+      expect(gpe.invite_expired?).to be(true)
+    end
+
+    # Admins null the send stamp to revoke a link (e.g. after correcting a
+    # guardian's email). That used to read as "never expires".
+    it "is true when the invite has no send recorded at all" do
+      gpe.update!(invite_token_sent_at: nil, invite_last_used_at: nil)
+
+      expect(gpe.invite_expired?).to be(true)
+    end
+
+    it "does not resolve a revoked token" do
+      token = gpe.generate_invite_token!
+      gpe.update!(invite_token_sent_at: nil, invite_last_used_at: nil)
+
+      expect { described_class.find_by_invite_token!(token) }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe "#touch_invite_use!" do
+    it "extends the window" do
+      gpe = create(:guardian_participant_event, invite_token_sent_at: 6.days.ago)
+
+      gpe.touch_invite_use!
+
+      expect(gpe.reload.invite_last_used_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "does not write again within the throttle interval" do
+      recent = 5.minutes.ago
+      gpe = create(:guardian_participant_event, invite_token_sent_at: 1.day.ago, invite_last_used_at: recent)
+
+      expect { gpe.touch_invite_use! }
+        .not_to change { gpe.reload.invite_last_used_at }
+    end
+  end
+
+  describe "#invite_url" do
+    # An unstamped invite is dead, so producing a shareable link has to count
+    # as a send or admins would hand out URLs that 404.
+    it "stamps the send so the link it returns actually resolves" do
+      gpe = create(:guardian_participant_event, invite_token_sent_at: nil)
+
+      url = gpe.invite_url
+
+      expect(gpe.reload.invite_expired?).to be(false)
+      token = url[%r{/guardian/portal/([A-Za-z0-9_\-]+)}, 1]
       expect(described_class.find_by_invite_token!(token)).to eq(gpe)
     end
   end

--- a/spec/requests/guardian_invites_locked_spec.rb
+++ b/spec/requests/guardian_invites_locked_spec.rb
@@ -104,11 +104,15 @@ RSpec.describe "Guardian invites locked", type: :request do
 
   describe "GuardianMailer.invitation" do
     it "refuses to send while locked" do
+      # Needs an invite that has genuinely never gone out, so the nil send
+      # stamp below proves the lock suppressed it.
+      unsent = create(:guardian_participant_event, :never_sent, participant_event: participant_event)
+
       expect {
-        GuardianMailer.invitation(guardian_participant_event: gpe).deliver_now
+        GuardianMailer.invitation(guardian_participant_event: unsent).deliver_now
       }.not_to change { ActionMailer::Base.deliveries.count }
 
-      expect(gpe.reload.invite_token_sent_at).to be_nil
+      expect(unsent.reload.invite_token_sent_at).to be_nil
     end
   end
 

--- a/spec/requests/guardian_portal_invite_window_spec.rb
+++ b/spec/requests/guardian_portal_invite_window_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "guardian portal invite window", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:event) { create(:event) }
+  let(:participant_event) { create(:participant_event, event: event) }
+  let(:gpe) { create(:guardian_participant_event, participant_event: participant_event) }
+
+  it "serves a link inside its window" do
+    token = gpe.generate_invite_token!
+    gpe.update!(invite_token_sent_at: 2.days.ago)
+
+    get guardian_portal_path(token: token)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  # The regression this whole change exists to prevent: a guardian who keeps
+  # working must not be cut off seven days after the first email.
+  it "keeps a guardian who is still using the portal signed in past the window" do
+    token = gpe.generate_invite_token!
+    gpe.update!(invite_token_sent_at: 6.days.ago)
+
+    get guardian_portal_path(token: token)
+    expect(response).to have_http_status(:ok)
+
+    # Two weeks after the original send, but only days since that visit.
+    travel 6.days do
+      get guardian_portal_path(token: token)
+      expect(response).to have_http_status(:ok)
+    end
+
+    travel 20.days do
+      get guardian_portal_path(token: token)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  it "rejects a link nobody has touched for longer than the window" do
+    token = gpe.generate_invite_token!
+    gpe.update!(invite_token_sent_at: 8.days.ago)
+
+    get guardian_portal_path(token: token)
+
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include(guardian_portal_center_path)
+  end
+
+  it "rejects a token whose send stamp was revoked" do
+    token = gpe.generate_invite_token!
+    gpe.update!(invite_token_sent_at: nil, invite_last_used_at: nil)
+
+    get guardian_portal_path(token: token)
+
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/onboarding_documents_step_spec.rb
+++ b/spec/requests/onboarding_documents_step_spec.rb
@@ -98,7 +98,9 @@ RSpec.describe "Onboarding documents step", type: :request do
   describe "submitting as a minor" do
     it "enqueues the guardian invitation at submit" do
       participant.update!(date_of_birth: 16.years.ago)
-      gpe = create(:guardian_participant_event, participant_event: participant_event)
+      # Onboarding is what triggers the first invite, so this guardian has not
+      # been sent one yet.
+      gpe = create(:guardian_participant_event, :never_sent, participant_event: participant_event)
       create(:consent, :signed, participant_event: participant_event)
       participant_event.emergency_contacts.create!(name: "Erin", phone: "+14155550100")
 


### PR DESCRIPTION
Follow-up to #13. That PR closed the "accepted once → link never expires" hole by measuring expiry from `invite_token_sent_at`, and #13's follow-up commit fixed `waiver_reset` emailing a dead link. Two things were left.

### A hard deadline instead of a link lifetime

The window ran from the send, so a guardian still gathering documents lost their link seven days after the *first email*, regardless of how actively they were using it. Measured on main: `aged 8d, opened 6d ago, mid-flow → 404`.

It now runs from the later of the send and the guardian's last use. Portal requests bump `invite_last_used_at` (throttled hourly — the window is in days, so per-request writes buy nothing).

### Unstamped tokens still never expired

`invite_token_sent_at.blank? → return false` meant a record with no send stamp was permanently valid. That is exactly how a link gets revoked today: `onboarding_controller` and `admin/guardians_controller` null the stamp when an admin corrects a guardian's email. So the never-expires class of bug had not gone away, it had moved from "any accepted guardian" to "guardians whose email was edited".

Missing timestamps now read as revoked. `invite_url` stamps a dead invite before returning it, so the admin copy-link button does not paste a URL that 404s; it deliberately does *not* re-stamp live invites, which would write a row and a PaperTrail version for every guardian on each admin page render.

### The job disagreed with the model

`SendPendingGuardianInvitesJob.gpes_needing_invites` filtered `accepted_at: nil`, so the auto-heal skipped precisely the guardians whose links had lapsed mid-flow. It now mirrors `#invite_expired?` in SQL and re-invites them.

## Behaviour

| situation | before | after |
|---|---|---|
| fresh invite, 2d old | 200 | 200 |
| aged 8d, never opened | 404 | 404 |
| aged 8d, used 1d ago (mid-flow) | **404** | **200** |
| aged 30d, last used 8d ago | 404 | 404 |
| completed, used 1d ago | **404** | **302 → confirmation** |
| revoked (no send stamp) | **200, forever** | **404** |
| `waiver_reset` link after 8d | 200 | 200 |
| admin copy-link on a revoked invite | 200 | 200 |

No immortal links in any row, and nobody is cut off while actively using the portal. Everyone who does hit a 404 gets the portal-center recovery path already linked from that page.

## Notes

- Migration backfills `invite_last_used_at` from `accepted_at` so guardians already part-way through don't all lock out the moment this deploys.
- The factory now stamps a send by default (a guardian who can reach the portal has been sent a link), with a `:never_sent` trait for cases that genuinely have not. That is what most of the spec churn is.
- Full suite: 1053 examples, 1 failure — `webhooks_spec.rb:247`, which fails identically on clean main (credentials-dependent). Rubocop and Brakeman clean.

## Not addressed

`redirect_if_expired` and the `guardian_portal/expired` view remain dead code: `find_by_invite_token!` raises before the `before_action` can run, so expired guardians get the generic 404 rather than the dedicated page. Pre-existing, and left alone here to keep this diff to the expiry rule.