### PR TITLE
Restrict MCP access to staff

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -39,7 +39,11 @@ class DashboardController < ApplicationController
         .sort_by { |event, _hidden| event.starts_at || Time.current }
         .reverse
     end
+    # MCP is staff-only, so the Connections section is too — except for someone who
+    # connected a client while they were staff and has since lost the role, who still
+    # needs a way to clear the (now dead) connection out.
     @mcp_connections = mcp_connections
+    @show_mcp_connections = current_user.admin? || @mcp_connections.any?
   end
 
   def update_staff_profile

--- a/app/toolboxes/application_toolbox.rb
+++ b/app/toolboxes/application_toolbox.rb
@@ -8,6 +8,7 @@ class ApplicationToolbox < Toolchest::Toolbox
 
   helper_method :current_user, :current_event, :global_admin?
 
+  before_action :require_staff!
   before_action :establish_current_context
   after_action :audit_write!
 
@@ -45,6 +46,15 @@ class ApplicationToolbox < Toolchest::Toolbox
   end
 
   private
+
+  # MCP is a staff-only surface. The consent screen and token resolution already
+  # gate on this (config/initializers/toolchest.rb), so getting here without a
+  # staff user means a token outlived its owner's roles — refuse every tool call.
+  def require_staff!
+    return if current_user&.admin?
+
+    halt error: "MCP access is limited to Attend staff."
+  end
 
   # Mirror ApplicationController#set_current_attributes so PaperTrail versions and
   # anything reading Current.* are attributed to the acting user, not a null actor.

--- a/app/views/dashboard/profile.html.erb
+++ b/app/views/dashboard/profile.html.erb
@@ -47,12 +47,14 @@
           Staff settings
         </a>
       <% end %>
-      <a href="#connections" class="flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium text-(--text) hover:bg-(--bg-elev-2) hover:text-(--text-strong) transition-colors">
-        <svg class="size-4 text-(--text-muted)" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"/>
-        </svg>
-        Connections
-      </a>
+      <% if @show_mcp_connections %>
+        <a href="#connections" class="flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium text-(--text) hover:bg-(--bg-elev-2) hover:text-(--text-strong) transition-colors">
+          <svg class="size-4 text-(--text-muted)" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"/>
+          </svg>
+          Connections
+        </a>
+      <% end %>
       <a href="#appearance" class="flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-1.5 text-sm font-medium text-(--text) hover:bg-(--bg-elev-2) hover:text-(--text-strong) transition-colors">
         <svg class="size-4 text-(--text-muted)" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
@@ -363,13 +365,21 @@
       <% end %>
 
       <!-- Connections -->
+      <% if @show_mcp_connections %>
       <section id="connections" class="scroll-mt-8">
         <h2 class="border-b border-(--border-soft) pb-3 text-xl font-semibold text-(--text-strong)">Connections</h2>
-        <p class="mt-3 text-sm text-(--text-muted)">
-          Apps connected to your Attend account through
-          <a href="https://attend.hackclub.com/mcp" class="font-medium text-(--text-link) hover:underline">MCP</a>.
-          They act as you, limited to the scopes you approved. Disconnecting one signs it out immediately.
-        </p>
+        <% if current_user.admin? %>
+          <p class="mt-3 text-sm text-(--text-muted)">
+            Apps connected to your Attend account through
+            <a href="https://attend.hackclub.com/mcp" class="font-medium text-(--text-link) hover:underline">MCP</a>.
+            They act as you, limited to the scopes you approved. Disconnecting one signs it out immediately.
+          </p>
+        <% else %>
+          <p class="mt-3 text-sm text-(--text-muted)">
+            MCP is only available to Attend staff, so these apps can no longer reach your
+            account. Disconnect them to clear them out.
+          </p>
+        <% end %>
 
         <% if @mcp_connections.any? %>
           <div class="mt-4 overflow-hidden rounded-2xl border border-(--border-card) bg-(--bg-elev)">
@@ -412,6 +422,7 @@
           </div>
         <% end %>
       </section>
+      <% end %>
 
       <!-- Appearance -->
       <section id="appearance" class="scroll-mt-8">

--- a/config/initializers/toolchest.rb
+++ b/config/initializers/toolchest.rb
@@ -26,10 +26,18 @@ Toolchest.configure do |config|
     request.env["warden"]&.user
   end
 
