### PR TITLE
Run Solid Queue in standalone worker pods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Prepare the test database
         run: bin/rails db:test:prepare
 
+      - name: Test container entrypoint
+        run: bash spec/bin/docker_entrypoint_spec.sh
+
       - name: Run tests
         run: bundle exec rspec
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-case "${PROCESS_TYPE:-web}" in
+case "${PROCESS_TYPE-web}" in
   web)
     ;;
   worker)

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+case "${PROCESS_TYPE:-web}" in
+  web)
+    ;;
+  worker)
+    set -- ./bin/jobs
+    ;;
+  *)
+    echo "Unknown PROCESS_TYPE: ${PROCESS_TYPE}" >&2
+    exit 64
+    ;;
+esac
+
 echo "=== Docker Entrypoint Starting ==="
 echo "Command: $@"
 echo "RAILS_MASTER_KEY set: ${RAILS_MASTER_KEY:+yes}"

--- a/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
+++ b/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
@@ -140,13 +140,13 @@ Call Orchard's GitHub deployment operation with exactly:
 
 `env` above means the exact in-memory array from Task 2, including `PROCESS_TYPE=worker`, not a serialized string. Capture the returned deployment ID as `staging_worker_id`.
 
-- [ ] **Step 2: Wait for the build and pod to become healthy**
-
-Poll Orchard deployment state until the build is `succeeded`, deployment state is `running`, one replica is available, and restart count is zero. On build or startup failure, inspect build logs and pod logs; do not change staging web.
-
-- [ ] **Step 3: Remove the auto-generated ingress**
+- [ ] **Step 2: Remove the auto-generated ingress**
 
 Read the deployment's ingress list, delete every ingress attached to `staging_worker_id`, then require the deployment to have no ingress and no publicly enabled service port.
+
+- [ ] **Step 3: Wait for the build and pod to become healthy**
+
+Poll Orchard deployment state until the build is `succeeded`, deployment state is `running`, one replica is available, and restart count is zero. On build or startup failure, inspect build logs and pod logs; do not change staging web.
 
 - [ ] **Step 4: Verify the worker process tree**
 

