### PR TITLE
Boot the scanner on Turbo visits, not just DOMContentLoaded

### DIFF
--- a/app/views/admin/scans/scanner.html.erb
+++ b/app/views/admin/scans/scanner.html.erb
@@ -2,6 +2,10 @@
 
 <%= content_for :head do %>
   <script src="<%= asset_path("vendor/zxing.min.js") %>"></script>
+  <%# Turbo doesn't re-run scripts when it restores a cached snapshot, so a %>
+  <%# back-navigation would land on a dead preview. Opt out of the cache and %>
+  <%# every arrival here is a fresh render that boots the camera again. %>
+  <meta name="turbo-cache-control" content="no-cache">
 <% end %>
 
 <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-0">
@@ -46,8 +50,14 @@
         <select id="camera-select" class="flex-1 border border-gray-300 rounded-md px-2 py-1 text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-[#ec3750]"></select>
       </div>
 
-      <div id="qr-reader" class="w-full bg-gray-900 rounded-lg overflow-hidden" style="min-height: 280px;">
+      <div id="qr-reader" class="w-full bg-gray-900 rounded-lg overflow-hidden relative" style="min-height: 280px;">
         <video id="qr-video" class="w-full h-full object-cover" style="min-height: 280px;" muted playsinline></video>
+        <!-- iOS home-screen web apps often refuse a camera prompt that isn't
+             tied to a tap, so keep a manual way to (re)start it. -->
+        <button type="button" id="start-camera-btn"
+                class="hidden absolute inset-0 w-full h-full flex items-center justify-center text-white text-sm font-medium bg-gray-900/80">
+          Tap to start camera
+        </button>
       </div>
       
       <div id="scan-result" class="mt-4 p-3 sm:p-4 rounded-lg hidden">
