### PR TITLE
Give MCP tools canonical Attend URLs

### DIFF
--- a/app/controllers/concerns/attend_urls.rb
+++ b/app/controllers/concerns/attend_urls.rb
@@ -1,0 +1,79 @@
+# Canonical absolute URLs for Attend pages, built from the routes rather than
+# glued together by hand.
+#
+# The MCP toolboxes lean on this: every serialized record carries the URL of the
+# page it lives on, so an agent can hand a human a link instead of an opaque ID
+# (or worse, inventing a path that 404s). LinksToolbox publishes the same
+# patterns for the pages nothing serializes yet.
+module AttendUrls
+  extend self
+
+  # Sub-pages of one registration in the admin UI, keyed by the name a human
+  # would use for them. These are all member routes on admin/participants.
+  PARTICIPANT_PAGES = %w[edit travel accommodation medical safeguarding consents notes history merge].freeze
+
+  # APP_HOST wins where it is set (production, staging, and a dev tunnel), and
+  # it always carries its own port; the mailer options are the local fallback,
+  # where the port lives separately.
+  def attend_base_url
+    options = Rails.application.config.action_mailer.default_url_options || {}
+    env_host = ENV["APP_HOST"].presence
+    host = env_host || options[:host].presence || "attend.hackclub.com"
+    host = "#{host}:#{options[:port]}" if env_host.nil? && options[:port].present? && !host.include?(":")
+    scheme = host.start_with?("localhost", "127.0.0.1") ? "http" : "https"
+    "#{scheme}://#{host}"
+  end
+
+  def attend_url(path) = "#{attend_base_url}#{path}"
+
+  def event_admin_url(event) = attend_url(routes.admin_event_dashboard_path(slug: event.slug))
+
+  def event_participants_url(event) = attend_url(routes.admin_event_participants_path(event_slug: event.slug))
+
+  def event_incidents_url(event) = attend_url(routes.admin_event_incidents_path(event_slug: event.slug))
+
+  def event_messages_url(event) = attend_url(routes.admin_event_messages_path(event_slug: event.slug))
+
+  def event_groups_url(event) = attend_url(routes.admin_event_groups_path(event_slug: event.slug))
+
+  def event_rooming_url(event) = attend_url(routes.admin_event_rooming_wizard_path(event_slug: event.slug))
+
+  def event_scanner_url(event) = attend_url(routes.scanner_admin_event_scans_path(event_slug: event.slug))
+
+  def event_airport_mode_url(event) = attend_url(routes.admin_event_airport_mode_path(event_slug: event.slug))
+
+  # The admin participant page is keyed by participant_event id, not participant
+  # id — a person has one page per event they're registered for.
+  def registration_url(participant_event, page: nil)
+    slug = participant_event.event.slug
+    id = participant_event.id
+    return attend_url(routes.admin_event_participant_path(event_slug: slug, id: id)) if page.blank?
+
+    page = page.to_s
+    raise ArgumentError, "Unknown participant page #{page}" unless PARTICIPANT_PAGES.include?(page)
+
+    attend_url(routes.public_send("#{page}_admin_event_participant_path", event_slug: slug, id: id))
+  end
+
+  def incident_admin_url(incident)
+    attend_url(routes.admin_event_incident_path(event_slug: incident.event.slug, id: incident.id))
+  end
+
+  def message_admin_url(message)
+    attend_url(routes.admin_event_message_path(event_slug: message.event.slug, id: message.id))
+  end
+
+  def ticket_url(ticket) = attend_url(routes.support_ticket_path(ticket))
+
+  # Opt-in only: a participant with no public profile has no shareable profile
+  # URL at all, and callers should say so rather than guessing a slug.
+  def public_profile_url(participant)
+    return nil unless participant.public_profile_enabled? && participant.public_profile_slug.present?
+
+    attend_url(routes.public_profile_path(slug: participant.public_profile_slug))
+  end
+
+  private
+
+  def routes = Rails.application.routes.url_helpers
+end