--- a/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
+++ b/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
@@ -1,0 +1,248 @@
+# Solid Queue Worker Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Solid Queue execution out of the staging and production Puma pods into independently scalable Orchard worker deployments.
+
+**Architecture:** Each environment keeps its existing web deployment and PostgreSQL-backed Solid Queue tables. A new Orchard deployment builds the same `hackclub/attend` Dockerfile from `main`, overrides the start command to `./bin/jobs`, and receives the corresponding Rails and database environment in memory from the existing web deployment. Staging is cut over and verified before production.
+
+**Tech Stack:** Rails 8.1, Solid Queue 1.4, PostgreSQL 17, Docker, Kubernetes, Orchard
+
+**Spec:** `docs/superpowers/specs/2026-08-24-solid-queue-worker-separation-design.md`
+
+## Global Constraints
+
+- Keep Solid Queue and PostgreSQL; do not add Redis or Sidekiq.
+- Do not expose either worker deployment through an ingress or public service.
+- Never write Orchard environment-variable values or database credentials to the repository, logs, plan, or final report.
+- Preserve the existing web deployments, services, ingresses, replica counts, and resource requests.
+- Keep embedded workers active until the corresponding standalone worker deployment has healthy pods and fresh Solid Queue heartbeats.
+- Complete and verify staging before creating the production worker deployment.
+- Roll back by restoring `SOLID_QUEUE_IN_PUMA=true` before pausing a faulty standalone worker.
+
+---
+
+### Task 1: Capture the Staging Baseline
+
+**Files:**
+- Read: `config/queue.yml`
+- Read: `config/puma.rb`
+- Read: `bin/jobs`
+- Read: `bin/docker-entrypoint`
+
+**Interfaces:**
+- Consumes: Orchard staging web deployment `61d39961-8f55-438a-a13b-3e223b7969e7`
+- Produces: `staging_worker_env`, an in-memory array of Orchard `{ key, value }` objects; baseline pod, queue, and database-connection observations
+
+- [ ] **Step 1: Confirm staging web and database health**
+
+Use Orchard to read deployment `61d39961-8f55-438a-a13b-3e223b7969e7` and database `fb69d175-ea99-4a19-b196-0cce0228ff34`. Require all current web replicas and the database to be healthy before proceeding.
+
+- [ ] **Step 2: Capture current Solid Queue state**
+
+Run this through `./bin/rails runner` in one staging web pod:
+
+```ruby
+puts({
+  processes: SolidQueue::Process.group(:kind).count,
+  ready: SolidQueue::ReadyExecution.count,
+  scheduled: SolidQueue::ScheduledExecution.count,
+  claimed: SolidQueue::ClaimedExecution.count,
+  blocked: SolidQueue::BlockedExecution.count,
+  failed: SolidQueue::FailedExecution.count
+}.to_json)
+```
+
+Record the output only as counts. Do not print environment values.
+
+- [ ] **Step 3: Build the staging worker environment in memory**
+
+Fetch the staging web environment from Orchard. Copy every entry except these web/build-specific keys:
+
+```ruby
+%w[SOLID_QUEUE_IN_PUMA HOST APP_REVISION GIT_REVISION]
+```
+
+Require the resulting keys to include `DATABASE_URL`, `RAILS_ENV`, and `RAILS_MASTER_KEY`, and require `RAILS_ENV` to equal `staging`. Do not display the values.
+
+### Task 2: Create and Validate the Staging Worker
+
+**Files:**
+- No repository files are changed.
+
+**Interfaces:**
+- Consumes: `staging_worker_env` from Task 1
+- Produces: `staging_worker_id`, the deployment ID returned by Orchard
+
+- [ ] **Step 1: Create the worker deployment**
+
+Call Orchard's GitHub deployment operation with exactly:
+
+```json
+{
+  "projectId": "70a03bbf-e89c-410e-aa1e-a37b5223bb60",
+  "githubRepo": "hackclub/attend",
+  "branch": "main",
+  "name": "attend-staging-worker",
+  "buildType": "dockerfile",
+  "dockerfilePath": "Dockerfile",
+  "startCommand": "./bin/jobs",
+  "port": 3000,
+  "cpuRequestMilli": 500,
+  "memoryRequestBytes": 2147483648,
+  "env": "staging_worker_env"
+}
+```
+
+`env` above means the exact in-memory array from Task 1, not a serialized string. Capture the returned deployment ID as `staging_worker_id`.
+
+- [ ] **Step 2: Wait for the build and pod to become healthy**
+
+Poll Orchard deployment state until the build is `succeeded`, deployment state is `running`, one replica is available, and restart count is zero. On build or startup failure, inspect build logs and pod logs; do not change staging web.
+
+- [ ] **Step 3: Verify the worker process tree**
+
+Read the worker pod logs and Solid Queue process records. Require fresh standalone `Supervisor`, `Worker`, `Dispatcher`, and `Scheduler` heartbeats. Require the deployment to have no ingress and no publicly enabled service port.
+
+- [ ] **Step 4: Enable worker auto-deploy**
+
+Enable auto-deploy for `staging_worker_id` on branch `main`, then read the deployment back and require `autoDeployEnabled=true`, `autoDeployBranch=main`, and `startCommand=./bin/jobs`.
+
+### Task 3: Cut Staging Web Over to the Standalone Worker
+
+**Files:**
+- No repository files are changed.
+
+**Interfaces:**
+- Consumes: `staging_worker_id` from Task 2
+- Produces: staging web without embedded Solid Queue; verified standalone job execution
+
+- [ ] **Step 1: Disable embedded workers**
+
+Delete only `SOLID_QUEUE_IN_PUMA` from staging web deployment `61d39961-8f55-438a-a13b-3e223b7969e7` through Orchard. This intentionally starts a rolling web restart.
+
+- [ ] **Step 2: Verify the staging web rollout**
+
+Require two available staging web replicas with zero unexpected restarts. Confirm the staging health endpoint from inside a pod and inspect startup logs for Rails boot or migration errors.
+
+- [ ] **Step 3: Verify standalone job execution**
+
+Enqueue a harmless marker job from a staging web pod:
+
+```ruby
+token = "standalone-worker-verification-#{SecureRandom.uuid}"
+SolidQueue::RecurringJob.perform_later(%(Rails.logger.info(#{token.dump})))
+puts token
+```
+
+Read the marker token from stdout, then require the same token to appear in the standalone worker pod logs and require the job to leave ready/claimed state.
+
+- [ ] **Step 4: Verify process ownership and database connections**
+
+Require fresh Solid Queue process heartbeats only from the standalone worker pod, with no Solid Queue supervisor process registered for either staging web pod. Query PostgreSQL connection count and require it to remain below 100.
+
+- [ ] **Step 5: Apply the staging rollback if any check fails**
+
+If Steps 2 through 4 fail, add `SOLID_QUEUE_IN_PUMA=true` back to staging web, wait for healthy embedded-worker heartbeats, then scale `staging_worker_id` to zero. Do not proceed to production.
+
+### Task 4: Capture the Production Baseline
+
+**Files:**
+- No repository files are changed.
+
+**Interfaces:**
+- Consumes: Orchard production web deployment `79b6905f-3928-4969-beaa-a95423b6a650`
+- Produces: `production_worker_env`, an in-memory array of Orchard `{ key, value }` objects; baseline pod, queue, and database-connection observations
+
+- [ ] **Step 1: Confirm production web and database health**
+
+Use Orchard to read deployment `79b6905f-3928-4969-beaa-a95423b6a650` and database `33d3b7bb-bbc2-4667-99ba-1a8c1bd1a73e`. Require three healthy web replicas, a healthy database, and a successful `https://attend.hackclub.com/up` response.
+
+- [ ] **Step 2: Capture current Solid Queue state and connection count**
+
+Run the queue-count runner from Task 1 in one production web pod. Query `pg_stat_activity` for the current database connection count and require it to remain below 100.
+
+- [ ] **Step 3: Build the production worker environment in memory**
+
+Fetch the production web environment from Orchard. Copy every entry except `SOLID_QUEUE_IN_PUMA` and `HOST`. Require the resulting keys to include `DATABASE_URL` and `RAILS_MASTER_KEY`. Do not display values.
+
+### Task 5: Create and Validate the Production Workers
+
+**Files:**
+- No repository files are changed.
+
+**Interfaces:**
+- Consumes: `production_worker_env` from Task 4
+- Produces: `production_worker_id`, the deployment ID returned by Orchard
+
+- [ ] **Step 1: Create the initial worker deployment**
+
+Call Orchard's GitHub deployment operation with exactly:
+
+```json
+{
+  "projectId": "70a03bbf-e89c-410e-aa1e-a37b5223bb60",
+  "githubRepo": "hackclub/attend",
+  "branch": "main",
+  "name": "attend-worker",
+  "buildType": "dockerfile",
+  "dockerfilePath": "Dockerfile",
+  "startCommand": "./bin/jobs",
+  "port": 3000,
+  "cpuRequestMilli": 1000,
+  "memoryRequestBytes": 2147483648,
+  "env": "production_worker_env"
+}
+```
+
+Capture the returned deployment ID as `production_worker_id`.
+
+- [ ] **Step 2: Validate one production worker pod**
+
+Wait for the build to succeed and one pod to run with zero restarts. Require fresh `Supervisor`, `Worker`, `Dispatcher`, and `Scheduler` heartbeats, and require no ingress or publicly enabled service port.
+
+- [ ] **Step 3: Scale to two worker replicas**
+
+Scale `production_worker_id` to two replicas. Require two available pods, zero unexpected restarts, and fresh process heartbeats from both pod hostnames.
+
+- [ ] **Step 4: Enable worker auto-deploy**
+
+Enable auto-deploy for `production_worker_id` on `main`, then read the deployment back and require `autoDeployEnabled=true`, `autoDeployBranch=main`, `startCommand=./bin/jobs`, and `replicas=2`.
+
+### Task 6: Cut Production Web Over and Complete Verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md`
+
+**Interfaces:**
+- Consumes: `production_worker_id` from Task 5
+- Produces: production web without embedded Solid Queue; two verified standalone worker replicas; completed runbook
+
+- [ ] **Step 1: Disable embedded production workers**
+
+Delete only `SOLID_QUEUE_IN_PUMA` from production web deployment `79b6905f-3928-4969-beaa-a95423b6a650` through Orchard.
+
+- [ ] **Step 2: Verify the production web rollout**
+
+Require three available web replicas with zero unexpected restarts. Require `https://attend.hackclub.com/up` to return HTTP 200 and inspect pod logs for Rails boot or migration errors.
+
+- [ ] **Step 3: Verify standalone production job execution**
+
+Enqueue the marker job from Task 3 in a production web pod. Require the marker token in one standalone worker pod's logs and require the job to leave ready/claimed state.
+
+- [ ] **Step 4: Verify final ownership and capacity**
+
+Require no Solid Queue supervisors in production web pods. Require fresh worker, dispatcher, scheduler, and supervisor heartbeats from both standalone worker pods. Require database connections below 100 and no new unexplained growth in ready, scheduled, claimed, blocked, or failed jobs.
+
+- [ ] **Step 5: Apply the production rollback if any check fails**
+
+If Steps 2 through 4 fail, add `SOLID_QUEUE_IN_PUMA=true` back to production web, wait for healthy embedded-worker heartbeats, then scale `production_worker_id` to zero.
+
+- [ ] **Step 6: Record completion**
+
+Mark every completed checkbox in this plan, append a short results section containing deployment IDs, replica counts, non-secret queue counts, connection counts, and verification outcome, then commit only this plan file:
+
+```bash
+git add docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
+git commit -m "Record standalone Solid Queue worker rollout"
+```