+  # MCP is staff-only. Anyone who isn't staff (participants, guardians, signed-up
+  # users with no role) can't reach the consent screen: toolchest bounces them back
+  # to the client with an access_denied error on both GET and POST /oauth/authorize.
+  config.authorize_link { |user| user.present? && user.admin? }
+
   # Resolve an access token back to the Attend user it was issued for. Everything a
-  # toolbox does runs as this user, with this user's real permissions.
+  # toolbox does runs as this user, with this user's real permissions. Tokens issued
+  # before a user lost their staff roles stop resolving here, so demoting someone
+  # kills their MCP access without anyone having to revoke tokens by hand.
   config.authenticate do |token|
-    User.find_by(id: token.resource_owner_id)
+    user = User.find_by(id: token.resource_owner_id)
+    user if user&.admin?
   end
 
   # Scopes the user consents to when connecting a client. These gate which tools are
@@ -57,6 +65,9 @@ Toolchest.configure do |config|
   # Never hand a client more than the account itself could ever use. Fine-grained,
   # per-event enforcement still happens inside the toolboxes via the event roles.
   config.allowed_scopes_for do |user, requested_scopes|
+    # Belt and braces with authorize_link above — a non-staff account gets nothing.
+    next [] unless user&.admin?
+
     allowed = requested_scopes
 
     # Global read-only accounts can never write anything.

--- a/spec/requests/dashboard_mcp_connections_spec.rb
+++ b/spec/requests/dashboard_mcp_connections_spec.rb
@@ -6,7 +6,9 @@ require "rails_helper"
 RSpec.describe "Dashboard MCP connections", type: :request do
   include Devise::Test::IntegrationHelpers
 
-  let(:user) { create(:user) }
+  # The Connections section is staff-only (non-staff only see it to clean up a
+  # connection made before they lost the role).
+  let(:user) { create(:user, global_role: "global_admin") }
   let!(:participant) { create(:participant, user: user) }
 
   let(:application) do

--- a/spec/requests/mcp_staff_only_spec.rb
+++ b/spec/requests/mcp_staff_only_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+# MCP is a staff surface: non-staff accounts (participants, guardians, anyone
+# signed in with no event or series role) can't connect a client, can't call a
+# tool, and don't see the Connections section on their profile.
+RSpec.describe "MCP staff-only access", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:event) { create(:event) }
+  let(:staff) { create(:user, global_role: "global_admin") }
+  let(:non_staff) { create(:user) }
+  # /dashboard/profile is a participant-or-staff page; give the non-staff user one.
+  let!(:non_staff_participant) { create(:participant, user: non_staff) }
+
+  let(:application) do
+    Toolchest::OauthApplication.create!(
+      name: "Poke",
+      redirect_uri: "https://poke.example.com/api/v1/mcp/callback"
+    )
+  end
+
+  def consent_params(overrides = {})
+    {
+      response_type: "code",
+      client_id: application.uid,
+      redirect_uri: application.redirect_uri,
+      code_challenge: "x" * 43,
+      code_challenge_method: "S256",
+      state: "abc123",
+      scope: "events:read"
+    }.merge(overrides)
+  end
+
+  describe "the OAuth consent screen" do
+    it "bounces a non-staff user back to the client with access_denied" do
+      sign_in non_staff
+
+      get "/mcp/oauth/authorize", params: consent_params
+
+      expect(response).to have_http_status(:found)
+      expect(response.headers["Location"]).to start_with(application.redirect_uri)
+      expect(response.headers["Location"]).to include("error=access_denied")
+    end
+
+    it "refuses to issue a grant to a non-staff user who posts the form anyway" do
+      sign_in non_staff
+
+      expect {
+        post "/mcp/oauth/authorize", params: consent_params(
+          scope: [ "events:read" ],
+          original_scope: "events:read"
+        )
+      }.not_to change(Toolchest::OauthAccessGrant, :count)
+
+      expect(response.headers["Location"]).to include("error=access_denied")
+    end
+
+    it "still renders for a staff user" do
+      sign_in staff
+
+      get "/mcp/oauth/authorize", params: consent_params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Poke")
+    end
+
+    it "renders for someone whose only role is on a single event" do
+      user = create(:user)
+      user.event_role_assignments.create!(event: event, role: :ops)
+      sign_in user
+
+      get "/mcp/oauth/authorize", params: consent_params
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "tool calls" do
+    def call_tool(user, name)
+      token = Toolchest::OauthAccessToken.create_for(
+        application: application,
+        resource_owner_id: user.id,
+        scopes: "events:read"
+      )
+
+      post "/mcp",
+        params: {
+          jsonrpc: "2.0", id: 1,
+          method: "tools/call",
+          params: { name: name, arguments: {} }
+        }.to_json,
+        headers: {
+          "CONTENT_TYPE" => "application/json",
+          "ACCEPT" => "application/json, text/event-stream",
+          "HTTP_AUTHORIZATION" => "Bearer #{token.raw_token}"
+        }
+    end
+
+    # A token issued while someone was staff keeps resolving until it expires,
+    # so the toolbox itself has to refuse rather than run with a nil user.
+    it "refuses every tool call from a non-staff token holder" do
+      call_tool(non_staff, "events_index")
+
+      expect(response.body).to include("MCP access is limited to Attend staff")
+    end
+
+    it "lets a staff token holder through" do
+      event
+      call_tool(staff, "events_index")
+
+      expect(response.body).not_to include("MCP access is limited to Attend staff")
+      expect(response.body).to include(event.name)
+    end
+  end
+
+  describe "the Connections section on /dashboard/profile" do
+    it "is hidden for a non-staff user with nothing connected" do
+      sign_in non_staff
+
+      get dashboard_profile_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("#connections")
+    end
+
+    # Someone who connected a client and later lost their role still needs a way
+    # to clear the (now dead) connection out.
+    it "stays visible for a non-staff user who still has a live connection" do
+      Toolchest::OauthAccessToken.create_for(
+        application: application,
+        resource_owner_id: non_staff.id,
+        scopes: "events:read"
+      )
+      sign_in non_staff
+
+      get dashboard_profile_path
+
+      expect(response.body).to include("Poke")
+      expect(response.body).to include("only available to Attend staff")
+    end
+
+    it "is visible for a staff user" do
+      sign_in staff
+
+      get dashboard_profile_path
+
+      expect(response.body).to include("#connections")
+    end
+  end
+end