--- a/app/toolboxes/application_toolbox.rb
+++ b/app/toolboxes/application_toolbox.rb
@@ -6,6 +6,10 @@ class ApplicationToolbox < Toolchest::Toolbox
   # auth.scopes         — scopes the user consented to for this client
   # auth.token          — the raw OAuth access token record
 
+  # Every serialized record carries the URL of the page it lives on, so agents
+  # hand humans links instead of bare IDs.
+  include AttendUrls
+
   helper_method :current_user, :current_event, :global_admin?
 
   before_action :require_staff!

--- a/app/toolboxes/events_toolbox.rb
+++ b/app/toolboxes/events_toolbox.rb
@@ -84,7 +84,8 @@ class EventsToolbox < ApplicationToolbox
       ends_at: e.ends_at,
       timezone: e.timezone,
       location: [ e.venue_name, e.location_city, e.location_country ].compact_blank.join(", "),
-      draft: e.setup_completed_at.nil?
+      draft: e.setup_completed_at.nil?,
+      url: event_admin_url(e)
     }
     return base unless full
 
@@ -101,7 +102,16 @@ class EventsToolbox < ApplicationToolbox
         nfc_badges: e.nfc_badges_enabled?,
         visa_options: e.visa_options_enabled?
       },
-      your_role: current_user.role_for_event(e) || (current_user.global_admin? ? "global_admin" : nil)
+      your_role: current_user.role_for_event(e) || (current_user.global_admin? ? "global_admin" : nil),
+      urls: {
+        participants: event_participants_url(e),
+        incidents: event_incidents_url(e),
+        messages: event_messages_url(e),
+        groups: event_groups_url(e),
+        rooming: event_rooming_url(e),
+        scanner: event_scanner_url(e),
+        airport_mode: event_airport_mode_url(e)
+      }
     )
   end
 end

--- a/app/toolboxes/groups_toolbox.rb
+++ b/app/toolboxes/groups_toolbox.rb
@@ -8,6 +8,7 @@ class GroupsToolbox < ApplicationToolbox
     authorize! current_event, :show?
     render json: {
       event: current_event.name,
+      url: event_groups_url(current_event),
       groups: current_event.groups.ordered.map { |g| serialize_group(g) }
     }
   end

--- a/app/toolboxes/incidents_toolbox.rb
+++ b/app/toolboxes/incidents_toolbox.rb
@@ -98,7 +98,8 @@ class IncidentsToolbox < ApplicationToolbox
       status: i.status,
       summary: i.summary,
       occurred_at: i.occurred_at,
-      location: i.location
+      location: i.location,
+      url: incident_admin_url(i)
     }
     return base unless full
 