@@ -262,7 +272,16 @@ function groupBadgeHtml(group, fallbackColor) {
   return html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium" style="background-color: ${color || fallbackColor}; color: ${color ? 'white' : '#1f2d3d'};">${group.name}</span>`;
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+// Runs on every render, not just the first: this script sits below the markup
+// it touches, and on a Turbo Drive visit DOMContentLoaded has long since fired
+// (which is why the scanner used to sit on "Initializing..." forever whenever
+// you arrived here from another page - e.g. always, inside the installed PWA).
+(function() {
+  // Everything bound to document/window is torn down when we navigate away,
+  // so repeat visits don't stack handlers over detached nodes.
+  const pageListeners = new AbortController();
+  const signal = pageListeners.signal;
+
   const scanUrl = '<%= admin_event_scans_path(current_event) %>';
   const searchUrl = '<%= search_admin_event_scans_path(current_event) %>';
   const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
@@ -286,6 +305,26 @@ document.addEventListener('DOMContentLoaded', function() {
     else if (state === 'error') dot.classList.add('bg-red-500');
     else if (state === 'scanning') dot.classList.add('bg-yellow-500', 'animate-pulse');
     else dot.classList.add('bg-gray-400');
+  }
+
+  function offerManualStart() {
+    document.getElementById('start-camera-btn').classList.remove('hidden');
+  }
+
+  function stopScanner() {
+    if (scanner) scanner.reset();
+    scanner = null;
+  }
+
+  function waitForZXing(timeoutMs = 8000) {
+    return new Promise((resolve) => {
+      const deadline = performance.now() + timeoutMs;
+      (function poll() {
+        if (typeof ZXing !== 'undefined' && ZXing.BrowserQRCodeReader) return resolve();
+        if (performance.now() > deadline) return resolve();
+        setTimeout(poll, 50);
+      })();
+    });
   }
 
   function showResult(message, isError = false) {
@@ -390,6 +429,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   async function initScanner() {
+    stopScanner(); // re-entrant: also reached from the tap-to-start button
     if (typeof ZXing === 'undefined' || !ZXing.BrowserQRCodeReader) {
       updateStatus('Scanner library not loaded', 'error');
       return;
@@ -419,6 +459,7 @@ document.addEventListener('DOMContentLoaded', function() {
       console.error('Camera permission error:', err.name, err.message, err);
       if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
         updateStatus('Camera blocked - check browser settings', 'error');
+        offerManualStart();
       } else if (err.name === 'NotFoundError' || err.name === 'DevicesNotFoundError') {
         updateStatus('No camera found on device', 'error');
       } else if (err.name === 'NotReadableError' || err.name === 'TrackStartError') {
@@ -430,10 +471,12 @@ document.addEventListener('DOMContentLoaded', function() {
           stream.getTracks().forEach(track => track.stop());
         } catch (retryErr) {
           updateStatus('Camera access failed: ' + retryErr.message, 'error');
+          offerManualStart();
           return;
         }
       } else {
         updateStatus('Camera error: ' + err.name + ' - ' + err.message, 'error');
+        offerManualStart();
       }
       return;
     }
@@ -474,12 +517,14 @@ document.addEventListener('DOMContentLoaded', function() {
     } catch (err) {
       console.error('Camera start error:', err);
       updateStatus('Camera access denied', 'error');
+      offerManualStart();
     }
   }
 
   async function startCamera(deviceId) {
     if (!scanner) return;
     updateStatus('Starting camera...', 'loading');
+    document.getElementById('start-camera-btn').classList.add('hidden');
     scanner.reset(); // stop any in-progress stream before switching
     try {
       await scanner.decodeFromVideoDevice(deviceId, 'qr-video', (result, err) => {
@@ -492,6 +537,7 @@ document.addEventListener('DOMContentLoaded', function() {
     } catch (err) {
       console.error('Camera start error:', err);
       updateStatus('Could not start camera', 'error');
+      offerManualStart();
     }
   }
 
@@ -568,15 +614,29 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!searchInput.contains(e.target) && !searchResults.contains(e.target)) {
       searchResults.classList.add('hidden');
     }
+  }, { signal });
+
+  document.getElementById('start-camera-btn').addEventListener('click', function() {
+    this.classList.add('hidden');
+    initScanner();
   });
 
-  // Initialize scanner
-  setTimeout(initScanner, 500);
-  
+  // Initialize scanner. The zxing tag lives in <head>, and on a Turbo visit
+  // Turbo appends it without waiting for it to load, so poll for the global
+  // rather than betting on a fixed delay.
+  waitForZXing().then(initScanner);
+
+  // Hand the camera back as soon as we navigate away, otherwise iOS keeps the
+  // capture (and its indicator) alive behind the next page.
+  document.addEventListener('turbo:before-render', function() {
+    stopScanner();
+    pageListeners.abort();
+  }, { signal });
+
   // Expose functions for NFC bridge integration
   window.showResult = showResult;
   window.getCurrentContextId = getCurrentContextId;
-});
+})();
 
 let currentModalParticipant = null;
 


### PR DESCRIPTION
Scanner mode never got past `Initializing...` in the installed iOS PWA.

The scanner's inline script was wrapped in `document.addEventListener('DOMContentLoaded', ...)`. Turbo re-evaluates inline body scripts on a visit, but `DOMContentLoaded` has long since fired by then, so `initScanner()` never ran and the status label sat on its server-rendered `Initializing...` forever. In the installed PWA you *always* reach `/admin/:event/scans/scanner` via a Turbo visit from `start_url` (`/`), so it never worked there at all — in Safari you'd only see it work if you hard-loaded the scanner URL directly.

The script sits below the markup it touches, so it can just run immediately. Along the way:

- Poll for the `ZXing` global instead of guessing `setTimeout(..., 500)`. The vendor tag lives in `<head>` and Turbo appends new head scripts *without* awaiting them, so the fixed delay was a race.
- Opt the page out of Turbo's snapshot cache. Turbo doesn't re-run scripts when restoring a snapshot, so a back-navigation would land on a dead preview.
- Offer a tap-to-start button on any camera failure. iOS home-screen web apps often refuse a `getUserMedia` prompt that isn't tied to a gesture, and this one fires from a timer.
- Release the camera on `turbo:before-render` and tear down the document-level listeners with an `AbortController`, so repeat visits don't stack handlers over detached nodes.

## Testing

- ERB compiles; the extracted inline JS passes `node --check`.
- A throwaway request spec confirmed the page renders with the new init path and no `addEventListener('DOMContentLoaded'` left behind.
- Camera behaviour itself needs a real device — verify by reinstalling the PWA and reaching Scanner from the sidebar.