### PR TITLE
Accept all participant QR identifiers in scanners

### DIFF
--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -124,12 +124,13 @@ module Admin
         scan_source = "nfc" if participant_event
       end
 
-      # Fall back to participant_id lookup (QR code flow)
+      # Fall back to participant identifier lookup (QR code flow)
       if participant_event.nil? && params[:participant_id].present?
-        participant_event = current_event.participant_events
-          .joins(:participant)
-          .includes(:medical, :dietary)
-          .find_by(participants: { id: params[:participant_id] })
+        participant_event = ScanParticipantResolver.call(
+          event: current_event,
+          identifier: params[:participant_id],
+          includes: [ :participant, :medical, :dietary ]
+        )
       end
 
       unless participant_event

--- a/app/controllers/api/v1/scans_controller.rb
+++ b/app/controllers/api/v1/scans_controller.rb
@@ -136,18 +136,13 @@ module Api
           scan_source = "nfc" if participant_event
         end
 
-        # Fall back to participant_id lookup (QR code flow)
+        # Fall back to participant identifier lookup (QR code flow)
         if participant_event.nil? && params[:participant_id].present?
-          # Support both participant_event_id (from QR code) and participant_id
-          participant_event = @event.participant_events
-            .includes(:participant, :medical, :dietary, :safeguarding_info)
-            .find_by(id: params[:participant_id])
-
-          # Fall back to lookup by participant.id if not found by participant_event.id
-          participant_event ||= @event.participant_events
-            .joins(:participant)
-            .includes(:participant, :medical, :dietary, :safeguarding_info)
-            .find_by(participants: { id: params[:participant_id] })
+          participant_event = ScanParticipantResolver.call(
+            event: @event,
+            identifier: params[:participant_id],
+            includes: [ :participant, :medical, :dietary, :safeguarding_info ]
+          )
         end
 
         # Manual search-based scan

--- a/app/services/scan_participant_resolver.rb
+++ b/app/services/scan_participant_resolver.rb
@@ -1,0 +1,22 @@
+class ScanParticipantResolver
+  DEEP_LINK_PATTERN = /\Aattend:\/\/checkin\/(.+)\z/
+
+  def self.call(event:, identifier:, includes: [])
+    identifier = normalize(identifier)
+    return if identifier.blank?
+
+    participant_events = event.participant_events
+    participant_events = participant_events.includes(*includes) if includes.any?
+
+    participant_events.find_by(id: identifier) ||
+      participant_events.joins(:participant).find_by(participants: { id: identifier })
+  end
+
+  def self.normalize(identifier)
+    identifier = identifier.to_s.strip
+    deep_link_match = identifier.match(DEEP_LINK_PATTERN)
+    (deep_link_match ? deep_link_match[1] : identifier).strip
+  end
+
+  private_class_method :normalize
+end

--- a/spec/requests/admin/scans_spec.rb
+++ b/spec/requests/admin/scans_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Scans", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:user, global_role: "global_admin") }
+  let(:event) { create(:event) }
+  let(:participant_event) { create(:participant_event, event: event) }
+  let(:scan_context) { event.scan_contexts.find_by!(checks_in: true) }
+
+  before { sign_in admin }
+
+  describe "POST /admin/events/:event_slug/scans" do
+    {
+      "a bare participant ID" => ->(pe) { pe.participant.id },
+      "a bare participant event ID" => ->(pe) { pe.id },
+      "an Apple Wallet participant deep link" => ->(pe) { "attend://checkin/#{pe.participant.id}" },
+      "a participant event deep link" => ->(pe) { "attend://checkin/#{pe.id}" }
+    }.each do |description, identifier|
+      it "accepts #{description}" do
+        expect {
+          post admin_event_scans_path(event), params: {
+            participant_id: identifier.call(participant_event),
+            scan_context_id: scan_context.id
+          }, as: :json
+        }.to change { participant_event.scans.count }.by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig("participant", "participant_event_id")).to eq(participant_event.id)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/scans_spec.rb
+++ b/spec/requests/api/v1/scans_spec.rb
@@ -9,6 +9,30 @@ RSpec.describe "Api::V1::Scans", type: :request do
     { "Authorization" => "Bearer #{mobile_token.token}" }
   end
 
+  describe "POST /api/v1/events/:event_id/scans" do
+    let(:participant_event) { create(:participant_event, event: event) }
+    let(:scan_context) { event.scan_contexts.find_by!(checks_in: true) }
+
+    {
+      "a bare participant ID" => ->(pe) { pe.participant.id },
+      "a bare participant event ID" => ->(pe) { pe.id },
+      "an Apple Wallet participant deep link" => ->(pe) { "attend://checkin/#{pe.participant.id}" },
+      "a participant event deep link" => ->(pe) { "attend://checkin/#{pe.id}" }
+    }.each do |description, identifier|
+      it "accepts #{description}" do
+        expect {
+          post "/api/v1/events/#{event.id}/scans", params: {
+            participant_id: identifier.call(participant_event),
+            scan_context_id: scan_context.id
+          }, headers: auth_headers, as: :json
+        }.to change { participant_event.scans.count }.by(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig("participant", "participant_event_id")).to eq(participant_event.id)
+      end
+    end
+  end
+
   describe "GET /api/v1/events/:event_id/scans with since" do
     it "caps the response and marks it resumable" do
       stub_const("Api::V1::ScansController::SINCE_SYNC_LIMIT", 3)


### PR DESCRIPTION
## summary

- centralize participant scan identifier normalization and lookup
- accept participant and participant-event UUIDs in both web and mobile scan endpoints
- accept raw UUIDs and attend check-in deep links consistently
- add request coverage for all supported forms on both endpoints

## verification

- 10 examples, 0 failures
- rubocop: 5 files, no offenses
- git diff --check clean