### PR TITLE
Add opt-in read-replica plumbing for the CNPG cluster

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,13 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # primary_replica only exists when REPLICA_DATABASE_URL is set (see
+  # config/database.yml). There is no automatic read/write-splitting middleware
+  # — some GET requests write (e.g. guardian portals heal expired invites), so
+  # replica reads are opt-in via `connected_to(role: :reading)`.
+  if ActiveRecord::Base.configurations.configs_for(
+    env_name: Rails.env, name: "primary_replica", include_hidden: true
+  )
+    connects_to database: { writing: :primary, reading: :primary_replica }
+  end
 end

--- a/config/blazer.yml
+++ b/config/blazer.yml
@@ -2,9 +2,12 @@
 
 data_sources:
   main:
-    # Same precedence as config/database.yml — otherwise Blazer on a non-production
-    # deployment would query whichever database the credentials file names.
-    url: <%= ENV["DATABASE_URL"] || Rails.application.credentials.dig(:database_url) %>
+    # BLAZER_DATABASE_URL points analytics queries at the CNPG read-only
+    # service so long-running admin queries stay off the primary. The rest is
+    # the same precedence as config/database.yml — otherwise Blazer on a
+    # non-production deployment would query whichever database the credentials
+    # file names.
+    url: <%= ENV["BLAZER_DATABASE_URL"] || ENV["DATABASE_URL"] || Rails.application.credentials.dig(:database_url) %>
 
     # statement timeout, in seconds
     # none by default

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,14 @@ default: &default
   # (The key must be `pool:` — Active Record silently ignores unknown keys
   # like max_connections, leaving the pool at its default.)
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  # Production runs on a CloudNativePG cluster whose -rw service repoints to a
+  # new primary during failover. While that happens, established connections
+  # drop and new connects find no ready endpoint. Retry idempotent statements
+  # on a fresh connection (bounded to 10s) rather than failing the request, and
+  # cap connect attempts so a request thread doesn't hang on a dead endpoint.
+  connection_retries: 3
+  retry_deadline: 10
+  connect_timeout: 5
 
 
 development:
@@ -90,6 +98,18 @@ production:
   primary: &primary_production
     <<: *default
     url: <%= ENV["DATABASE_URL"] || Rails.application.credentials.dig(:database_url) %>
+<% if ENV["REPLICA_DATABASE_URL"] %>
+  # Hot-standby reads via the CNPG -ro service. Only defined when the env var
+  # is set so environments without replicas (and ApplicationRecord.connects_to,
+  # which keys off this config existing) are unaffected. Deliberately the -ro
+  # service rather than -r: -r includes the primary, so an accidental write on
+  # the reading role would succeed intermittently instead of failing every time.
+  primary_replica:
+    <<: *primary_production
+    url: <%= ENV["REPLICA_DATABASE_URL"] %>
+    replica: true
+    database_tasks: false
+<% end %>
   cache:
     <<: *primary_production
     migrations_paths: db/cache_migrate
@@ -108,6 +128,13 @@ staging:
   primary: &primary_staging
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
+<% if ENV["REPLICA_DATABASE_URL"] %>
+  primary_replica:
+    <<: *primary_staging
+    url: <%= ENV["REPLICA_DATABASE_URL"] %>
+    replica: true
+    database_tasks: false
+<% end %>
   cache:
     <<: *primary_staging
     migrations_paths: db/cache_migrate

--- a/spec/config/database_replica_spec.rb
+++ b/spec/config/database_replica_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "config/database.yml replica configuration" do
+  # Guards the ERB conditional in database.yml: primary_replica must appear
+  # exactly when REPLICA_DATABASE_URL is set, marked replica so db:prepare in
+  # the entrypoint never targets it, and pointing at the replica URL rather
+  # than inheriting the primary's.
+  def rendered_config(replica_url)
+    original = ENV["REPLICA_DATABASE_URL"]
+    ENV["REPLICA_DATABASE_URL"] = replica_url
+    yaml = ERB.new(Rails.root.join("config/database.yml").read).result
+    YAML.safe_load(yaml, aliases: true)
+  ensure
+    if original.nil?
+      ENV.delete("REPLICA_DATABASE_URL")
+    else
+      ENV["REPLICA_DATABASE_URL"] = original
+    end
+  end
+
+  context "when REPLICA_DATABASE_URL is set" do
+    let(:url) { "postgresql://user:pass@pg-ro.example:5432/app" }
+
+    it "defines primary_replica for production and staging" do
+      config = rendered_config(url)
+
+      %w[production staging].each do |env|
+        replica = config.fetch(env)["primary_replica"]
+        expect(replica).to be_present, "#{env} is missing primary_replica"
+        expect(replica["url"]).to eq(url)
+        expect(replica["replica"]).to be(true)
+        expect(replica["database_tasks"]).to be(false)
+      end
+    end
+  end
+
+  context "when REPLICA_DATABASE_URL is not set" do
+    it "omits primary_replica so connects_to keeps a single writer config" do
+      config = rendered_config(nil)
+
+      %w[production staging].each do |env|
+        expect(config.fetch(env)).not_to have_key("primary_replica")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Production now runs on a three-instance CloudNativePG cluster with automatic failover (`pg-attend-db`, scaled in place — same `-rw` URL, no data migration). This PR wires the app up to it:

- **Replica reads, opt-in**: `primary_replica` config appears when `REPLICA_DATABASE_URL` is set (pointed at the `-ro` service), and `ApplicationRecord` gains `connects_to` so `connected_to(role: :reading)` works. Deliberately **no** automatic read/write-splitting middleware: some GET requests write (guardian portals heal expired invites on GET), and blanket read-routing would break those on a hot standby. `-ro` over `-r` so an accidental write on the reading role fails every time instead of intermittently.
- **Blazer → read-only service**: `BLAZER_DATABASE_URL` moves admin analytics queries off the primary.
- **Failover hardening**: `connection_retries: 3`, `retry_deadline: 10`, `connect_timeout: 5` so request threads retry through the connection drops of a primary switch instead of failing, and don't hang while the `-rw` service has no ready endpoint.

## Why now

During this morning's in-place scale-out (09:55Z), both worker pods crashed (Solid Queue supervisor died on the dropped connection) and were restarted by k8s; web pods rode through. The retry settings shrink the blast radius of the next failover.

## Verification

- New spec guards the ERB conditional: `primary_replica` present with `replica: true` / `database_tasks: false` exactly when `REPLICA_DATABASE_URL` is set.
- Local production-mode boot with a replica URL: reading role routes to `primary_replica`, writing to `primary`, select works; without the env var the guard is a no-op (dev/test/staging unaffected).
- Rollout is env-var-gated: merging this changes nothing until `REPLICA_DATABASE_URL` / `BLAZER_DATABASE_URL` are set on the deployments, and unsetting them reverts.