### PR TITLE
Redesign 404, 500, and 422 error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -7,87 +7,135 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/icon-32.png" type="image/png" sizes="32x32">
   <style>
+    /* Static page: must stand alone (no app assets). Values mirror the
+       default light and dark palettes in app/assets/stylesheets/themes.css. */
+    :root {
+      --bg-app: #f9fafc;
+      --bg-elev: #ffffff;
+      --border-card: #e0e6ed;
+      --border-soft: #f3f4f6;
+      --text-strong: #1f2d3d;
+      --text: #3c4858;
+      --text-muted: #8492a6;
+      --text-link: #2563eb;
+      --accent: #ec3750;
+      --accent-fill: #d42f46;
+      --accent-fill-hover: #b82840;
+      --accent-soft: rgba(236, 55, 80, 0.10);
+      --pill-bg: #f3f4f6;
+      --pill-text: #3c4858;
+      --shadow-sm: 0 1px 2px rgba(31, 45, 61, 0.06);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-app: #0f1115;
+        --bg-elev: #161922;
+        --border-card: #2a3043;
+        --border-soft: #1d2231;
+        --text-strong: #f3f4f8;
+        --text: #d6dae5;
+        --text-muted: #8089a0;
+        --text-link: #7dabff;
+        --accent-soft: rgba(236, 55, 80, 0.16);
+        --pill-bg: #242938;
+        --pill-text: #aab1c1;
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+      }
+    }
+
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    
+
+    ::selection { background: var(--accent-soft); color: var(--text-strong); }
+
     body {
       font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      background: var(--bg-app);
+      color: var(--text);
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
+      padding: 1.5rem;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .card {
+      background: var(--bg-elev);
+      border: 1px solid var(--border-card);
+      border-radius: 8px;
+      box-shadow: var(--shadow-sm);
       padding: 2rem;
-    }
-    
-    .container {
-      background: white;
-      border-radius: 1rem;
-      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-      padding: 3rem;
-      text-align: center;
-      max-width: 28rem;
+      max-width: 26rem;
       width: 100%;
+      animation: rise 0.3s cubic-bezier(0.16, 1, 0.3, 1);
     }
-    
-    .error-code {
-      font-size: 6rem;
-      font-weight: 800;
-      color: #e5e7eb;
-      line-height: 1;
-      margin-bottom: 1rem;
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: none; }
     }
-    
+    @media (prefers-reduced-motion: reduce) {
+      .card { animation: none; }
+    }
+
+    .logo { height: 2.25rem; width: auto; display: block; margin-bottom: 1.5rem; }
+
     h1 {
       font-size: 1.5rem;
       font-weight: 700;
-      color: #1f2937;
-      margin-bottom: 0.75rem;
-    }
-    
-    p {
-      color: #6b7280;
-      margin-bottom: 2rem;
-      line-height: 1.6;
-    }
-    
-    .btn {
-      display: inline-block;
-      background: #4f46e5;
-      color: white;
-      padding: 0.75rem 1.5rem;
-      border-radius: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      transition: background 0.2s;
-    }
-    
-    .btn:hover {
-      background: #4338ca;
-    }
-    
-    .logo {
-      width: 3rem;
-      height: 3rem;
-      margin-bottom: 1.5rem;
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--text-strong);
+      margin-bottom: 0.5rem;
     }
 
-    @media (prefers-color-scheme: dark) {
-      body {
-        background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
-      }
-      .container {
-        background: #1f2937;
-      }
-      .error-code {
-        color: #374151;
-      }
-      h1 {
-        color: #f9fafb;
-      }
-      p {
-        color: #9ca3af;
-      }
+    p { font-size: 0.875rem; line-height: 1.6; margin-bottom: 1rem; }
+    p:last-of-type { margin-bottom: 1.5rem; }
+
+    a { color: var(--text-link); }
+    a:focus-visible, .btn:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
+
+    .btn {
+      display: block;
+      width: 100%;
+      text-align: center;
+      background: var(--accent-fill);
+      color: #ffffff;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s ease-out;
+    }
+    .btn:hover { background: var(--accent-fill-hover); }
+    .btn:focus-visible { border-radius: 6px; }
+    @media (min-width: 480px) {
+      .btn { display: inline-block; width: auto; }
+    }
+
+    .meta {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border-soft);
+    }
+    .pill {
+      display: inline-block;
+      background: var(--pill-bg);
+      color: var(--pill-text);
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1.4;
+      padding: 0.125rem 0.625rem;
+      border-radius: 9999px;
+    }
+    .meta span { font-size: 0.75rem; color: var(--text-muted); }
   </style>
   <script async src="https://plausible.io/js/pa-_d2ghIq2L9Mv3kvZk8u3A.js"></script>
   <script>
