### PR TITLE
Track undeliverable emails and stop retrying Postmark-suppressed addresses

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -559,6 +559,12 @@ module Admin
     def send_travel_update_reminder
       authorize @participant_event, :update_travel?
 
+      if @participant_event.participant.email_undeliverable?
+        redirect_to admin_event_participant_path(current_event, @participant_event),
+          alert: "#{@participant_event.participant.email} is bouncing — correct the participant's email before sending."
+        return
+      end
+
       ParticipantMailer.travel_update_reminder(participant_event: @participant_event).deliver_later
       redirect_to admin_event_participant_path(current_event, @participant_event),
         notice: "Travel update reminder sent to #{@participant_event.participant.email}."
@@ -649,6 +655,13 @@ module Admin
       end
 
       gpe = @participant_event.guardian_participant_events.find(params[:guardian_participant_event_id])
+
+      if gpe.guardian.email_undeliverable?
+        redirect_to admin_event_participant_path(current_event, @participant_event),
+          alert: "#{gpe.guardian.email} is bouncing — correct the guardian's email before resending."
+        return
+      end
+
       gpe.update!(invite_token_sent_at: nil)
 
       GuardianMailer.invitation(guardian_participant_event: gpe).deliver_later

--- a/app/controllers/api/v1/postmark_webhooks_controller.rb
+++ b/app/controllers/api/v1/postmark_webhooks_controller.rb
@@ -10,6 +10,8 @@ module Api
           handle_delivery
         when "Bounce"
           handle_bounce
+        when "SpamComplaint"
+          handle_spam_complaint
         when "Open"
           handle_open
         when "Click"
@@ -105,10 +107,54 @@ module Api
           )
         end
 
+        # Postmark suppresses the address after a hard bounce; further sends
+        # would raise InactiveRecipientError, so flag the owner now.
+        mark_recipients_undeliverable(email_log) if params[:Type] == "HardBounce"
+
         Rails.logger.info("[Postmark Webhook] Bounce recorded for #{message_id}: #{params[:Type]}")
       rescue => e
         Rails.logger.error("[Postmark Webhook] Failed to record bounce for #{message_id}: #{e.class}: #{e.message}")
         Sentry.capture_exception(e) if defined?(Sentry)
