### PR TITLE
Fix QR code rendering dark-on-dark in non-light themes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -353,6 +353,7 @@ def admin_tool(class_name = "", element = "div", **options, &block)
     qr = ::RQRCode::QRCode.new(data)
     qr.as_svg(
       color: "000",
+      fill: "fff",
       shape_rendering: "crispEdges",
       module_size: 4,
       standalone: true,

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -162,7 +162,9 @@
               <% end %>
             </div>
             <p class="text-xs text-[#8492a6] uppercase tracking-wide mb-2">Scan to Check In</p>
-            <div class="bg-white p-2 rounded-lg shadow-sm border border-[#e0e6ed]">
+            <%# literal white, not bg-white — themes.css remaps --color-white to the theme
+    surface, which would put black QR modules on a dark tile %>
+            <div class="bg-[#ffffff] p-2 rounded-lg shadow-sm border border-[#e0e6ed]">
               <%= qr_code_svg(attend_deep_link(@participant_event.participant_id), size: 100) %>
             </div>
             <p class="text-xs text-[#8492a6] mt-2 font-mono"><%= @participant_event.participant_id[0..7].upcase %></p>


### PR DESCRIPTION
## Problem
On the participant dashboard boarding pass, the check-in QR code rendered black modules on a dark tile in every non-light theme — effectively invisible and unscannable.

**Cause:** `themes.css` remaps Tailwind's `--color-white` token to `var(--bg-elev)` in non-light themes so `bg-white` surfaces re-skin. That's right for cards, but the QR tile was `bg-white`, so it went dark while the QR modules stayed hardcoded black (`color: "000"` in `qr_code_svg`), and the SVG had no background of its own.

## Fix
- Pin the QR tile to literal white via `bg-[#ffffff]`, which compiles to a plain `background-color:#fff` with no CSS variable for themes to remap (comment added so it doesn't get "cleaned up" back to `bg-white`)
- Add `fill: "fff"` to `qr_code_svg` so the SVG carries its own white background rect — anywhere the helper is used in future, the QR stays dark-on-light and scannable

A white QR tile in dark mode is intentional: scanners need dark-on-light contrast.

## Verification
- Rebuilt Tailwind; `.bg-\[\#ffffff\]{background-color:#fff}` present in the build
- `rails runner` output of the helper now starts with `<rect width="100" height="100" fill="#fff"/>` before the module path