--- a/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
+++ b/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
@@ -167,13 +167,26 @@ Enable auto-deploy for `staging_worker_id` on branch `main`, then read the deplo
 
 - [ ] **Step 1: Disable embedded workers**
 
-Delete only `SOLID_QUEUE_IN_PUMA` from staging web deployment `61d39961-8f55-438a-a13b-3e223b7969e7` through Orchard. This intentionally starts a rolling web restart.
+Record the current UTC timestamp as `staging_cutover_started_at`, then delete only `SOLID_QUEUE_IN_PUMA` from staging web deployment `61d39961-8f55-438a-a13b-3e223b7969e7` through Orchard. This intentionally starts a rolling web restart.
 
 - [ ] **Step 2: Verify the staging web rollout**
 
 Require two available staging web replicas with zero unexpected restarts. Confirm the staging health endpoint from inside a pod and inspect startup logs for Rails boot or migration errors.
 
-- [ ] **Step 3: Verify standalone job execution**
+- [ ] **Step 3: Verify the standalone scheduler and worker together**
+
+After embedded processes have disappeared, wait up to three minutes for a naturally scheduled job matching all of these conditions:
+
+```ruby
+SolidQueue::Job
+  .where(class_name: "ProcessScheduledMessagesJob")
+  .where("created_at > ?", staging_cutover_started_at)
+  .where.not(finished_at: nil)
+```
+
+Require a matching job and its execution log in the standalone worker pod. This job is configured by `config/recurring.yml` to run every minute, so the check verifies both the standalone scheduler and worker rather than directly invoking the scheduler's internal job class.
+
+- [ ] **Step 4: Verify a harmless marker job**
 
 Enqueue a harmless marker job from a staging web pod:
 
@@ -185,13 +198,13 @@ puts token
 
 Read the marker token from stdout, then require the same token to appear in the standalone worker pod logs and require the job to leave ready/claimed state.
 
-- [ ] **Step 4: Verify process ownership and database connections**
+- [ ] **Step 5: Verify process ownership and database connections**
 
 Require fresh Solid Queue process heartbeats only from the standalone worker pod, with no Solid Queue supervisor process registered for either staging web pod. Query PostgreSQL connection count and require it to remain below 100.
 
-- [ ] **Step 5: Apply the staging rollback if any check fails**
+- [ ] **Step 6: Apply the staging rollback if any check fails**
 
-If Steps 2 through 4 fail, add `SOLID_QUEUE_IN_PUMA=true` back to staging web, wait for healthy embedded-worker heartbeats, then scale `staging_worker_id` to zero. Do not proceed to production.
+If Steps 2 through 5 fail, add `SOLID_QUEUE_IN_PUMA=true` back to staging web, wait for healthy embedded-worker heartbeats, then scale `staging_worker_id` to zero. Do not proceed to production.
 
 ### Task 5: Capture the Production Baseline
 
@@ -271,25 +284,29 @@ Enable auto-deploy for `production_worker_id` on `main`, then read the deploymen
 
 - [ ] **Step 1: Disable embedded production workers**
 
-Delete only `SOLID_QUEUE_IN_PUMA` from production web deployment `79b6905f-3928-4969-beaa-a95423b6a650` through Orchard.
+Record the current UTC timestamp as `production_cutover_started_at`, then delete only `SOLID_QUEUE_IN_PUMA` from production web deployment `79b6905f-3928-4969-beaa-a95423b6a650` through Orchard.
 
 - [ ] **Step 2: Verify the production web rollout**
 
 Require three available web replicas with zero unexpected restarts. Require `https://attend.hackclub.com/up` to return HTTP 200 and inspect pod logs for Rails boot or migration errors.
 
-- [ ] **Step 3: Verify standalone production job execution**
+- [ ] **Step 3: Verify the standalone production scheduler and worker together**
+
+After embedded processes have disappeared, wait up to three minutes for a finished `ProcessScheduledMessagesJob` created after `production_cutover_started_at`, using the query from Task 4 with the production timestamp. Require the execution log in a standalone production worker pod.
+
+- [ ] **Step 4: Verify a harmless production marker job**
 
 Enqueue the marker job from Task 4 in a production web pod. Require the marker token in one standalone worker pod's logs and require the job to leave ready/claimed state.
 