+      end
+
+      def handle_spam_complaint
+        message_id = params[:MessageID]
+        return unless message_id
+
+        email_log = EmailLog.find_by(postmark_message_id: message_id)
+        unless email_log
+          Rails.logger.warn("[Postmark Webhook] No email log found for message_id: #{message_id}")
+          return
+        end
+
+        occurred_at = parse_timestamp(params[:BouncedAt]) || Time.current
+
+        EmailLog.transaction do
+          email_log.update!(status: "failed") unless email_log.bounced?
+          email_log.email_log_events.create!(
+            event_type: "spam_complaint",
+            occurred_at: occurred_at,
+            metadata: {
+              type_code: params[:TypeCode],
+              description: params[:Description],
+              details: params[:Details]
+            }.compact
+          )
+        end
+
+        # A spam complaint also lands the address on Postmark's suppression list.
+        mark_recipients_undeliverable(email_log)
+
+        Rails.logger.info("[Postmark Webhook] Spam complaint recorded for #{message_id}")
+      rescue => e
+        Rails.logger.error("[Postmark Webhook] Failed to record spam complaint for #{message_id}: #{e.class}: #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+      end
+
+      def mark_recipients_undeliverable(email_log)
+        addresses = email_log.to_address.to_s.split(",").map(&:strip)
+        Participant.mark_email_undeliverable!(addresses)
+        Guardian.mark_email_undeliverable!(addresses)
       end
 
       def handle_open

--- a/app/jobs/mail_delivery_job.rb
+++ b/app/jobs/mail_delivery_job.rb
@@ -1,0 +1,18 @@
+# Used for all `deliver_later` sends (config.action_mailer.delivery_job).
+#
+# Postmark permanently rejects sends to suppressed addresses, so retrying or
+# surfacing the error as an incident is useless — the address itself is the
+# problem. Flag the owning Participant/Guardian so admins see it and manual
+# sends refuse early, then drop the job.
+class MailDeliveryJob < ActionMailer::MailDeliveryJob
+  discard_on Postmark::InactiveRecipientError do |job, error|
+    mailer, action = job.arguments
+    if error.recipients.blank?
+      Rails.logger.error("[MailDeliveryJob] Discarded #{mailer}##{action}: inactive recipient, but none parsed from: #{error.message}")
+    else
+      flagged = Participant.mark_email_undeliverable!(error.recipients) +
+        Guardian.mark_email_undeliverable!(error.recipients)
+      Rails.logger.warn("[MailDeliveryJob] Discarded #{mailer}##{action}: inactive recipients #{error.recipients.join(', ')} (#{flagged} records flagged)")
+    end
+  end
+end

--- a/app/jobs/send_pending_guardian_invites_job.rb
+++ b/app/jobs/send_pending_guardian_invites_job.rb
@@ -60,6 +60,13 @@ class SendPendingGuardianInvitesJob < ApplicationJob
     Rails.logger.info("[SendPendingGuardianInvitesJob] Sending #{pending_gpes.count} guardian invites for event #{event.id}")
 
     pending_gpes.find_each do |gpe|
+      # Postmark suppresses hard-bounced addresses; re-sending every run just
+      # raises InactiveRecipientError. Needs the email corrected in admin.
+      if gpe.guardian.email_undeliverable?
+        Rails.logger.warn("[SendPendingGuardianInvitesJob] Skipping GPE #{gpe.id}: guardian email is undeliverable")
+        next
+      end
+
       GuardianMailer.invitation(guardian_participant_event: gpe).deliver_later
       Rails.logger.info("[SendPendingGuardianInvitesJob] Sent invite for GPE #{gpe.id}")
     end

--- a/app/models/concerns/email_deliverability.rb
+++ b/app/models/concerns/email_deliverability.rb
@@ -1,0 +1,34 @@
+# Tracks whether a record's email address is known-undeliverable. Postmark
+# suppresses an address after a hard bounce or spam complaint and rejects all
+# later sends to it (Postmark::InactiveRecipientError), so once flagged the
+# only remedy is correcting the address — which clears the flag automatically.
+module EmailDeliverability
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :clear_email_undeliverable_flag, if: :will_save_change_to_email?
+
+    scope :email_undeliverable, -> { where.not(email_undeliverable_at: nil) }
+  end
+
+  class_methods do
+    def mark_email_undeliverable!(addresses)
+      normalized = Array(addresses).filter_map { |a| a.to_s.strip.downcase.presence }
+      return 0 if normalized.empty?
+
+      where("LOWER(email) IN (?)", normalized)
+        .where(email_undeliverable_at: nil)
+        .update_all(email_undeliverable_at: Time.current)
+    end
+  end
+
+  def email_undeliverable?
+    email_undeliverable_at.present?
+  end
+
+  private
+
+  def clear_email_undeliverable_flag
+    self.email_undeliverable_at = nil unless will_save_change_to_email_undeliverable_at?
+  end
+end

--- a/app/models/guardian.rb
+++ b/app/models/guardian.rb
@@ -1,4 +1,6 @@
 class Guardian < ApplicationRecord
+  include EmailDeliverability
+
   has_paper_trail
 
   self.implicit_order_column = "created_at"

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,6 +1,7 @@
 class Participant < ApplicationRecord
   include WalletPassUpdatable
   include DecodableImageAttachment
+  include EmailDeliverability
 
   has_paper_trail
 

--- a/app/views/admin/participants/_header.html.erb
+++ b/app/views/admin/participants/_header.html.erb
@@ -33,7 +33,12 @@
       <% if @participant.preferred_name.present? %>
         <p class="text-gray-600">Legal name: <%= @participant.full_name %></p>
       <% end %>
-      <p class="text-gray-600"><%= @participant.email %></p>
+      <p class="text-gray-600">
+        <%= @participant.email %>
+        <% if @participant.email_undeliverable? %>
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800" title="This address hard-bounced and is suppressed — emails to it will not be delivered. Correct the email to clear this.">⚠ Email bouncing</span>
+        <% end %>
+      </p>
     </div>
   </div>
   <div class="relative w-full lg:w-auto" data-controller="dropdown">

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -233,7 +233,12 @@
                 <div class="flex justify-between items-start">
                   <div>
                     <div class="font-medium"><%= gpe.guardian.full_name %></div>
-                    <div class="text-sm text-gray-600"><%= gpe.guardian.email %></div>
+                    <div class="text-sm text-gray-600">
+                      <%= gpe.guardian.email %>
+                      <% if gpe.guardian.email_undeliverable? %>
+                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800" title="This address hard-bounced and is suppressed — emails to it will not be delivered. Correct the email to clear this.">⚠ Email bouncing</span>
+                      <% end %>
+                    </div>
                     <div class="text-sm text-gray-500"><%= gpe.guardian.phone %></div>
                   </div>
                   <div class="text-right">

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,8 @@ module Attend
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Discards sends to Postmark-suppressed addresses instead of erroring.
+    config.action_mailer.delivery_job = "MailDeliveryJob"
   end
 end

--- a/db/migrate/20260824140000_add_email_undeliverable_at_to_participants_and_guardians.rb
+++ b/db/migrate/20260824140000_add_email_undeliverable_at_to_participants_and_guardians.rb
@@ -1,0 +1,6 @@
+class AddEmailUndeliverableAtToParticipantsAndGuardians < ActiveRecord::Migration[8.1]
+  def change
+    add_column :participants, :email_undeliverable_at, :datetime
+    add_column :guardians, :email_undeliverable_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_130002) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -518,6 +518,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_130002) do
     t.text "country"
     t.datetime "created_at", null: false
     t.string "email", null: false