--- a/spec/requests/toolchest_oauth_consent_spec.rb
+++ b/spec/requests/toolchest_oauth_consent_spec.rb
@@ -9,8 +9,9 @@ require "rails_helper"
 RSpec.describe "Toolchest OAuth consent screen", type: :request do
   include Devise::Test::IntegrationHelpers
 
+  # MCP is staff-only, so the consent screen only renders for staff.
   let(:user) do
-    create(:user).tap do |u|
+    create(:user, global_role: "global_admin").tap do |u|
       u.avatar.attach(
         io: File.open(file_fixture("headshot.png")),
         filename: "headshot.png",


### PR DESCRIPTION
MCP exposes participant, medical, and safeguarding data, so it shouldn't be reachable by a participant or guardian account. This makes it staff-only, blocked at three layers and hidden in the UI.

## Block

`config/initializers/toolchest.rb`:
- `config.authorize_link` — toolchest bounces non-staff off the consent screen (both `GET` and `POST /mcp/oauth/authorize`) with an `access_denied` error back to the client, so no grant is ever issued.
- `config.authenticate` only resolves a token if the owner is *still* staff, so a token issued before someone lost their roles stops working — no manual revocation needed.
- `allowed_scopes_for` returns `[]` for non-staff as belt and braces.

`ApplicationToolbox` gains a `require_staff!` before_action that halts every tool call. This one matters: toolchest's rack app doesn't 401 when `authenticate` returns nil, it hands the toolbox a nil `resource_owner`, which would have blown up in `current_user.can_access_event?`.

## Hide

The Connections nav link and section on `/dashboard/profile` only render when `current_user.admin? || @mcp_connections.any?`. The `.any?` escape hatch is deliberate — someone who connected a client and later lost their role still needs a way to clear the now-dead connection out, and they get copy saying MCP is staff-only.

## Notes

"Staff" is the existing `User#admin?` — global admin, any `event_admin`/`ops`/`safeguarding_lead` role, or any series role. That excludes users whose only role is `read_only`.

New `spec/requests/mcp_staff_only_spec.rb` covers consent denial, grant refusal, tool-call refusal by bearer token, and the three profile states. The two existing MCP specs now use staff users.