-- [ ] **Step 4: Verify final ownership and capacity**
+- [ ] **Step 5: Verify final ownership and capacity**
 
 Require no Solid Queue supervisors in production web pods. Require fresh worker, dispatcher, scheduler, and supervisor heartbeats from both standalone worker pods. Require database connections below 100 and no new unexplained growth in ready, scheduled, claimed, blocked, or failed jobs.
 
-- [ ] **Step 5: Apply the production rollback if any check fails**
+- [ ] **Step 6: Apply the production rollback if any check fails**
 
-If Steps 2 through 4 fail, add `SOLID_QUEUE_IN_PUMA=true` back to production web, wait for healthy embedded-worker heartbeats, then scale `production_worker_id` to zero.
+If Steps 2 through 5 fail, add `SOLID_QUEUE_IN_PUMA=true` back to production web, wait for healthy embedded-worker heartbeats, then scale `production_worker_id` to zero.
 
-- [ ] **Step 6: Record completion**
+- [ ] **Step 7: Record completion**
 
 Mark every completed checkbox in this plan, append a short results section containing deployment IDs, replica counts, non-secret queue counts, connection counts, and verification outcome, then commit only this plan file:
 

--- a/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
+++ b/docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Move Solid Queue execution out of the staging and production Puma pods into independently scalable Orchard worker deployments.
 
-**Architecture:** Each environment keeps its existing web deployment and PostgreSQL-backed Solid Queue tables. A new Orchard deployment builds the same `hackclub/attend` Dockerfile from `main`, overrides the start command to `./bin/jobs`, and receives the corresponding Rails and database environment in memory from the existing web deployment. Staging is cut over and verified before production.
+**Architecture:** Each environment keeps its existing web deployment and PostgreSQL-backed Solid Queue tables. A tested `PROCESS_TYPE` selector in `bin/docker-entrypoint` preserves the default web command and switches worker deployments to `./bin/jobs`. A new Orchard deployment builds the same `hackclub/attend` Dockerfile from `main`, receives the corresponding Rails and database environment in memory from the existing web deployment, and has Orchard's auto-generated ingress removed before validation. Staging is cut over and verified before production.
 
 **Tech Stack:** Rails 8.1, Solid Queue 1.4, PostgreSQL 17, Docker, Kubernetes, Orchard
 
@@ -13,7 +13,7 @@
 ## Global Constraints
 
 - Keep Solid Queue and PostgreSQL; do not add Redis or Sidekiq.
-- Do not expose either worker deployment through an ingress or public service.
+- Delete Orchard's auto-generated worker ingress immediately after deployment creation, and do not expose either worker through any other ingress or public service.
 - Never write Orchard environment-variable values or database credentials to the repository, logs, plan, or final report.
 - Preserve the existing web deployments, services, ingresses, replica counts, and resource requests.
 - Keep embedded workers active until the corresponding standalone worker deployment has healthy pods and fresh Solid Queue heartbeats.
@@ -22,7 +22,52 @@
 
 ---
 
-### Task 1: Capture the Staging Baseline
+### Task 1: Add and Land the Container Process Role
+
+**Files:**
+- Modify: `bin/docker-entrypoint`
+- Create: `spec/bin/docker_entrypoint_spec.sh`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: `PROCESS_TYPE`, with supported values `web` and `worker`
+- Produces: a Docker entrypoint that preserves the image command for `web`, runs `./bin/jobs` for `worker`, and exits 64 for any other value
+
+- [x] **Step 1: Write and run the failing worker-role test**
+
+Execute the real entrypoint from a temporary directory containing controlled `bin/rails`, `bin/jobs`, and `bin/thrust` executables. Require `PROCESS_TYPE=worker` to execute `bin/jobs` without executing `db:prepare` or Thruster.
+
+Run:
+
+```bash
+bash spec/bin/docker_entrypoint_spec.sh
+```
+
+Expected before implementation: exit 1 with `worker process did not start bin/jobs`.
+
+- [x] **Step 2: Implement and verify the worker role**
+
+Select `./bin/jobs` before the existing boot checks when `PROCESS_TYPE=worker`, then rerun the test and require exit 0.
+
+- [x] **Step 3: Write and run the failing invalid-role test**
+
+Require a misspelled `PROCESS_TYPE=workre` to exit nonzero without invoking Rails, jobs, or Thruster.
+
+Run the shell spec and require it to fail with `invalid process type did not fail` before implementing validation.
+
+- [x] **Step 4: Implement fail-closed validation and verify both roles**
+
+Accept `web` and `worker`, default an absent value to `web`, and exit 64 for every other value. Rerun the shell spec and require exit 0.
+
+- [x] **Step 5: Add the shell spec to continuous integration**
+
+Add a `Test container entrypoint` step running `bash spec/bin/docker_entrypoint_spec.sh` immediately before the RSpec step in `.github/workflows/ci.yml`.
+
+- [ ] **Step 6: Commit and land the change on `main`**
+
+Commit the entrypoint, test, CI, design, and plan changes. Push the working branch, create or update its pull request, merge it after required checks pass, then require both existing web deployments to auto-deploy the merged commit and return to their existing healthy replica counts before creating a worker.
+
+### Task 2: Capture the Staging Baseline
 
 **Files:**
 - Read: `config/queue.yml`
@@ -60,18 +105,18 @@ Record the output only as counts. Do not print environment values.
 Fetch the staging web environment from Orchard. Copy every entry except these web/build-specific keys:
 
 ```ruby
-%w[SOLID_QUEUE_IN_PUMA HOST APP_REVISION GIT_REVISION]
+%w[SOLID_QUEUE_IN_PUMA HOST APP_REVISION GIT_REVISION PROCESS_TYPE]
 ```
 
-Require the resulting keys to include `DATABASE_URL`, `RAILS_ENV`, and `RAILS_MASTER_KEY`, and require `RAILS_ENV` to equal `staging`. Do not display the values.
+Require the resulting keys to include `DATABASE_URL`, `RAILS_ENV`, and `RAILS_MASTER_KEY`, and require `RAILS_ENV` to equal `staging`. Add `{ key: "PROCESS_TYPE", value: "worker" }`. Do not display the other values.
 