+    t.datetime "email_undeliverable_at"
     t.string "legal_first_name", null: false
     t.string "legal_last_name", null: false
     t.text "phone"
@@ -858,6 +859,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_130002) do
     t.datetime "created_at", null: false
     t.date "date_of_birth"
     t.string "email", null: false
+    t.datetime "email_undeliverable_at"
     t.text "engagement_notes"
     t.string "engagement_preference"
     t.string "legal_first_name", null: false

--- a/spec/jobs/mail_delivery_job_spec.rb
+++ b/spec/jobs/mail_delivery_job_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe MailDeliveryJob do
+  def inactive_recipient_error(*addresses)
+    message = "You tried to send to recipient(s) that have been marked as inactive. " \
+      "Found inactive addresses: #{addresses.join(', ')}. Inactive recipients are ones " \
+      "that have generated a hard bounce, a spam complaint, or a manual suppression."
+    Postmark::InactiveRecipientError.new(406, message, { "ErrorCode" => 406, "Message" => message })
+  end
+
+  def perform_failing_delivery(error)
+    delivery = double("message")
+    allow(ParticipantMailer).to receive(:travel_update_reminder).and_return(delivery)
+    allow(delivery).to receive(:deliver_now).and_raise(error)
+
+    described_class.perform_now("ParticipantMailer", "travel_update_reminder", "deliver_now", args: [])
+  end
+
+  it "is configured as the ActionMailer delivery job" do
+    expect(ActionMailer::Base.delivery_job).to eq(described_class)
+  end
+
+  describe "on Postmark::InactiveRecipientError" do
+    it "discards instead of raising" do
+      expect {
+        perform_failing_delivery(inactive_recipient_error("dead@example.com"))
+      }.not_to raise_error
+    end
+
+    it "flags matching participants and guardians as undeliverable" do
+      participant = create(:participant, email: "dead@example.com")
+      guardian = create(:guardian, email: "dead@example.com")
+      bystander = create(:participant, email: "alive@example.com")
+
+      perform_failing_delivery(inactive_recipient_error("dead@example.com"))
+
+      expect(participant.reload.email_undeliverable_at).to be_present
+      expect(guardian.reload.email_undeliverable_at).to be_present
+      expect(bystander.reload.email_undeliverable_at).to be_nil
+    end
+
+    it "still discards when no recipients can be parsed from the error" do
+      error = Postmark::InactiveRecipientError.new(406, "unexpected format", { "Message" => "unexpected format" })
+
+      expect { perform_failing_delivery(error) }.not_to raise_error
+    end
+  end
+
+  it "re-raises other Postmark errors" do
+    expect {
+      perform_failing_delivery(Postmark::ApiInputError.new(300, "bad", { "Message" => "bad" }))
+    }.to raise_error(Postmark::ApiInputError)
+  end
+end

--- a/spec/jobs/send_pending_guardian_invites_job_spec.rb
+++ b/spec/jobs/send_pending_guardian_invites_job_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe SendPendingGuardianInvitesJob do
 
   describe "guardian invites" do
     def invitation_for(gpe)
-      have_enqueued_job(ActionMailer::MailDeliveryJob)
+      have_enqueued_job(ActionMailer::Base.delivery_job)
         .with("GuardianMailer", "invitation", "deliver_now", args: [ { guardian_participant_event: gpe } ])
     end
 
@@ -125,7 +125,18 @@ RSpec.describe SendPendingGuardianInvitesJob do
 
       expect {
         described_class.perform_now(event.id)
-      }.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      }.not_to have_enqueued_job(ActionMailer::Base.delivery_job)
+    end
+
+    it "skips guardians whose email is known-undeliverable" do
+      pe = submitted_minor_pe
+      gpe = create(:guardian_participant_event, :never_sent, participant_event: pe)
+      gpe.guardian.update!(email_undeliverable_at: Time.current)
+      create(:consent, :signed, participant_event: pe)
+
+      expect {
+        described_class.perform_now(event.id)
+      }.not_to have_enqueued_job(ActionMailer::Base.delivery_job)
     end
 
     it "does not re-invite unopened invites still inside their validity window" do
