### PR TITLE
Hide admin travel card when travel is disabled

### DIFF
--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -40,6 +40,7 @@
         </dl>
       </section>
 
+      <% if current_event.travel_enabled? %>
       <section class="bg-white rounded-lg border border-gray-200 p-6">
         <div class="flex justify-between items-center mb-4">
           <h2 class="text-lg font-semibold">Travel</h2>
@@ -117,6 +118,7 @@
           <p class="text-gray-500">No travel information provided.</p>
         <% end %>
       </section>
+      <% end %>
 
       <% if current_event.accommodation_enabled? %>
       <section class="bg-white rounded-lg border border-gray-200 p-6">
@@ -376,14 +378,16 @@
       <section class="bg-white rounded-lg border border-gray-200 p-6">
         <h2 class="text-lg font-semibold mb-4">Onboarding Progress</h2>
         <ul class="space-y-2">
-          <li class="flex items-center gap-2">
-            <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @travel_inbound ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
-            <span class="text-sm">Inbound Travel</span>
-          </li>
-          <li class="flex items-center gap-2">
-            <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @travel_outbound ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
-            <span class="text-sm">Outbound Travel</span>
-          </li>
+          <% if current_event.travel_enabled? %>
+            <li class="flex items-center gap-2">
+              <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @travel_inbound ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
+              <span class="text-sm">Inbound Travel</span>
+            </li>
+            <li class="flex items-center gap-2">
+              <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @travel_outbound ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>
+              <span class="text-sm">Outbound Travel</span>
+            </li>
+          <% end %>
           <% if current_event.accommodation_enabled? %>
             <li class="flex items-center gap-2">
               <span class="w-4 h-4 rounded-full flex items-center justify-center text-xs <%= @accommodation ? 'bg-green-500 text-white' : 'bg-gray-200' %>">✓</span>


### PR DESCRIPTION
The participant overview always rendered the Travel section, so events with `travel_enabled` off showed an empty "No travel information provided." card with Edit / Send Update Reminder actions for a module they don't use.

- Gate the Travel section on `current_event.travel_enabled?`, matching how the Accommodation section right below it is gated.
- Gate the Inbound/Outbound Travel rows in the Onboarding Progress sidebar too — with travel off they always rendered unchecked and read as missing data, while `ParticipantEvent#onboarding_steps` already omits travel in that case.

View-only change; no visual pass done yet on a travel-disabled event.