@@ -97,12 +145,16 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <main class="card">
     <img src="/hackclub-logo.png" alt="Hack Club" class="logo">
-    <div class="error-code">404</div>
-    <h1>Page Not Found</h1>
-    <p>Sorry, we couldn't find the page you're looking for. It may have been moved or deleted.</p>
-    <a href="/" class="btn">Go Home</a>
-  </div>
+    <h1>Page not found</h1>
+    <p>This page doesn&rsquo;t exist, or it may have moved. If you followed a link from an email or text message, the link may have expired &mdash; check for a newer message from us.</p>
+    <p>Parent or guardian looking for a consent form? You can <a href="/guardian/portals">find your portal here</a>.</p>
+    <a href="/" class="btn">Go to home</a>
+    <div class="meta">
+      <span class="pill">404</span>
+      <span>Page not found &middot; Attend by Hack Club</span>
+    </div>
+  </main>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -3,91 +3,138 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Unprocessable Content – Attend</title>
+  <title>Change Rejected – Attend</title>
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/icon-32.png" type="image/png" sizes="32x32">
   <style>
+    /* Static page: must stand alone (no app assets). Values mirror the
+       default light and dark palettes in app/assets/stylesheets/themes.css. */
+    :root {
+      --bg-app: #f9fafc;
+      --bg-elev: #ffffff;
+      --border-card: #e0e6ed;
+      --border-soft: #f3f4f6;
+      --text-strong: #1f2d3d;
+      --text: #3c4858;
+      --text-muted: #8492a6;
+      --text-link: #2563eb;
+      --accent: #ec3750;
+      --accent-fill: #d42f46;
+      --accent-fill-hover: #b82840;
+      --accent-soft: rgba(236, 55, 80, 0.10);
+      --pill-bg: rgba(255, 140, 55, 0.14);
+      --pill-text: #c2410c;
+      --shadow-sm: 0 1px 2px rgba(31, 45, 61, 0.06);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-app: #0f1115;
+        --bg-elev: #161922;
+        --border-card: #2a3043;
+        --border-soft: #1d2231;
+        --text-strong: #f3f4f8;
+        --text: #d6dae5;
+        --text-muted: #8089a0;
+        --text-link: #7dabff;
+        --accent-soft: rgba(236, 55, 80, 0.16);
+        --pill-bg: rgba(255, 140, 55, 0.14);
+        --pill-text: #ffa55c;
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+      }
+    }
+
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    
+
+    ::selection { background: var(--accent-soft); color: var(--text-strong); }
+
     body {
       font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+      background: var(--bg-app);
+      color: var(--text);
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
+      padding: 1.5rem;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .card {
+      background: var(--bg-elev);
+      border: 1px solid var(--border-card);
+      border-radius: 8px;
+      box-shadow: var(--shadow-sm);
       padding: 2rem;
-    }
-    
-    .container {
-      background: white;
-      border-radius: 1rem;
-      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-      padding: 3rem;
-      text-align: center;
-      max-width: 28rem;
+      max-width: 26rem;
       width: 100%;
+      animation: rise 0.3s cubic-bezier(0.16, 1, 0.3, 1);
     }
-    
-    .error-code {
-      font-size: 6rem;
-      font-weight: 800;
-      color: #fef3c7;
-      line-height: 1;
-      margin-bottom: 1rem;
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: none; }
     }
-    
+    @media (prefers-reduced-motion: reduce) {
+      .card { animation: none; }
+    }
+
+    .logo { height: 2.25rem; width: auto; display: block; margin-bottom: 1.5rem; }
+
     h1 {
       font-size: 1.5rem;
       font-weight: 700;
-      color: #1f2937;
-      margin-bottom: 0.75rem;
-    }
-    
-    p {
-      color: #6b7280;
-      margin-bottom: 2rem;
-      line-height: 1.6;
-    }
-    
-    .btn {
-      display: inline-block;
-      background: #f59e0b;
-      color: white;
-      padding: 0.75rem 1.5rem;
-      border-radius: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      transition: background 0.2s;
-    }
-    
-    .btn:hover {
-      background: #d97706;
-    }
-    
-    .logo {
-      width: 3rem;
-      height: 3rem;
-      margin-bottom: 1.5rem;
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--text-strong);
+      margin-bottom: 0.5rem;
     }
 