@@ -135,7 +146,7 @@ RSpec.describe SendPendingGuardianInvitesJob do
 
       expect {
         described_class.perform_now(event.id)
-      }.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      }.not_to have_enqueued_job(ActionMailer::Base.delivery_job)
     end
   end
 end

--- a/spec/jobs/sync_slack_channel_job_spec.rb
+++ b/spec/jobs/sync_slack_channel_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SyncSlackChannelJob, type: :job do
 
     expect {
       described_class.perform_now(event.id, send_emails: true)
-    }.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+    }.to have_enqueued_job(ActionMailer::Base.delivery_job)
       .with("ParticipantMailer", "slack_link_reminder", "deliver_now", anything)
   end
 

--- a/spec/models/concerns/email_deliverability_spec.rb
+++ b/spec/models/concerns/email_deliverability_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe EmailDeliverability do
+  describe ".mark_email_undeliverable!" do
+    it "flags matching records case-insensitively" do
+      participant = create(:participant, email: "Bounced@Example.com")
+
+      Participant.mark_email_undeliverable!([ "bounced@example.com" ])
+
+      expect(participant.reload.email_undeliverable_at).to be_present
+    end
+
+    it "does not touch records with other addresses" do
+      participant = create(:participant, email: "fine@example.com")
+
+      Participant.mark_email_undeliverable!([ "bounced@example.com" ])
+
+      expect(participant.reload.email_undeliverable_at).to be_nil
+    end
+
+    it "does not move the timestamp of already-flagged records" do
+      participant = create(:participant, email: "bounced@example.com", email_undeliverable_at: 2.days.ago)
+
+      expect {
+        Participant.mark_email_undeliverable!([ "bounced@example.com" ])
+      }.not_to change { participant.reload.email_undeliverable_at }
+    end
+
+    it "ignores blank input" do
+      expect(Participant.mark_email_undeliverable!([ nil, "" ])).to eq(0)
+    end
+
+    it "flags guardians too" do
+      guardian = create(:guardian, email: "bounced@example.com")
+
+      Guardian.mark_email_undeliverable!([ "bounced@example.com" ])
+
+      expect(guardian.reload.email_undeliverable_at).to be_present
+    end
+  end
+
+  describe "clearing the flag on email change" do
+    it "clears the flag when the email is corrected" do
+      participant = create(:participant, email: "typo@example.con", email_undeliverable_at: Time.current)
+
+      participant.update!(email: "typo@example.com")
+
+      expect(participant.reload.email_undeliverable_at).to be_nil
+    end
+
+    it "keeps the flag when other attributes change" do
+      participant = create(:participant, email: "typo@example.con", email_undeliverable_at: Time.current)
+
+      participant.update!(preferred_name: "Sam")
+
+      expect(participant.reload.email_undeliverable_at).to be_present
+    end
+
+    it "allows setting the flag and email together explicitly" do
+      participant = create(:participant, email: "old@example.com")
+
+      participant.update!(email: "new@example.com", email_undeliverable_at: Time.current)
+
+      expect(participant.reload.email_undeliverable_at).to be_present
+    end
+  end
+end

--- a/spec/requests/api/v1/postmark_webhooks_spec.rb
+++ b/spec/requests/api/v1/postmark_webhooks_spec.rb
@@ -167,6 +167,56 @@ RSpec.describe "Api::V1::PostmarkWebhooks", type: :request do
         expect(event.metadata["bounce_type"]).to eq("HardBounce")
         expect(event.metadata["description"]).to eq("The email account does not exist")
       end
