### PR TITLE
Set invitation reply-to from event support email

### DIFF
--- a/app/mailers/participant_mailer.rb
+++ b/app/mailers/participant_mailer.rb
@@ -26,7 +26,7 @@ class ParticipantMailer < ApplicationMailer
       to: participant&.email || email,
       from: "Hack Club #{@event_name} <#{@support_email}>",
       subject: "Complete your attendee information for #{@event_name}",
-      reply_to: "attend@hackclub.com"
+      reply_to: @support_email
     )
   end
 

--- a/spec/mailers/participant_mailer_spec.rb
+++ b/spec/mailers/participant_mailer_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe ParticipantMailer, type: :mailer do
+  describe "#invitation" do
+    it "replies to the event's configured support email" do
+      event = create(:event, support_email: "organizers@hackclub.com")
+
+      mail = described_class.invitation(
+        email: "participant@example.com",
+        event: event
+      )
+
+      expect(mail.reply_to).to eq([ "organizers@hackclub.com" ])
+    end
+  end
+end


### PR DESCRIPTION
## summary\n- reply to the configured event support email for participant invitations\n- cover the reply-to behavior in the participant mailer spec\n\n## testing\n- ............................................................................................................................................................W, [2026-08-24T03:55:59.231368 #88031]  WARN -- omniauth: [hack_club] userinfo fetch failed: OAuth2::Error: 
...................................................................................................................................................................*......................................................................................**..........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) IncidentComment add some examples to (or delete) /Users/leo/.bb/worktrees/env_hbyiafufrm/attend/spec/models/incident_comment_spec.rb
     # Not yet implemented
     # ./spec/models/incident_comment_spec.rb:4

  2) SlackBlastRecipient add some examples to (or delete) /Users/leo/.bb/worktrees/env_hbyiafufrm/attend/spec/models/slack_blast_recipient_spec.rb
     # Not yet implemented
     # ./spec/models/slack_blast_recipient_spec.rb:4

  3) SlackBlast add some examples to (or delete) /Users/leo/.bb/worktrees/env_hbyiafufrm/attend/spec/models/slack_blast_spec.rb
     # Not yet implemented
     # ./spec/models/slack_blast_spec.rb:4

Finished in 27.19 seconds (files took 2.23 seconds to load)
1154 examples, 0 failures, 3 pending