--- a/app/toolboxes/links_toolbox.rb
+++ b/app/toolboxes/links_toolbox.rb
@@ -1,0 +1,119 @@
+class LinksToolbox < ApplicationToolbox
+  # Agents kept handing people bare IDs ("her participant id is 808db791-…")
+  # because nothing told them what an Attend URL looks like. Most read tools now
+  # return a `url` on every record; this toolbox covers the rest — the page
+  # patterns, and every link that exists for one person.
+  #
+  # Templates are checked against the real route helpers in
+  # spec/toolboxes/links_toolbox_spec.rb, so they can't quietly rot.
+
+  PATTERNS = {
+    "public participant profile" => {
+      template: "/p/{public_profile_slug}",
+      notes: "Opt-in only. Participants enable it themselves at /dashboard/profile. " \
+             "If public_profile_url is null there is no profile link — say so instead of guessing a slug."
+    },
+    "event admin dashboard" => {
+      template: "/admin/{event_slug}",
+      notes: "The staff home for an event. Note the short form: no /events/ segment here."
+    },
+    "event participant list" => {
+      template: "/admin/events/{event_slug}/participants",
+      notes: "Supports ?search=, ?status= and ?flag= query params, same as the UI filters."
+    },
+    "one participant at one event" => {
+      template: "/admin/events/{event_slug}/participants/{participant_event_id}",
+      notes: "Keyed by participant_event_id (one registration), NOT participant_id. " \
+             "A person registered for three events has three of these pages."
+    },
+    "participant sub-pages" => {
+      template: "/admin/events/{event_slug}/participants/{participant_event_id}/{page}",
+      notes: "page is one of: #{AttendUrls::PARTICIPANT_PAGES.join(", ")}. " \
+             "medical and safeguarding need the matching event role."
+    },
+    "event incident" => {
+      template: "/admin/events/{event_slug}/incidents/{incident_id}",
+      notes: "List at /admin/events/{event_slug}/incidents."
+    },
+    "event message/blast" => {
+      template: "/admin/events/{event_slug}/messages/{message_id}",
+      notes: "List at /admin/events/{event_slug}/messages."
+    },
+    "event groups" => { template: "/admin/events/{event_slug}/groups", notes: nil },
+    "rooming wizard" => { template: "/admin/events/{event_slug}/rooming_wizard", notes: nil },
+    "check-in scanner" => { template: "/admin/events/{event_slug}/scans/scanner", notes: nil },
+    "airport mode" => { template: "/admin/events/{event_slug}/airport_mode", notes: nil },
+    "support ticket" => { template: "/support/tickets/{ticket_id}", notes: "Not event-scoped." },
+    "participant's own dashboard" => {
+      template: "/dashboard",
+      notes: "Renders for whoever is signed in. There is no way to link a staff user at " \
+             "another person's dashboard — link their admin participant page instead."
+    },
+    "guardian portal finder" => {
+      template: "/guardian/portals",
+      notes: "Where a guardian recovers their own portal links. Individual portal URLs contain " \
+             "a secret token and are never safe to construct or share."
+    }
+  }.freeze
+
+  tool "The URL patterns for Attend pages — use this when you need to link somewhere no other tool " \
+       "returned a url for. Read tools already include a `url` on the records they return; prefer those.",
+    access: :read, scope: %w[events:read participants:read] do
+  end
+  def patterns
+    render json: {
+      base_url: attend_base_url,
+      how_to_use: "Join base_url with a template and substitute the {placeholders}. " \
+                  "IDs are UUIDs; event_slug is the event's slug, not its name or ID.",
+      pages: PATTERNS.map { |name, pattern|
+        { page: name, url_template: "#{attend_base_url}#{pattern[:template]}", notes: pattern[:notes] }.compact
+      },
+      cautions: [
+        "Never invent a link for a page you haven't confirmed exists — say you don't have one.",
+        "Token URLs (guardian invites/portals, wallet passes, NFC badges) are secrets. Don't construct or forward them.",
+        "A participant_id alone can't be linked anywhere. Use links_participant to turn one into real URLs."
+      ]
+    }
+  end
+
+  tool "Every link that exists for one participant: their public profile if they have one, " \
+       "and their admin page (plus sub-pages) for each event you can access.",
+    access: :read, scope: "participants:read" do
+    param :participant_id, :string, "Participant ID"
+    param :event_id, :string, "Only link this event", optional: true
+    param :event_slug, :string, "Only link this event by slug", optional: true
+  end
+  def participant
+    @participant = Participant.find(params[:participant_id])
+
+    registrations = @participant.participant_events.includes(:event)
+    unless current_user.global_admin?
+      registrations = registrations.where(event_id: current_user.assigned_events.select(:id))
+    end
+    if (event = current_event)
+      registrations = registrations.where(event_id: event.id)
+    end
+    registrations = registrations.to_a
+    halt error: "You don't have access to any event this participant is registered for." if registrations.empty?
+
+    profile_url = public_profile_url(@participant)
+    render json: {
+      participant_id: @participant.id,
+      name: [ @participant.preferred_name.presence || @participant.legal_first_name,
+              @participant.legal_last_name ].join(" "),
+      public_profile_url: profile_url,
+      public_profile_note: profile_url ? nil : "No public profile. Profiles are opt-in — only the " \
+        "participant can enable one, at #{attend_url("/dashboard/profile")}. There is no profile link to share.",
+      registrations: registrations.map { |pe|
+        {
+          participant_event_id: pe.id,
+          event: pe.event.name,
+          event_slug: pe.event.slug,
+          status: pe.status,
+          url: registration_url(pe),
+          pages: AttendUrls::PARTICIPANT_PAGES.to_h { |page| [ page, registration_url(pe, page: page) ] }
+        }
+      }
+    }
+  end
+end