-### Task 2: Create and Validate the Staging Worker
+### Task 3: Create and Validate the Staging Worker
 
 **Files:**
 - No repository files are changed.
 
 **Interfaces:**
-- Consumes: `staging_worker_env` from Task 1
+- Consumes: `staging_worker_env` from Task 2
 - Produces: `staging_worker_id`, the deployment ID returned by Orchard
 
 - [ ] **Step 1: Create the worker deployment**
@@ -86,7 +131,6 @@ Call Orchard's GitHub deployment operation with exactly:
   "name": "attend-staging-worker",
   "buildType": "dockerfile",
   "dockerfilePath": "Dockerfile",
-  "startCommand": "./bin/jobs",
   "port": 3000,
   "cpuRequestMilli": 500,
   "memoryRequestBytes": 2147483648,
@@ -94,27 +138,31 @@ Call Orchard's GitHub deployment operation with exactly:
 }
 ```
 
-`env` above means the exact in-memory array from Task 1, not a serialized string. Capture the returned deployment ID as `staging_worker_id`.
+`env` above means the exact in-memory array from Task 2, including `PROCESS_TYPE=worker`, not a serialized string. Capture the returned deployment ID as `staging_worker_id`.
 
 - [ ] **Step 2: Wait for the build and pod to become healthy**
 
 Poll Orchard deployment state until the build is `succeeded`, deployment state is `running`, one replica is available, and restart count is zero. On build or startup failure, inspect build logs and pod logs; do not change staging web.
 
-- [ ] **Step 3: Verify the worker process tree**
+- [ ] **Step 3: Remove the auto-generated ingress**
 
-Read the worker pod logs and Solid Queue process records. Require fresh standalone `Supervisor`, `Worker`, `Dispatcher`, and `Scheduler` heartbeats. Require the deployment to have no ingress and no publicly enabled service port.
+Read the deployment's ingress list, delete every ingress attached to `staging_worker_id`, then require the deployment to have no ingress and no publicly enabled service port.
 
-- [ ] **Step 4: Enable worker auto-deploy**
+- [ ] **Step 4: Verify the worker process tree**
 
-Enable auto-deploy for `staging_worker_id` on branch `main`, then read the deployment back and require `autoDeployEnabled=true`, `autoDeployBranch=main`, and `startCommand=./bin/jobs`.
+Read the worker pod logs and require `Command: ./bin/jobs`, with no `Running db:prepare` or Puma startup. Require fresh standalone `Supervisor`, `Worker`, `Dispatcher`, and `Scheduler` heartbeats.
 
-### Task 3: Cut Staging Web Over to the Standalone Worker
+- [ ] **Step 5: Enable worker auto-deploy**
+
+Enable auto-deploy for `staging_worker_id` on branch `main`, then read the deployment back and require `autoDeployEnabled=true`, `autoDeployBranch=main`, and `PROCESS_TYPE=worker`.
+
+### Task 4: Cut Staging Web Over to the Standalone Worker
 
 **Files:**
 - No repository files are changed.
 
 **Interfaces:**
-- Consumes: `staging_worker_id` from Task 2
+- Consumes: `staging_worker_id` from Task 3
 - Produces: staging web without embedded Solid Queue; verified standalone job execution
 
 - [ ] **Step 1: Disable embedded workers**
@@ -145,7 +193,7 @@ Require fresh Solid Queue process heartbeats only from the standalone worker pod
 
 If Steps 2 through 4 fail, add `SOLID_QUEUE_IN_PUMA=true` back to staging web, wait for healthy embedded-worker heartbeats, then scale `staging_worker_id` to zero. Do not proceed to production.
 
-### Task 4: Capture the Production Baseline
+### Task 5: Capture the Production Baseline
 
 **Files:**
 - No repository files are changed.
@@ -160,19 +208,19 @@ Use Orchard to read deployment `79b6905f-3928-4969-beaa-a95423b6a650` and databa
 
 - [ ] **Step 2: Capture current Solid Queue state and connection count**
 
-Run the queue-count runner from Task 1 in one production web pod. Query `pg_stat_activity` for the current database connection count and require it to remain below 100.
+Run the queue-count runner from Task 2 in one production web pod. Query `pg_stat_activity` for the current database connection count and require it to remain below 100.
 
 - [ ] **Step 3: Build the production worker environment in memory**
 
-Fetch the production web environment from Orchard. Copy every entry except `SOLID_QUEUE_IN_PUMA` and `HOST`. Require the resulting keys to include `DATABASE_URL` and `RAILS_MASTER_KEY`. Do not display values.
+Fetch the production web environment from Orchard. Copy every entry except `SOLID_QUEUE_IN_PUMA`, `HOST`, and `PROCESS_TYPE`. Require the resulting keys to include `DATABASE_URL` and `RAILS_MASTER_KEY`. Add `{ key: "PROCESS_TYPE", value: "worker" }`. Do not display the other values.
 
-### Task 5: Create and Validate the Production Workers
+### Task 6: Create and Validate the Production Workers
 
 **Files:**
 - No repository files are changed.
 
 **Interfaces:**
-- Consumes: `production_worker_env` from Task 4
+- Consumes: `production_worker_env` from Task 5
 - Produces: `production_worker_id`, the deployment ID returned by Orchard
 
 - [ ] **Step 1: Create the initial worker deployment**
@@ -187,7 +235,6 @@ Call Orchard's GitHub deployment operation with exactly:
   "name": "attend-worker",
   "buildType": "dockerfile",
   "dockerfilePath": "Dockerfile",
-  "startCommand": "./bin/jobs",
   "port": 3000,
   "cpuRequestMilli": 1000,
   "memoryRequestBytes": 2147483648,
@@ -197,25 +244,29 @@ Call Orchard's GitHub deployment operation with exactly:
 
 Capture the returned deployment ID as `production_worker_id`.
 
-- [ ] **Step 2: Validate one production worker pod**
+- [ ] **Step 2: Remove the auto-generated ingress**
 
-Wait for the build to succeed and one pod to run with zero restarts. Require fresh `Supervisor`, `Worker`, `Dispatcher`, and `Scheduler` heartbeats, and require no ingress or publicly enabled service port.
+Delete every ingress attached to `production_worker_id`, then require no ingress and no publicly enabled service port.
 
-- [ ] **Step 3: Scale to two worker replicas**
+- [ ] **Step 3: Validate one production worker pod**
+
+Wait for the build to succeed and one pod to run with zero restarts. Require logs to show `Command: ./bin/jobs` without `Running db:prepare` or Puma startup. Require fresh `Supervisor`, `Worker`, `Dispatcher`, and `Scheduler` heartbeats.
+
+- [ ] **Step 4: Scale to two worker replicas**
 
 Scale `production_worker_id` to two replicas. Require two available pods, zero unexpected restarts, and fresh process heartbeats from both pod hostnames.
 
-- [ ] **Step 4: Enable worker auto-deploy**
+- [ ] **Step 5: Enable worker auto-deploy**
 
-Enable auto-deploy for `production_worker_id` on `main`, then read the deployment back and require `autoDeployEnabled=true`, `autoDeployBranch=main`, `startCommand=./bin/jobs`, and `replicas=2`.
+Enable auto-deploy for `production_worker_id` on `main`, then read the deployment back and require `autoDeployEnabled=true`, `autoDeployBranch=main`, `PROCESS_TYPE=worker`, and `replicas=2`.
 
-### Task 6: Cut Production Web Over and Complete Verification
+### Task 7: Cut Production Web Over and Complete Verification
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-08-24-solid-queue-worker-separation.md`
 
 **Interfaces:**