+
+      it "flags matching participants and guardians as undeliverable on hard bounces" do
+        participant = create(:participant, email: email_log.to_address)
+        guardian = create(:guardian, email: email_log.to_address)
+
+        post api_v1_postmark_webhooks_path, params: payload.to_json, headers: headers
+
+        expect(participant.reload.email_undeliverable_at).to be_present
+        expect(guardian.reload.email_undeliverable_at).to be_present
+      end
+
+      it "does not flag recipients on soft bounces" do
+        participant = create(:participant, email: email_log.to_address)
+
+        post api_v1_postmark_webhooks_path,
+          params: payload.merge(Type: "SoftBounce").to_json,
+          headers: headers
+
+        expect(participant.reload.email_undeliverable_at).to be_nil
+      end
+    end
+
+    describe "SpamComplaint events" do
+      let(:payload) do
+        {
+          RecordType: "SpamComplaint",
+          MessageID: "msg-12345",
+          BouncedAt: "2024-12-22T10:30:00Z",
+          TypeCode: 512,
+          Description: "The subscriber explicitly marked this message as spam."
+        }
+      end
+
+      it "records a spam_complaint event and marks the log failed" do
+        expect {
+          post api_v1_postmark_webhooks_path, params: payload.to_json, headers: headers
+        }.to change(EmailLogEvent, :count).by(1)
+
+        email_log.reload
+        expect(email_log.status).to eq("failed")
+        expect(email_log.email_log_events.last.event_type).to eq("spam_complaint")
+      end
+
+      it "flags matching recipients as undeliverable" do
+        participant = create(:participant, email: email_log.to_address)
+
+        post api_v1_postmark_webhooks_path, params: payload.to_json, headers: headers
+
+        expect(participant.reload.email_undeliverable_at).to be_present
+      end
     end
 
     describe "Open events" do
@@ -260,7 +310,7 @@ RSpec.describe "Api::V1::PostmarkWebhooks", type: :request do
     describe "Unhandled events" do
       it "returns 200 OK for unhandled record types" do
         post api_v1_postmark_webhooks_path,
-          params: { RecordType: "SpamComplaint", MessageID: "msg-12345" }.to_json,
+          params: { RecordType: "SubscriptionChange", MessageID: "msg-12345" }.to_json,
           headers: headers
 
         expect(response).to have_http_status(:ok)

--- a/spec/requests/guardian_invites_locked_spec.rb
+++ b/spec/requests/guardian_invites_locked_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Guardian invites locked", type: :request do
 
       expect {
         post dashboard_resend_guardian_invite_path(participant_event)
-      }.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      }.not_to have_enqueued_job(ActionMailer::Base.delivery_job)
 
       expect(response).to redirect_to(dashboard_event_path(participant_event))
       expect(flash[:alert]).to include("aren't open for this event yet")
@@ -125,7 +125,7 @@ RSpec.describe "Guardian invites locked", type: :request do
         expect {
           SendPendingGuardianInvitesJob.perform_now(event.id)
         }.not_to change(Consent, :count)
-      }.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      }.not_to have_enqueued_job(ActionMailer::Base.delivery_job)
     end
   end
 end

--- a/spec/requests/onboarding_documents_step_spec.rb
+++ b/spec/requests/onboarding_documents_step_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "Onboarding documents step", type: :request do
         post complete_onboarding_path(event_id: event.id), params: {
           code_of_conduct_accepted: "1", code_of_conduct_signature: "Milo Minorson"
         }
-      }.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      }.to have_enqueued_job(ActionMailer::Base.delivery_job)
         .with("GuardianMailer", "invitation", "deliver_now", args: [ { guardian_participant_event: gpe } ])
 
       expect(response).to redirect_to(dashboard_path)


### PR DESCRIPTION
## why

`Postmark::InactiveRecipientError` was landing as untriaged AppSignal incidents (latest: `ParticipantMailer#travel_update_reminder` to a typo'd `gmail.con` address). Postmark suppresses an address after a hard bounce or spam complaint and rejects every later send to it, so these errors can never succeed on retry — they mean "you already know this address is dead" and need a human to fix the email, not an exception report.

## what

- **`email_undeliverable_at`** on participants and guardians, managed by a shared `EmailDeliverability` concern. Correcting the email clears the flag automatically.
- **`MailDeliveryJob`** (new `config.action_mailer.delivery_job`) discards on `InactiveRecipientError` and flags the matching participant/guardian records instead of erroring.
- **Postmark webhook** flags recipients on `HardBounce`, and now handles `SpamComplaint` events (previously ignored) — both feed Postmark's suppression list.
- **Admin UI**: "⚠ Email bouncing" badge on the participant header and guardian cards, so organizers see the problem where they'd act on it.
- **Manual sends refuse early**: travel update reminder and guardian invite resend redirect with an actionable alert instead of "sent!" followed by a silent background failure.
- **`SendPendingGuardianInvitesJob`** skips known-undeliverable guardians instead of raising on every scheduled run.

Spec matchers that asserted `have_enqueued_job(ActionMailer::MailDeliveryJob)` now use `ActionMailer::Base.delivery_job` — exact-class matching would otherwise make the `not_to` assertions vacuously pass.

## testing

- 40 examples across the new concern/job specs and the postmark webhook request spec, all green.
- Adjacent suites re-run green: guardian invites job, invites-locked, onboarding documents, slack sync, participant/guardian models, mailers (94 examples).
- Rubocop clean on all touched files.