--- a/app/toolboxes/me_toolbox.rb
+++ b/app/toolboxes/me_toolbox.rb
@@ -10,9 +10,16 @@ class MeToolbox < ApplicationToolbox
       global_role: current_user.global_role,
       global_admin: current_user.global_admin?,
       events: current_user.event_role_assignments.includes(:event).map { |ra|
-        { id: ra.event_id, name: ra.event.name, slug: ra.event.slug, role: ra.role }
+        { id: ra.event_id, name: ra.event.name, slug: ra.event.slug, role: ra.role,
+          url: event_admin_url(ra.event) }
       },
-      accessible_scopes: auth&.scopes
+      accessible_scopes: auth&.scopes,
+      urls: {
+        # Where a participant turns their own public profile on — the only way a
+        # /p/:slug profile link ever comes into existence.
+        profile_settings: attend_url("/dashboard/profile"),
+        participant_dashboard: attend_url("/dashboard")
+      }
     }
   end
 end

--- a/app/toolboxes/messages_toolbox.rb
+++ b/app/toolboxes/messages_toolbox.rb
@@ -87,7 +87,8 @@ class MessagesToolbox < ApplicationToolbox
 
   def serialize_message(m, full: false)
     base = { id: m.id, subject: m.subject, audience: m.audience_label,
-             channels: m.channels, status: m.status, scheduled_at: m.scheduled_at, sent_at: m.sent_at }
+             channels: m.channels, status: m.status, scheduled_at: m.scheduled_at, sent_at: m.sent_at,
+             url: message_admin_url(m) }
     return base unless full
 
     base.merge(body: m.body, recipient_count: m.recipient_count,

--- a/app/toolboxes/participant_events_toolbox.rb
+++ b/app/toolboxes/participant_events_toolbox.rb
@@ -154,8 +154,11 @@ class ParticipantEventsToolbox < ApplicationToolbox
       name: [ p.preferred_name.presence || p.legal_first_name, p.legal_last_name ].join(" "),
       email: p.email,
       event: pe.event.name,
+      event_slug: pe.event.slug,
       status: pe.status,
-      checked_in: pe.check_in_time.present?
+      checked_in: pe.check_in_time.present?,
+      url: registration_url(pe),
+      public_profile_url: public_profile_url(p)
     }
   end
 

--- a/app/toolboxes/participants_toolbox.rb
+++ b/app/toolboxes/participants_toolbox.rb
@@ -75,7 +75,10 @@ class ParticipantsToolbox < ApplicationToolbox
       name: [ p.preferred_name.presence || p.legal_first_name, p.legal_last_name ].join(" "),
       legal_name: [ p.legal_first_name, p.legal_last_name ].join(" "),
       email: p.email,
-      pronouns: p.pronouns
+      pronouns: p.pronouns,
+      # Only opted-in participants have a public profile; nil means there is no
+      # shareable profile link, not that you should guess a slug.
+      public_profile_url: public_profile_url(p)
     }
     return base unless full
 
@@ -90,7 +93,8 @@ class ParticipantsToolbox < ApplicationToolbox
       registrations: p.participant_events
         .where(current_user.global_admin? ? {} : { event_id: current_user.assigned_events.select(:id) })
         .includes(:event).map { |pe|
-          { participant_event_id: pe.id, event: pe.event.name, event_slug: pe.event.slug, status: pe.status }
+          { participant_event_id: pe.id, event: pe.event.name, event_slug: pe.event.slug,
+            status: pe.status, url: registration_url(pe) }
         }
     )
   end