-    @media (prefers-color-scheme: dark) {
-      body {
-        background: linear-gradient(135deg, #451a03 0%, #78350f 100%);
-      }
-      .container {
-        background: #1f2937;
-      }
-      .error-code {
-        color: #78350f;
-      }
-      h1 {
-        color: #f9fafb;
-      }
-      p {
-        color: #9ca3af;
-      }
+    p { font-size: 0.875rem; line-height: 1.6; margin-bottom: 1.5rem; }
+
+    a { color: var(--text-link); }
+    a:focus-visible, .btn:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
+
+    .btn {
+      display: block;
+      width: 100%;
+      text-align: center;
+      background: var(--accent-fill);
+      color: #ffffff;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s ease-out;
+    }
+    .btn:hover { background: var(--accent-fill-hover); }
+    .btn:focus-visible { border-radius: 6px; }
+    @media (min-width: 480px) {
+      .btn { display: inline-block; width: auto; }
+    }
+
+    .meta {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border-soft);
+    }
+    .pill {
+      display: inline-block;
+      background: var(--pill-bg);
+      color: var(--pill-text);
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1.4;
+      padding: 0.125rem 0.625rem;
+      border-radius: 9999px;
+    }
+    .meta span { font-size: 0.75rem; color: var(--text-muted); }
   </style>
   <script async src="https://plausible.io/js/pa-_d2ghIq2L9Mv3kvZk8u3A.js"></script>
   <script>
@@ -97,12 +144,15 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <main class="card">
     <img src="/hackclub-logo.png" alt="Hack Club" class="logo">
-    <div class="error-code">422</div>
-    <h1>Unprocessable Content</h1>
-    <p>The request was well-formed but couldn't be processed. This might be due to a security issue or invalid data.</p>
-    <a href="/" class="btn">Go Home</a>
-  </div>
+    <h1>That didn&rsquo;t go through</h1>
+    <p>The change you submitted couldn&rsquo;t be saved. This usually happens when a page has been open for a while and the form expired &mdash; go back, refresh the page, and try once more.</p>
+    <a href="/" class="btn">Go to home</a>
+    <div class="meta">
+      <span class="pill">422</span>
+      <span>Change rejected &middot; Attend by Hack Club</span>
+    </div>
+  </main>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -7,87 +7,138 @@
   <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/icon-32.png" type="image/png" sizes="32x32">
   <style>
+    /* Static page: must stand alone (no app assets). Values mirror the
+       default light and dark palettes in app/assets/stylesheets/themes.css. */
+    :root {
+      --bg-app: #f9fafc;
+      --bg-elev: #ffffff;
+      --border-card: #e0e6ed;
+      --border-soft: #f3f4f6;
+      --text-strong: #1f2d3d;
+      --text: #3c4858;
+      --text-muted: #8492a6;
+      --text-link: #2563eb;
+      --accent: #ec3750;
+      --accent-fill: #d42f46;
+      --accent-fill-hover: #b82840;
+      --accent-soft: rgba(236, 55, 80, 0.10);
+      --pill-bg: rgba(236, 55, 80, 0.10);
+      --pill-text: #d42f46;
+      --shadow-sm: 0 1px 2px rgba(31, 45, 61, 0.06);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-app: #0f1115;
+        --bg-elev: #161922;
+        --border-card: #2a3043;
+        --border-soft: #1d2231;
+        --text-strong: #f3f4f8;
+        --text: #d6dae5;
+        --text-muted: #8089a0;
+        --text-link: #7dabff;
+        --accent-soft: rgba(236, 55, 80, 0.16);
+        --pill-bg: rgba(236, 55, 80, 0.16);
+        --pill-text: #ff7588;
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+      }
+    }
+
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    
+
+    ::selection { background: var(--accent-soft); color: var(--text-strong); }
+
     body {
       font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
+      background: var(--bg-app);
+      color: var(--text);
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
+      padding: 1.5rem;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .card {
+      background: var(--bg-elev);
+      border: 1px solid var(--border-card);
+      border-radius: 8px;
+      box-shadow: var(--shadow-sm);
       padding: 2rem;
-    }
-    
-    .container {
-      background: white;
-      border-radius: 1rem;
-      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
-      padding: 3rem;
-      text-align: center;
-      max-width: 28rem;
+      max-width: 26rem;
       width: 100%;
+      animation: rise 0.3s cubic-bezier(0.16, 1, 0.3, 1);
     }
-    
-    .error-code {
-      font-size: 6rem;
-      font-weight: 800;
-      color: #fecaca;
-      line-height: 1;
-      margin-bottom: 1rem;
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: none; }
     }