-- Consumes: `production_worker_id` from Task 5
+- Consumes: `production_worker_id` from Task 6
 - Produces: production web without embedded Solid Queue; two verified standalone worker replicas; completed runbook
 
 - [ ] **Step 1: Disable embedded production workers**
@@ -228,7 +279,7 @@ Require three available web replicas with zero unexpected restarts. Require `htt
 
 - [ ] **Step 3: Verify standalone production job execution**
 
-Enqueue the marker job from Task 3 in a production web pod. Require the marker token in one standalone worker pod's logs and require the job to leave ready/claimed state.
+Enqueue the marker job from Task 4 in a production web pod. Require the marker token in one standalone worker pod's logs and require the job to leave ready/claimed state.
 
 - [ ] **Step 4: Verify final ownership and capacity**
 

--- a/docs/superpowers/specs/2026-08-24-solid-queue-worker-separation-design.md
+++ b/docs/superpowers/specs/2026-08-24-solid-queue-worker-separation-design.md
@@ -8,13 +8,13 @@ this change does not introduce redis or sidekiq. jobs remain durable in postgres
 
 ## considered approaches
 
-### 1. separate orchard deployments with a start-command override
+### 1. separate orchard deployments with an explicit process role
 
-build the existing dockerfile from the same github repository, but override the worker deployment's command to `./bin/jobs`.
+build the existing dockerfile from the same github repository. set `PROCESS_TYPE=worker` on worker deployments, and have `bin/docker-entrypoint` replace the image's default web command with `./bin/jobs` before performing its boot checks.
 
 advantages:
 
-- no application-code or image-layout change
+- one small, tested application-entrypoint change
 - uses the existing supported solid queue executable
 - web and worker replicas can be scaled independently
 - both roles can continue auto-deploying from `main`
@@ -24,8 +24,11 @@ tradeoffs:
 - orchard builds the repository once for each deployment
 - web and worker rollouts can briefly overlap different commits
 - workers do not expose an http health endpoint, so health is verified through pod state, logs, and solid queue heartbeats
+- orchard's github deployment flow creates a protected ingress automatically, so the worker ingress must be deleted immediately after creation
 
 this is the selected approach.
+
+orchard's dockerfile `startCommand` override was tested and rejected: orchard persisted `./bin/jobs` in deployment metadata, but the generated kubernetes pod still ran the Dockerfile's default puma command. the failed staging deployment and its generated ingress were deleted before any web-tier change.
 
 ### 2. add a worker-specific dockerfile
 
@@ -48,7 +51,7 @@ this is operationally simple, but every web replica also creates a solid queue s
 - github repository: `hackclub/attend`
 - branch: `main`
 - dockerfile: `Dockerfile`
-- start command: `./bin/jobs`
+- environment: `PROCESS_TYPE=worker`
 - replicas: 1
 - initial resources: 500 millicpu and 2 gibibytes memory per pod
 - no ingress and no public service exposure
@@ -61,7 +64,7 @@ this is operationally simple, but every web replica also creates a solid queue s
 - github repository: `hackclub/attend`
 - branch: `main`
 - dockerfile: `Dockerfile`
-- start command: `./bin/jobs`
+- environment: `PROCESS_TYPE=worker`
 - replicas: 2, allowing one worker pod or node to fail without stopping job processing
 - initial resources: 1000 millicpu and 2 gibibytes memory per pod
 - no ingress and no public service exposure
@@ -71,7 +74,7 @@ the worker deployments receive the environment needed to boot the corresponding 
 
 ## startup and migrations
 
-the existing container entrypoint performs a rails boot check for every process. it only runs `db:prepare` and secondary-schema setup for the rails server command, so standalone workers will not attempt concurrent schema changes.
+the container entrypoint defaults `PROCESS_TYPE` to `web`, preserving the existing Dockerfile command. `PROCESS_TYPE=worker` replaces that command with `./bin/jobs`; any other value fails closed before Rails boots. the entrypoint performs a Rails boot check for every valid process, but it only runs `db:prepare` and secondary-schema setup for the Rails server command, so standalone workers do not attempt concurrent schema changes.
 
 web and worker builds can complete in either order when both deployments auto-deploy from `main`. migrations must remain compatible with the preceding application release because the web tier already uses rolling updates and old web pods remain live while a new pod runs `db:prepare`. the worker separation does not create a new migration-safety requirement, but it makes release-version overlap more visible.
 
@@ -80,13 +83,14 @@ web and worker builds can complete in either order when both deployments auto-de
 each environment is migrated independently, staging first.
 
 1. record the existing web, database, and solid queue state.
-2. create the standalone worker deployment while embedded puma workers remain active.
-3. wait for all worker pods to run without restarts.
-4. verify solid queue registers the expected standalone processes and has fresh heartbeats.
-5. observe an existing recurring job being claimed and completed by the standalone worker.
-6. remove `SOLID_QUEUE_IN_PUMA` from the web deployment, triggering a rolling restart.
-7. verify web health, worker health, queue progress, and the absence of solid queue supervisors in web pods.
-8. observe logs, restarts, database connections, cpu, and memory before proceeding to the next environment.
+2. create the standalone worker deployment with `PROCESS_TYPE=worker` while embedded puma workers remain active.
+3. delete the worker deployment's auto-generated ingress and verify that it has no public exposure.
+4. wait for all worker pods to run without restarts.
+5. verify solid queue registers the expected standalone processes and has fresh heartbeats.
+6. observe an existing recurring job being claimed and completed by the standalone worker.
+7. remove `SOLID_QUEUE_IN_PUMA` from the web deployment, triggering a rolling restart.
+8. verify web health, worker health, queue progress, and the absence of solid queue supervisors in web pods.
+9. observe logs, restarts, database connections, cpu, and memory before proceeding to the next environment.
 
 brief duplicate worker capacity during the cutover is safe because solid queue coordinates claims in postgresql.
 

--- a/docs/superpowers/specs/2026-08-24-solid-queue-worker-separation-design.md
+++ b/docs/superpowers/specs/2026-08-24-solid-queue-worker-separation-design.md
@@ -1,0 +1,117 @@
+# solid queue worker separation
+
+## objective
+
+run solid queue outside the puma web pods in both staging and production. web request capacity and background-job capacity must be independently scalable, and a worker failure must not remove a web replica.
+
+this change does not introduce redis or sidekiq. jobs remain durable in postgresql through solid queue.
+
+## considered approaches
+
+### 1. separate orchard deployments with a start-command override
+
+build the existing dockerfile from the same github repository, but override the worker deployment's command to `./bin/jobs`.
+
+advantages:
+
+- no application-code or image-layout change
+- uses the existing supported solid queue executable
+- web and worker replicas can be scaled independently
+- both roles can continue auto-deploying from `main`
+
+tradeoffs:
+
+- orchard builds the repository once for each deployment
+- web and worker rollouts can briefly overlap different commits
+- workers do not expose an http health endpoint, so health is verified through pod state, logs, and solid queue heartbeats
+
+this is the selected approach.
+
+### 2. add a worker-specific dockerfile
+
+add `Dockerfile.worker` with `CMD ["./bin/jobs"]` and deploy it separately.
+
+this makes the process role explicit in source control, but duplicates dockerfile maintenance and still requires separate builds. it adds code without improving runtime isolation.
+
+### 3. keep solid queue embedded in puma
+
+retain `SOLID_QUEUE_IN_PUMA=true` and scale web and job capacity together.
+
+this is operationally simple, but every web replica also creates a solid queue supervisor, dispatcher, scheduler, and worker. it couples failure domains, resource usage, and database connection growth, which is what this change is intended to remove.
+
+## target topology
+
+### staging
+
+- existing `attend-staging` deployment remains the web tier
+- new `attend-staging-worker` deployment
+- github repository: `hackclub/attend`
+- branch: `main`
+- dockerfile: `Dockerfile`
+- start command: `./bin/jobs`
+- replicas: 1
+- initial resources: 500 millicpu and 2 gibibytes memory per pod
+- no ingress and no public service exposure
+- `SOLID_QUEUE_IN_PUMA` absent
+
+### production
+
+- existing `attend` deployment remains the web tier
+- new `attend-worker` deployment
+- github repository: `hackclub/attend`
+- branch: `main`
+- dockerfile: `Dockerfile`
+- start command: `./bin/jobs`
+- replicas: 2, allowing one worker pod or node to fail without stopping job processing
+- initial resources: 1000 millicpu and 2 gibibytes memory per pod
+- no ingress and no public service exposure
+- `SOLID_QUEUE_IN_PUMA` absent
+
+the worker deployments receive the environment needed to boot the corresponding rails environment and connect to its existing internal postgresql endpoint. secret values are copied through orchard and are not written to this repository.
+
+## startup and migrations
+
+the existing container entrypoint performs a rails boot check for every process. it only runs `db:prepare` and secondary-schema setup for the rails server command, so standalone workers will not attempt concurrent schema changes.
+
+web and worker builds can complete in either order when both deployments auto-deploy from `main`. migrations must remain compatible with the preceding application release because the web tier already uses rolling updates and old web pods remain live while a new pod runs `db:prepare`. the worker separation does not create a new migration-safety requirement, but it makes release-version overlap more visible.
+
+## rollout
+
+each environment is migrated independently, staging first.
+
+1. record the existing web, database, and solid queue state.
+2. create the standalone worker deployment while embedded puma workers remain active.
+3. wait for all worker pods to run without restarts.
+4. verify solid queue registers the expected standalone processes and has fresh heartbeats.
+5. observe an existing recurring job being claimed and completed by the standalone worker.
+6. remove `SOLID_QUEUE_IN_PUMA` from the web deployment, triggering a rolling restart.
+7. verify web health, worker health, queue progress, and the absence of solid queue supervisors in web pods.
+8. observe logs, restarts, database connections, cpu, and memory before proceeding to the next environment.
+
+brief duplicate worker capacity during the cutover is safe because solid queue coordinates claims in postgresql.
+
+## failure and rollback
+
+if a standalone worker deployment fails before embedded workers are disabled, leave the web deployment unchanged and repair or remove the new worker deployment.
+
+if a failure appears after cutover:
+
+1. restore `SOLID_QUEUE_IN_PUMA=true` on the web deployment.
+2. wait for the web rollout and embedded worker heartbeats.
+3. scale the standalone worker deployment to zero or remove it after job processing is confirmed.
+
+queued jobs remain in postgresql throughout the transition.
+
+## verification criteria
+
+an environment is complete only when:
+
+- every web and worker pod is running with zero unexpected restarts
+- the web health endpoint succeeds
+- an existing recurring job completes on a standalone worker
+- solid queue heartbeats are fresh
+- web pods no longer run solid queue supervisors
+- ready, scheduled, claimed, blocked, and failed job counts show no new unexplained growth
+- database connection usage remains below the current 100-connection limit
+
+production is changed only after staging meets these criteria.

--- a/spec/bin/docker_entrypoint_spec.sh
+++ b/spec/bin/docker_entrypoint_spec.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+test_root="$(mktemp -d)"
+calls_file="$test_root/calls"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+mkdir -p "$test_root/bin"
+
+cat > "$test_root/bin/rails" <<'SCRIPT'
+#!/bin/bash
+printf 'rails:%s\n' "$*" >> "$CALLS_FILE"
+SCRIPT
+
+cat > "$test_root/bin/jobs" <<'SCRIPT'
+#!/bin/bash
+printf 'jobs:%s\n' "$*" >> "$CALLS_FILE"
+SCRIPT
+
+cat > "$test_root/bin/thrust" <<'SCRIPT'
+#!/bin/bash
+printf 'thrust:%s\n' "$*" >> "$CALLS_FILE"
+SCRIPT
+
+chmod +x "$test_root/bin/rails" "$test_root/bin/jobs" "$test_root/bin/thrust"
+
+(
+  cd "$test_root"
+  CALLS_FILE="$calls_file" PROCESS_TYPE=worker \
+    "$repo_root/bin/docker-entrypoint" ./bin/thrust ./bin/rails server >/dev/null
+)
+
+if ! grep -qx 'jobs:' "$calls_file"; then
+  echo "worker process did not start bin/jobs" >&2
+  exit 1
+fi
+if grep -q '^rails:db:prepare$' "$calls_file"; then
+  echo "worker process ran db:prepare" >&2
+  exit 1
+fi
+if grep -q '^thrust:' "$calls_file"; then
+  echo "worker process started the web server" >&2
+  exit 1
+fi
+
+: > "$calls_file"
+
+set +e
+(
+  cd "$test_root"
+  CALLS_FILE="$calls_file" PROCESS_TYPE=workre \
+    "$repo_root/bin/docker-entrypoint" ./bin/thrust ./bin/rails server >/dev/null 2>&1
+)
+invalid_status=$?
+set -e
+
+if [ "$invalid_status" -eq 0 ]; then
+  echo "invalid process type did not fail" >&2
+  exit 1
+fi
+if [ -s "$calls_file" ]; then
+  echo "invalid process type started a container process" >&2
+  exit 1
+fi
+
+: > "$calls_file"
+
+(
+  cd "$test_root"
+  CALLS_FILE="$calls_file" \
+    "$repo_root/bin/docker-entrypoint" ./bin/thrust ./bin/rails server >/dev/null
+)
+
+grep -qx 'rails:db:prepare' "$calls_file"
+grep -qx 'rails:db:ensure_secondary_schemas' "$calls_file"
+grep -qx 'thrust:./bin/rails server' "$calls_file"

--- a/spec/bin/docker_entrypoint_spec.sh
+++ b/spec/bin/docker_entrypoint_spec.sh
@@ -44,6 +44,14 @@ if grep -q '^rails:db:prepare$' "$calls_file"; then
   echo "worker process ran db:prepare" >&2
   exit 1
 fi
+if grep -q '^rails:db:ensure_secondary_schemas$' "$calls_file"; then
+  echo "worker process ensured secondary schemas" >&2
+  exit 1
+fi
+if grep -q '^rails:server$' "$calls_file"; then
+  echo "worker process started Rails directly" >&2
+  exit 1
+fi
 if grep -q '^thrust:' "$calls_file"; then
   echo "worker process started the web server" >&2
   exit 1
@@ -60,8 +68,8 @@ set +e
 invalid_status=$?
 set -e
 
-if [ "$invalid_status" -eq 0 ]; then
-  echo "invalid process type did not fail" >&2
+if [ "$invalid_status" -ne 64 ]; then
+  echo "invalid process type exited $invalid_status instead of 64" >&2
   exit 1
 fi
 if [ -s "$calls_file" ]; then
@@ -71,9 +79,41 @@ fi
 
 : > "$calls_file"
 
+set +e
+(
+  cd "$test_root"
+  CALLS_FILE="$calls_file" PROCESS_TYPE= \
+    "$repo_root/bin/docker-entrypoint" ./bin/thrust ./bin/rails server >/dev/null 2>&1
+)
+empty_status=$?
+set -e
+
+if [ "$empty_status" -ne 64 ]; then
+  echo "empty process type exited $empty_status instead of 64" >&2
+  exit 1
+fi
+if [ -s "$calls_file" ]; then
+  echo "empty process type started a container process" >&2
+  exit 1
+fi
+
+: > "$calls_file"
+
 (
   cd "$test_root"
   CALLS_FILE="$calls_file" \
+    "$repo_root/bin/docker-entrypoint" ./bin/thrust ./bin/rails server >/dev/null
+)
+
+grep -qx 'rails:db:prepare' "$calls_file"
+grep -qx 'rails:db:ensure_secondary_schemas' "$calls_file"
+grep -qx 'thrust:./bin/rails server' "$calls_file"
+
+: > "$calls_file"
+
+(
+  cd "$test_root"
+  CALLS_FILE="$calls_file" PROCESS_TYPE=web \
     "$repo_root/bin/docker-entrypoint" ./bin/thrust ./bin/rails server >/dev/null
 )
 


### PR DESCRIPTION
Separates the container process role from Puma by adding a fail-closed PROCESS_TYPE selector to the Docker entrypoint. Adds a real shell regression test to CI and documents the staging-first Orchard rollout, ingress removal, verification, and rollback gates. No Redis or Sidekiq is introduced.