--- a/app/toolboxes/rooming_toolbox.rb
+++ b/app/toolboxes/rooming_toolbox.rb
@@ -17,6 +17,7 @@ class RoomingToolbox < ApplicationToolbox
     plan = current_event.rooming_plan
     render json: {
       event: current_event.name,
+      url: event_rooming_url(current_event),
       plan: plan && { status: plan.status, locked: plan.locked?, default_capacity: plan.room_capacity },
       rooms: current_event.rooms.ordered.map { |r| serialize_room(r) },
       unassigned: unassigned_registrations.map { |pe| serialize_person(pe) }

--- a/app/toolboxes/tickets_toolbox.rb
+++ b/app/toolboxes/tickets_toolbox.rb
@@ -79,7 +79,8 @@ class TicketsToolbox < ApplicationToolbox
       phone_number: t.phone_number,
       event: t.event&.name,
       assigned_to: t.assigned_to&.display_name_or_fallback,
-      last_message_at: t.last_message_at
+      last_message_at: t.last_message_at,
+      url: ticket_url(t)
     }
     return base unless full
 

--- a/config/initializers/toolchest.rb
+++ b/config/initializers/toolchest.rb
@@ -12,6 +12,11 @@ Toolchest.configure do |config|
     retrying. Prefer the read tools to orient yourself before making any changes. To port a
     rooming sheet, call rooming_overview first to map names to participant_event_ids and see
     existing rooms, then rooming_bulk_assign (it can create rooms by name as it fills them).
+    When you tell a human about a record, give them its link, not its ID: read tools return a
+    `url` on the records they serialize, links_participant turns a participant_id into every
+    link that exists for that person, and links_patterns has the URL templates for anything
+    else. Public participant profiles (/p/:slug) are opt-in, so many people simply don't have
+    one — never invent a profile URL or any other path.
   INSTRUCTIONS
 
   config.auth = :oauth