-    
+    @media (prefers-reduced-motion: reduce) {
+      .card { animation: none; }
+    }
+
+    .logo { height: 2.25rem; width: auto; display: block; margin-bottom: 1.5rem; }
+
     h1 {
       font-size: 1.5rem;
       font-weight: 700;
-      color: #1f2937;
-      margin-bottom: 0.75rem;
-    }
-    
-    p {
-      color: #6b7280;
-      margin-bottom: 2rem;
-      line-height: 1.6;
-    }
-    
-    .btn {
-      display: inline-block;
-      background: #dc2626;
-      color: white;
-      padding: 0.75rem 1.5rem;
-      border-radius: 0.5rem;
-      text-decoration: none;
-      font-weight: 600;
-      transition: background 0.2s;
-    }
-    
-    .btn:hover {
-      background: #b91c1c;
-    }
-    
-    .logo {
-      width: 3rem;
-      height: 3rem;
-      margin-bottom: 1.5rem;
+      line-height: 1.25;
+      letter-spacing: -0.01em;
+      color: var(--text-strong);
+      margin-bottom: 0.5rem;
     }
 
-    @media (prefers-color-scheme: dark) {
-      body {
-        background: linear-gradient(135deg, #450a0a 0%, #7f1d1d 100%);
-      }
-      .container {
-        background: #1f2937;
-      }
-      .error-code {
-        color: #7f1d1d;
-      }
-      h1 {
-        color: #f9fafb;
-      }
-      p {
-        color: #9ca3af;
-      }
+    p { font-size: 0.875rem; line-height: 1.6; margin-bottom: 1rem; }
+    p:last-of-type { margin-bottom: 1.5rem; }
+
+    a { color: var(--text-link); }
+    a:focus-visible, .btn:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
+
+    .actions { display: flex; flex-direction: column; gap: 0.75rem; align-items: stretch; }
+    @media (min-width: 480px) {
+      .actions { flex-direction: row; align-items: center; gap: 1.25rem; }
+    }
+
+    .btn {
+      display: block;
+      text-align: center;
+      background: var(--accent-fill);
+      color: #ffffff;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s ease-out;
+    }
+    .btn:hover { background: var(--accent-fill-hover); }
+    .btn:focus-visible { border-radius: 6px; }
+
+    .link-secondary { font-size: 0.875rem; font-weight: 500; text-align: center; }
+
+    .meta {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border-soft);
+    }
+    .pill {
+      display: inline-block;
+      background: var(--pill-bg);
+      color: var(--pill-text);
+      font-size: 0.75rem;
+      font-weight: 600;
+      line-height: 1.4;
+      padding: 0.125rem 0.625rem;
+      border-radius: 9999px;
+    }
+    .meta span { font-size: 0.75rem; color: var(--text-muted); }
   </style>
   <script async src="https://plausible.io/js/pa-_d2ghIq2L9Mv3kvZk8u3A.js"></script>
   <script>
@@ -97,12 +148,18 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <main class="card">
     <img src="/hackclub-logo.png" alt="Hack Club" class="logo">
-    <div class="error-code">500</div>
-    <h1>Something Went Wrong</h1>
-    <p>We're sorry, but something unexpected happened. Our team has been notified and we're working on it.</p>
-    <a href="/" class="btn">Go Home</a>
-  </div>
+    <h1>Something went wrong</h1>
+    <p>That&rsquo;s on us, not you. The error has been reported to the team automatically, and these things are usually temporary &mdash; trying again in a moment often works.</p>
+    <div class="actions">
+      <a href="" class="btn">Try again</a>
+      <a href="/" class="link-secondary">Go to home</a>
+    </div>
+    <div class="meta">
+      <span class="pill">500</span>
+      <span>Server error &middot; Attend by Hack Club</span>
+    </div>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
our error pages looked really jank — the 404 sat on a stock purple/indigo gradient with an indigo button (colors that appear nowhere in Attend), the 500 was a wall-to-wall red gradient, the 422 the same template in amber, and all three floated a heavy drop-shadow card.

## what changed

All three static pages now follow the app's design system:

- quiet `--bg-app` page with a white card, 1px hairline border, 8px radius — no gradients, no mega-shadow
- primary button uses the deepened red (`#d42f46`) under white text, full-width on phones, proper focus ring
- Attend's signature status pill carries the error code in a metadata footer (grey 404, red-tinted 500, amber 422), tint + word
- type snapped to the documented ramp (1.5rem headline, 0.875rem body, 0.75rem label), system font stack kept
- dark mode uses the real dark-theme tokens from `themes.css`
- one subtle 300ms rise animation, disabled under `prefers-reduced-motion`
- Plausible tracking, noindex, and favicon kept; everything stays inline so the 500 renders even when Rails is down

## ux upgrades

- the 404 is where expired magic links from emails/texts land — its copy now explains the link may have expired and points guardians at `/guardian/portals`
- the 500 gains a JS-free **Try again** action (plain `href=""` reload)
- the 422 explains the stale-form cause in human terms

`400.html` and `406-unsupported-browser.html` are untouched — they're the deliberately conservative Rails defaults for ancient browsers.