### PR TITLE
Allow manual room assignments

### DIFF
--- a/app/controllers/admin/rooming_wizard_controller.rb
+++ b/app/controllers/admin/rooming_wizard_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :require_event_selected
     before_action :authorize_rooming!
     before_action :set_rooming_plan
-    before_action :require_unlocked!, only: %i[auto_assign move_assignment create_room update_room destroy_room add_staff remove_staff toggle_exempt reorder_rooms]
+    before_action :require_unlocked!, only: %i[manual_assign auto_assign move_assignment create_room update_room destroy_room add_staff remove_staff toggle_exempt reorder_rooms]
 
     def show
       redirect_to latest_wizard_step_path
@@ -128,6 +128,13 @@ module Admin
 
       redirect_to assignments_admin_event_rooming_wizard_path(@event.slug),
         notice: "Auto-assignment complete. #{result[:assigned]} participants assigned, #{result[:unassigned]} unassigned."
+    end
+
+    def manual_assign
+      @rooming_plan.update!(status: :preferences_linked)
+
+      redirect_to assignments_admin_event_rooming_wizard_path(@event.slug),
+        notice: "Manual assignment ready. Drag participants into rooms to assign them."
     end
 
     def assignments

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,5 +1,7 @@
 module DashboardHelper
   def wallet_pass_url(participant_event)
+    return if ENV["PASSKIT_WEB_SERVICE_HOST"].blank?
+
     Passkit::UrlGenerator.new(Passkit::EventTicket, participant_event).ios
   end
 

--- a/app/views/admin/rooming_wizard/preferences.html.erb
+++ b/app/views/admin/rooming_wizard/preferences.html.erb
@@ -18,8 +18,8 @@
 
   <!-- Progress Banner -->
   <div class="bg-white border border-gray-200 rounded-lg p-4">
-    <div class="flex items-center justify-between">
-      <div class="flex items-center gap-4">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
         <div class="text-sm">
           <span class="font-medium"><%= @participant_events.count %></span> participants to review
         </div>
@@ -27,9 +27,14 @@
           <span class="font-medium text-orange-600"><%= @unreviewed_count %></span> unreviewed
         </div>
       </div>
-      <div class="flex gap-3">
-        <%= form_with url: auto_assign_admin_event_rooming_wizard_path(@event.slug), method: :post, class: "inline" do %>
-          <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md  text-white bg-[#d42f46] hover:bg-[#b82840]">
+      <div class="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">
+        <%= form_with url: manual_assign_admin_event_rooming_wizard_path(@event.slug), method: :post, class: "w-full sm:w-auto" do %>
+          <button type="submit" class="inline-flex w-full cursor-pointer items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-[#ec3750]/30 sm:w-auto">
+            Assign Manually
+          </button>
+        <% end %>
+        <%= form_with url: auto_assign_admin_event_rooming_wizard_path(@event.slug), method: :post, class: "w-full sm:w-auto" do %>
+          <button type="submit" class="inline-flex w-full cursor-pointer items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-[#d42f46] hover:bg-[#b82840] focus:ring-2 focus:ring-[#ec3750]/30 sm:w-auto">
             Continue to Auto-Assign
             <svg class="ml-2 -mr-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -184,8 +184,10 @@
           Save your pass for easy access
         </p>
         <div class="flex flex-wrap gap-2 items-center">
-          <%= link_to wallet_pass_url(@participant_event), class: "inline-flex items-center hover:opacity-80 transition-opacity" do %>
-            <img src="/add-to-apple-wallet.svg" alt="Add to Apple Wallet" class="h-11">
+          <% if (apple_wallet_url = wallet_pass_url(@participant_event)) %>
+            <%= link_to apple_wallet_url, class: "inline-flex items-center hover:opacity-80 transition-opacity" do %>
+              <img src="/add-to-apple-wallet.svg" alt="Add to Apple Wallet" class="h-11">
+            <% end %>
           <% end %>
           <button
             id="google-wallet-btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,7 @@ Rails.application.routes.draw do
         get :preferences
         post :link_preference
         delete :unlink_preference
+        post :manual_assign
         post :auto_assign
         get :assignments
         post :move_assignment

--- a/spec/requests/admin/rooming_wizard_spec.rb
+++ b/spec/requests/admin/rooming_wizard_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Admin::RoomingWizard", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { User.create!(email: "admin-rooming@example.com", name: "Admin", global_role: "global_admin") }
+  let(:event) { create(:event) }
+  let!(:rooming_plan) do
+    event.create_rooming_plan!(created_by_user: admin, room_capacity: 2, status: :draft)
+  end
+
+  before { sign_in admin }
+
+  describe "GET preferences" do
+    it "offers manual assignment without auto-assigning" do
+      get preferences_admin_event_rooming_wizard_path(event.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Assign Manually")
+      expect(response.body).to include(manual_assign_admin_event_rooming_wizard_path(event.slug))
+    end
+  end
+
+  describe "POST manual_assign" do
+    it "continues to assignments without changing existing assignments" do
+      participant_event = create(:participant_event, event: event)
+      room = event.rooms.create!(capacity: 2)
+      assignment = RoomAssignment.create!(room: room, participant_event: participant_event)
+
+      expect do
+        post manual_assign_admin_event_rooming_wizard_path(event.slug)
+      end.not_to change(RoomAssignment, :count)
+
+      expect(response).to redirect_to(assignments_admin_event_rooming_wizard_path(event.slug))
+      expect(rooming_plan.reload).to be_preferences_linked
+      expect(assignment.reload.room).to eq(room)
+    end
+
+    it "makes assignments the latest wizard step" do
+      post manual_assign_admin_event_rooming_wizard_path(event.slug)
+
+      get admin_event_rooming_wizard_path(event.slug)
+
+      expect(response).to redirect_to(assignments_admin_event_rooming_wizard_path(event.slug))
+    end
+  end
+end

--- a/spec/requests/dashboard_wallets_spec.rb
+++ b/spec/requests/dashboard_wallets_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard wallet passes", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+  let(:participant) { create(:participant, user: user) }
+  let(:participant_event) { create(:participant_event, participant: participant, status: :complete) }
+
+  before { sign_in user }
+
+  it "hides the Apple Wallet action when Passkit is not configured" do
+    web_service_host = ENV.delete("PASSKIT_WEB_SERVICE_HOST")
+
+    get dashboard_event_path(participant_event)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("Add to Apple Wallet")
+    expect(response.body).to include("Add to Google Wallet")
+  ensure
+    ENV["PASSKIT_WEB_SERVICE_HOST"] = web_service_host
+  end
+end


### PR DESCRIPTION
## summary

- add an Assign Manually path that skips auto-assignment and preserves existing room assignments
- remember manual assignment as the latest rooming wizard step
- make the preference-step actions responsive on mobile
- hide the Apple Wallet action when Passkit is unavailable instead of crashing the dashboard

closes #42

## testing

- `bundle exec rspec` (1153 examples, 0 failures, 3 pending)
- targeted RuboCop (5 files, no offenses)