--- a/spec/toolboxes/links_toolbox_spec.rb
+++ b/spec/toolboxes/links_toolbox_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe LinksToolbox do
+  let(:routes) { Rails.application.routes.url_helpers }
+  let(:base) { AttendUrls.attend_base_url }
+
+  def run(action, params = {}, actor:)
+    toolbox = described_class.new(params: params.transform_keys(&:to_s))
+    allow(toolbox).to receive(:current_user).and_return(actor)
+    catch(:halt) { toolbox.public_send(action) }
+    toolbox
+  end
+
+  # Actions render a JSON string into @_response; errors render plain text.
+  def raw(toolbox) = toolbox.instance_variable_get(:@_response)
+
+  def payload(toolbox) = JSON.parse(raw(toolbox)[:content].first[:text], symbolize_names: true)
+
+  def error_text(toolbox) = raw(toolbox)[:content].first[:text]
+
+  describe "the published patterns" do
+    # The templates are hand-written so they stay readable; these assertions are
+    # what stops them drifting away from the routes they describe.
+    it "match the real routes they claim to describe" do
+      expected = {
+        "public participant profile" => routes.public_profile_path(slug: "slug"),
+        "event admin dashboard" => routes.admin_event_dashboard_path(slug: "slug"),
+        "event participant list" => routes.admin_event_participants_path(event_slug: "slug"),
+        "one participant at one event" => routes.admin_event_participant_path(event_slug: "slug", id: "id"),
+        "event incident" => routes.admin_event_incident_path(event_slug: "slug", id: "id"),
+        "event message/blast" => routes.admin_event_message_path(event_slug: "slug", id: "id"),
+        "event groups" => routes.admin_event_groups_path(event_slug: "slug"),
+        "rooming wizard" => routes.admin_event_rooming_wizard_path(event_slug: "slug"),
+        "check-in scanner" => routes.scanner_admin_event_scans_path(event_slug: "slug"),
+        "airport mode" => routes.admin_event_airport_mode_path(event_slug: "slug"),
+        "support ticket" => routes.support_ticket_path("id"),
+        "guardian portal finder" => routes.guardian_portal_center_path
+      }
+
+      expected.each do |page, real_path|
+        template = described_class::PATTERNS.fetch(page)[:template]
+        filled = template.gsub(/\{event_slug\}|\{public_profile_slug\}/, "slug").gsub(/\{\w+\}/, "id")
+        expect(filled).to eq(real_path), "#{page}: template #{template} does not match #{real_path}"
+      end
+    end
+
+    it "names only participant sub-pages that route" do
+      described_class::PATTERNS.fetch("participant sub-pages")
+      AttendUrls::PARTICIPANT_PAGES.each do |page|
+        expect(routes).to respond_to("#{page}_admin_event_participant_path")
+      end
+    end
+  end
+
+  describe "links_participant" do
+    let(:admin) { create(:user, global_role: "global_admin") }
+
+    it "returns the admin registration link for each event, keyed by participant_event id" do
+      pe = create(:participant_event)
+
+      data = payload(run(:participant, { participant_id: pe.participant_id }, actor: admin))
+      registration = data[:registrations].sole
+
+      expect(registration[:participant_event_id]).to eq(pe.id)
+      expect(registration[:url]).to eq("#{base}/admin/events/#{pe.event.slug}/participants/#{pe.id}")
+      expect(registration[:pages][:medical]).to end_with("/participants/#{pe.id}/medical")
+    end
+
+    it "explains that there is no profile link when the participant hasn't opted in" do
+      pe = create(:participant_event)
+
+      data = payload(run(:participant, { participant_id: pe.participant_id }, actor: admin))
+
+      expect(data[:public_profile_url]).to be_nil
+      expect(data[:public_profile_note]).to include("opt-in")
+    end
+
+    it "links the public profile of a participant who enabled one" do
+      pe = create(:participant_event)
+      pe.participant.update!(public_profile_enabled: true, public_profile_slug: "zoe-h")
+
+      data = payload(run(:participant, { participant_id: pe.participant_id }, actor: admin))
+
+      expect(data[:public_profile_url]).to eq("#{base}/p/zoe-h")
+      expect(data[:public_profile_note]).to be_nil
+    end
+
+    it "refuses to link a participant from an event the user cannot access" do
+      pe = create(:participant_event)
+      stranger = create(:user)
+
+      toolbox = run(:participant, { participant_id: pe.participant_id }, actor: stranger)
+
+      expect(raw(toolbox)[:isError]).to be(true)
+      expect(error_text(toolbox)).to include("don't have access")
+    end
+  end
+end

--- a/spec/toolboxes/participant_events_toolbox_spec.rb
+++ b/spec/toolboxes/participant_events_toolbox_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe ParticipantEventsToolbox do
     expect(serialize(pe)[:checked_in]).to be(false)
   end
 
+  it "links every registration at its admin page, keyed by participant_event id" do
+    pe = create(:participant_event, event: event)
+
+    expect(serialize(pe)[:url]).to end_with("/admin/events/#{event.slug}/participants/#{pe.id}")
+  end
+
   it "reports a participant with no check-in at all as not checked in" do
     expect(serialize(create(:participant_event, event: event))[:checked_in]).to be(false)
   end


### PR DESCRIPTION
## summary

- add canonical absolute Attend URLs to MCP/toolbox serializers
- add links_patterns and links_participant tools for discoverable, authorized links
- document opt-in public profiles and protect token-bearing URLs from being invented or shared
- verify published URL templates against Rails route helpers

## verification

- mise exec -- ruby -S bundle exec rspec spec/toolboxes (15 examples, 0 failures)
- mise exec -- ruby -S bundle exec rubocop (619 files, no offenses)
- git diff --check origin/main...HEAD

## local full-suite note

The full suite reached 1070 examples with one pre-existing, environment-dependent failure in spec/requests/api/v1/webhooks_spec.rb:247. The test stubs the old credentials lookup, while the unchanged controller reads Docuseal::HostConfig.webhook_secrets; this checkout has a real cluster secret configured and therefore returns 401 instead of the expected 503. This branch does not modify that controller or spec.