### PR TITLE
Show automated texts as system messages in support chat history

### DIFF
--- a/app/jobs/send_guardian_portal_code_sms_job.rb
+++ b/app/jobs/send_guardian_portal_code_sms_job.rb
@@ -4,7 +4,9 @@ class SendGuardianPortalCodeSmsJob < ApplicationJob
   def perform(phone, code)
     TwilioService.new.send_sms(
       to: phone,
-      body: "Your Attend verification code is #{code}. It expires in 10 minutes."
+      body: "Your Attend verification code is #{code}. It expires in 10 minutes.",
+      log_body: "Your Attend verification code is [redacted]. It expires in 10 minutes.",
+      source: "Guardian portal"
     )
   end
 end

--- a/app/jobs/send_incident_report_confirmation_sms_job.rb
+++ b/app/jobs/send_incident_report_confirmation_sms_job.rb
@@ -10,7 +10,7 @@ class SendIncidentReportConfirmationSmsJob < ApplicationJob
     report = IncidentReport.find(incident_report_id)
     return if report.reporter_phone.blank?
 
-    TwilioService.new.send_sms(to: report.reporter_phone, body: MESSAGE)
+    TwilioService.new.send_sms(to: report.reporter_phone, body: MESSAGE, source: "Incident reports")
   rescue TwilioService::Error => e
     Rails.logger.error("[IncidentReportSms] confirmation SMS failed for #{incident_report_id}: #{e.message}")
   end

--- a/app/jobs/send_incident_report_update_sms_job.rb
+++ b/app/jobs/send_incident_report_update_sms_job.rb
@@ -9,7 +9,7 @@ class SendIncidentReportUpdateSmsJob < ApplicationJob
     sender = comment.user&.display_name_or_fallback
     body = sender.present? ? "#{sender}: #{comment.body}" : comment.body
 
-    TwilioService.new.send_sms(to: report.reporter_phone, body: body)
+    TwilioService.new.send_sms(to: report.reporter_phone, body: body, source: "Incident reports")
   rescue TwilioService::Error => e
     Rails.logger.error("[IncidentReportSms] update SMS failed for comment #{comment_id}: #{e.message}")
   end

--- a/app/jobs/send_support_ticket_sms_notification_job.rb
+++ b/app/jobs/send_support_ticket_sms_notification_job.rb
@@ -43,7 +43,7 @@ class SendSupportTicketSmsNotificationJob < ApplicationJob
   end
 
   def send_sms(to:, body:, ticket:)
-    TwilioService.new.send_sms(to: to, body: body)
+    TwilioService.new.send_sms(to: to, body: body, source: "Staff notifications")
   rescue TwilioService::Error => e
     Rails.logger.error("[SupportTicketSms] notification to #{to} failed for ticket #{ticket.id}: #{e.message}")
   end

--- a/app/jobs/single_delivery_job.rb
+++ b/app/jobs/single_delivery_job.rb
@@ -150,7 +150,8 @@ class SingleDeliveryJob < ApplicationJob
     sms_service = TwilioService.new
     result = sms_service.send_sms(
       to: phone,
-      body: sms_body
+      body: sms_body,
+      source: "Broadcast message"
     )
 
     if result[:skipped]

--- a/app/models/automated_sms_log.rb
+++ b/app/models/automated_sms_log.rb
@@ -1,0 +1,11 @@
+class AutomatedSmsLog < ApplicationRecord
+  self.implicit_order_column = "created_at"
+
+  encrypts :body
+
+  validates :phone_number, presence: true
+  validates :body, presence: true
+  validates :sent_at, presence: true
+
+  scope :for_phone, ->(phone) { where(phone_number: phone) }
+end

--- a/app/models/ticket_message.rb
+++ b/app/models/ticket_message.rb
@@ -25,6 +25,12 @@ class TicketMessage < ApplicationRecord
   validates :channel, presence: true
   validates :body, presence: true
 
+  # Short label for where an automated message came from (e.g. "Broadcast
+  # message", "Incident reports"), stored when the message is recorded.
+  def automated_source
+    raw_payload&.dig("source")
+  end
+
   after_create_commit :broadcast_message
   after_create_commit :notify_assigned_user, if: :inbound?
   after_create_commit :notify_assigned_user_by_sms, if: :inbound?

--- a/app/services/support/process_incoming_twilio_message.rb
+++ b/app/services/support/process_incoming_twilio_message.rb
@@ -27,6 +27,8 @@ module Support
       ticket = find_or_create_ticket(phone:, channel:, twilio_to: to_raw)
       new_chat = ticket.previously_new_record?
 
+      backfill_automated_messages(ticket) if new_chat
+
       message = TicketMessage.create!(
         ticket: ticket,
         direction: "inbound",
@@ -80,6 +82,43 @@ module Support
         last_inbound_at: Time.current,
         last_message_at: Time.current
       )
+    end
+
+    BACKFILL_WINDOW = 7.days
+    BACKFILL_LIMIT = 10
+
+    # When a reply opens a new ticket, pull in recent automated texts sent to
+    # this number so the agent can see what the person is responding to.
+    # Automated sends go out as plain SMS, so only SMS tickets get them.
+    def backfill_automated_messages(ticket)
+      return unless ticket.sms?
+
+      logs = AutomatedSmsLog.for_phone(ticket.phone_number)
+                            .where(sent_at: BACKFILL_WINDOW.ago..)
+                            .order(sent_at: :desc)
+                            .limit(BACKFILL_LIMIT)
+                            .to_a
+                            .reverse
+
+      sids = logs.filter_map(&:twilio_sid)
+      already_shown = TicketMessage.where(twilio_message_sid: sids).pluck(:twilio_message_sid).to_set
+
+      logs.each do |log|
+        next if log.twilio_sid.present? && already_shown.include?(log.twilio_sid)
+
+        TicketMessage.create!(
+          ticket: ticket,
+          direction: "outbound",
+          channel: "sms",
+          automated: true,
+          body: log.body,
+          twilio_message_sid: log.twilio_sid,
+          raw_payload: { "source" => log.source }.compact,
+          sent_at: log.sent_at
+        )
+      end
+    rescue => e
+      Rails.logger.error("[Support::ProcessIncomingTwilioMessage] Backfill failed for ticket #{ticket.id}: #{e.class}: #{e.message}")
     end
 
     def attach_subject_if_unset(ticket, phone)

--- a/app/services/support/record_automated_sms.rb
+++ b/app/services/support/record_automated_sms.rb
@@ -1,0 +1,59 @@
+module Support
+  # Records an automated (system-sent) SMS so support agents can see it in
+  # ticket chat history. Called by TwilioService after a successful send.
+  #
+  # If the recipient already has an open SMS ticket, the message is appended
+  # to that thread immediately. Otherwise the log is picked up later by
+  # ProcessIncomingTwilioMessage when a reply opens a new ticket.
+  class RecordAutomatedSms
+    def self.call(phone:, body:, twilio_sid: nil, source: nil)
+      new(phone:, body:, twilio_sid:, source:).call
+    end
+
+    def initialize(phone:, body:, twilio_sid: nil, source: nil)
+      @phone = phone
+      @body = body
+      @twilio_sid = twilio_sid
+      @source = source
+    end
+
+    def call
+      normalized = PhoneNormalizer.normalize(@phone)
+      return if normalized.blank? || @body.blank?
+
+      log = AutomatedSmsLog.create!(
+        phone_number: normalized,
+        body: @body,
+        twilio_sid: @twilio_sid,
+        source: @source,
+        sent_at: Time.current
+      )
+
+      materialize_into_open_ticket(log)
+
+      log
+    end
+
+    private
+
+    def materialize_into_open_ticket(log)
+      ticket = Ticket.where(phone_number: log.phone_number, channel: "sms", status: "open")
+                     .order(created_at: :desc)
+                     .first
+      return unless ticket
+
+      TicketMessage.create!(
+        ticket: ticket,
+        direction: "outbound",
+        channel: "sms",
+        automated: true,
+        body: log.body,
+        twilio_message_sid: log.twilio_sid,
+        raw_payload: { "source" => log.source }.compact,
+        sent_at: log.sent_at
+      )
+
+      ticket.update_columns(last_message_at: log.sent_at)
+    end
+  end
+end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -7,7 +7,10 @@ class TwilioService
     @from_number = from_number || Setting.twilio_from_number.presence || ENV["TWILIO_FROM_NUMBER"]
   end
 
-  def send_sms(to:, body:)
+  # log_body: alternative body to record in support chat history (e.g. with
+  # sensitive codes redacted). source: short label for where the automated
+  # message came from, shown to support agents.
+  def send_sms(to:, body:, log_body: nil, source: nil)
     return { skipped: true, reason: "Twilio disabled" } unless Setting.twilio_enabled?
     raise Error, "Twilio not configured" unless configured?
 
@@ -26,6 +29,7 @@ class TwilioService
     end
 
     parsed = JSON.parse(response.body)
+    record_automated_sms(to: to, body: log_body || body, sid: parsed["sid"], source: source)
     { sid: parsed["sid"], status: parsed["status"] }
   rescue Faraday::Error => e
     raise Error, "Twilio API error: #{e.message}"
@@ -36,6 +40,15 @@ class TwilioService
   end
 
   private
+
+  # Never let history logging fail the send — the SMS has already gone out,
+  # and raising here would make callers retry and double-send.
+  def record_automated_sms(to:, body:, sid:, source:)
+    Support::RecordAutomatedSms.call(phone: to, body: body, twilio_sid: sid, source: source)
+  rescue => e
+    Rails.logger.error("[TwilioService] Failed to record automated SMS: #{e.class}: #{e.message}")
+    nil
+  end
 
   def connection
     @connection ||= Faraday.new(url: "https://api.twilio.com/2010-04-01/") do |conn|

--- a/app/views/support/tickets/_message.html.erb
+++ b/app/views/support/tickets/_message.html.erb
@@ -3,8 +3,12 @@
     <div class="order-2 w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center text-white text-xs font-medium flex-shrink-0" title="<%= message.user.display_name_or_fallback %>">
       <%= message.user.display_name_or_fallback.split.map(&:first).join.upcase[0..1] %>
     </div>
+  <% elsif message.automated? %>
+    <div class="order-2 w-8 h-8 rounded-full bg-gray-200 border border-gray-300 flex items-center justify-center text-gray-500 flex-shrink-0" title="Automated message<%= " · #{message.automated_source}" if message.automated_source.present? %>">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+    </div>
   <% end %>
-  <div class="max-w-[85%] sm:max-w-md <%= message.inbound? ? 'bg-gray-100' : 'bg-blue-600 text-white order-1' %> rounded-lg px-3 sm:px-4 py-2">
+  <div class="max-w-[85%] sm:max-w-md <%= message.inbound? ? 'bg-gray-100' : (message.automated? ? 'bg-gray-100 border border-dashed border-gray-300 order-1' : 'bg-blue-600 text-white order-1') %> rounded-lg px-3 sm:px-4 py-2">
     <% if message.media.attached? %>
       <div class="flex flex-wrap gap-2 mb-2">
         <% message.media.each do |attachment| %>
@@ -23,17 +27,22 @@
     <% unless message.body == "(media)" %>
       <p class="whitespace-pre-wrap"><%= message.body %></p>
     <% end %>
+    <% meta_class = (message.inbound? || message.automated?) ? "text-gray-500" : "text-blue-200" %>
     <div class="flex items-center justify-end gap-2 mt-1">
       <% if message.outbound? && message.user.present? %>
-        <span class="text-xs <%= message.inbound? ? 'text-gray-500' : 'text-blue-200' %>">
+        <span class="text-xs <%= meta_class %>">
           <%= message.user.display_name_or_fallback %>
         </span>
+      <% elsif message.automated? %>
+        <span class="text-xs <%= meta_class %>">
+          Automated<%= " · #{message.automated_source}" if message.automated_source.present? %>
+        </span>
       <% end %>
-      <span class="text-xs <%= message.inbound? ? 'text-gray-500' : 'text-blue-200' %>">
+      <span class="text-xs <%= meta_class %>">
         <%= message.sent_at&.strftime("%H:%M") || message.created_at.strftime("%H:%M") %>
       </span>
       <% if message.outbound? && message.twilio_status.present? %>
-        <span class="text-xs flex items-center gap-1 <%= message.inbound? ? 'text-gray-400' : 'text-blue-200' %>" title="<%= message.twilio_status %>">
+        <span class="text-xs flex items-center gap-1 <%= (message.inbound? || message.automated?) ? 'text-gray-400' : 'text-blue-200' %>" title="<%= message.twilio_status %>">
           <% case message.twilio_status %>
           <% when "queued", "accepted" %>
             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><circle cx="10" cy="10" r="3"/></svg>
@@ -53,7 +62,7 @@
       <% end %>
     </div>
     <% if message.error_message.present? %>
-      <p class="text-xs text-red-300 mt-1"><%= message.error_message %></p>
+      <p class="text-xs <%= message.automated? ? 'text-red-600' : 'text-red-300' %> mt-1"><%= message.error_message %></p>
     <% end %>
   </div>
 </div>

--- a/db/migrate/20260825150000_add_automated_to_ticket_messages.rb
+++ b/db/migrate/20260825150000_add_automated_to_ticket_messages.rb
@@ -1,0 +1,5 @@
+class AddAutomatedToTicketMessages < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ticket_messages, :automated, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260825150001_create_automated_sms_logs.rb
+++ b/db/migrate/20260825150001_create_automated_sms_logs.rb
@@ -1,0 +1,16 @@
+class CreateAutomatedSmsLogs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :automated_sms_logs, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.string :phone_number, null: false
+      t.text :body, null: false
+      t.string :twilio_sid
+      t.string :source
+      t.datetime :sent_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :automated_sms_logs, [ :phone_number, :sent_at ]
+    add_index :automated_sms_logs, :twilio_sid, unique: true, where: "twilio_sid IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_150001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -121,6 +121,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
     t.datetime "updated_at", null: false
     t.index ["auditor_id"], name: "index_audits1984_audits_on_auditor_id"
     t.index ["session_id"], name: "index_audits1984_audits_on_session_id"
+  end
+
+  create_table "automated_sms_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.string "phone_number", null: false
+    t.datetime "sent_at", null: false
+    t.string "source"
+    t.string "twilio_sid"
+    t.datetime "updated_at", null: false
+    t.index ["phone_number", "sent_at"], name: "index_automated_sms_logs_on_phone_number_and_sent_at"
+    t.index ["twilio_sid"], name: "index_automated_sms_logs_on_twilio_sid", unique: true, where: "(twilio_sid IS NOT NULL)"
   end
 
   create_table "ban_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1155,6 +1167,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
   end
 
   create_table "ticket_messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "automated", default: false, null: false
     t.text "body", null: false
     t.string "channel", null: false
     t.datetime "created_at", null: false

--- a/spec/jobs/send_support_ticket_sms_notification_job_spec.rb
+++ b/spec/jobs/send_support_ticket_sms_notification_job_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
     it "texts every configured number" do
       described_class.perform_now(message.id, "new_ticket")
 
-      expect(twilio).to have_received(:send_sms).with(to: "+14155551234", body: a_string_including("+15550001111", "Help please"))
-      expect(twilio).to have_received(:send_sms).with(to: "+447700900123", body: a_string_including("WhatsApp"))
+      expect(twilio).to have_received(:send_sms).with(to: "+14155551234", body: a_string_including("+15550001111", "Help please"), source: "Staff notifications")
+      expect(twilio).to have_received(:send_sms).with(to: "+447700900123", body: a_string_including("WhatsApp"), source: "Staff notifications")
     end
 
     it "sends nothing when the feature is disabled" do
@@ -33,10 +33,10 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
     end
 
     it "survives a Twilio error on one number and continues to the next" do
-      allow(twilio).to receive(:send_sms).with(to: "+14155551234", body: anything).and_raise(TwilioService::Error, "boom")
+      allow(twilio).to receive(:send_sms).with(to: "+14155551234", body: anything, source: anything).and_raise(TwilioService::Error, "boom")
 
       expect { described_class.perform_now(message.id, "new_ticket") }.not_to raise_error
-      expect(twilio).to have_received(:send_sms).with(to: "+447700900123", body: anything)
+      expect(twilio).to have_received(:send_sms).with(to: "+447700900123", body: anything, source: anything)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
     it "texts the assignee's phone" do
       described_class.perform_now(message.id, "assigned_reply")
 
-      expect(twilio).to have_received(:send_sms).with(to: "+15559990000", body: a_string_including("new reply"))
+      expect(twilio).to have_received(:send_sms).with(to: "+15559990000", body: a_string_including("new reply"), source: "Staff notifications")
     end
 
     it "skips when the assignee has no phone" do

--- a/spec/services/support/process_incoming_twilio_message_spec.rb
+++ b/spec/services/support/process_incoming_twilio_message_spec.rb
@@ -38,6 +38,75 @@ RSpec.describe Support::ProcessIncomingTwilioMessage do
     end
   end
 
+  describe "automated message backfill" do
+    let(:phone) { "+14155551234" }
+    let(:sms_payload) do
+      {
+        "From" => phone,
+        "To" => "+18556254225",
+        "Body" => "Ok twin",
+        "MessageSid" => "SM_INBOUND",
+        "NumMedia" => "0"
+      }
+    end
+
+    def create_log(body:, sid:, sent_at: 1.hour.ago, source: nil)
+      AutomatedSmsLog.create!(phone_number: phone, body: body, twilio_sid: sid, sent_at: sent_at, source: source)
+    end
+
+    it "backfills recent automated texts into a newly created ticket, before the reply" do
+      create_log(body: "Your event starts at 9am", sid: "SM_AUTO_1", source: "Broadcast message")
+
+      ticket = described_class.call(sms_payload)
+
+      messages = ticket.ticket_messages.order(created_at: :asc)
+      expect(messages.map(&:body)).to eq([ "Your event starts at 9am", "Ok twin" ])
+      expect(messages.first).to be_automated
+      expect(messages.first).to be_outbound
+      expect(messages.first.automated_source).to eq("Broadcast message")
+    end
+
+    it "skips logs older than the backfill window" do
+      create_log(body: "Ancient text", sid: "SM_OLD", sent_at: 8.days.ago)
+
+      ticket = described_class.call(sms_payload)
+
+      expect(ticket.ticket_messages.map(&:body)).to eq([ "Ok twin" ])
+    end
+
+    it "skips logs already shown in another ticket" do
+      log = create_log(body: "Already seen", sid: "SM_SEEN")
+      old_ticket = Ticket.create!(phone_number: phone, channel: "sms", status: "closed")
+      TicketMessage.create!(ticket: old_ticket, direction: "outbound", channel: "sms",
+                            automated: true, body: log.body, twilio_message_sid: log.twilio_sid, sent_at: log.sent_at)
+
+      ticket = described_class.call(sms_payload)
+
+      expect(ticket).not_to eq(old_ticket)
+      expect(ticket.ticket_messages.map(&:body)).to eq([ "Ok twin" ])
+    end
+
+    it "does not backfill into an existing open ticket" do
+      existing = Ticket.create!(phone_number: phone, channel: "sms", status: "open")
+      create_log(body: "New automated text", sid: "SM_AUTO_2")
+
+      ticket = described_class.call(sms_payload)
+
+      expect(ticket).to eq(existing)
+      expect(ticket.ticket_messages.map(&:body)).to eq([ "Ok twin" ])
+    end
+
+    it "does not backfill SMS logs into a new whatsapp ticket" do
+      create_log(body: "SMS only", sid: "SM_AUTO_3")
+      whatsapp_payload = sms_payload.merge("From" => "whatsapp:#{phone}", "To" => "whatsapp:+18556254225")
+
+      ticket = described_class.call(whatsapp_payload)
+
+      expect(ticket.channel).to eq("whatsapp")
+      expect(ticket.ticket_messages.map(&:body)).to eq([ "Ok twin" ])
+    end
+  end
+
   describe "#attach_media" do
     it "skips invalid media URLs before creating an HTTP client" do
       payload = {

--- a/spec/services/support/record_automated_sms_spec.rb
+++ b/spec/services/support/record_automated_sms_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe Support::RecordAutomatedSms do
+  let(:phone) { "+14155551234" }
+
+  it "creates a log with the normalized phone number" do
+    log = described_class.call(phone: "(415) 555-1234", body: "Hello", twilio_sid: "SM100", source: "Incident reports")
+
+    expect(log.phone_number).to eq(phone)
+    expect(log.body).to eq("Hello")
+    expect(log.twilio_sid).to eq("SM100")
+    expect(log.source).to eq("Incident reports")
+    expect(log.sent_at).to be_present
+  end
+
+  it "returns nil for an invalid phone number" do
+    expect(described_class.call(phone: "not a phone", body: "Hello")).to be_nil
+    expect(AutomatedSmsLog.count).to eq(0)
+  end
+
+  context "when the recipient has an open SMS ticket" do
+    let!(:ticket) { Ticket.create!(phone_number: phone, channel: "sms", status: "open") }
+
+    it "appends an automated message to the ticket thread" do
+      described_class.call(phone: phone, body: "Your event starts soon", twilio_sid: "SM101", source: "Broadcast message")
+
+      message = ticket.ticket_messages.sole
+      expect(message).to be_outbound
+      expect(message).to be_automated
+      expect(message.body).to eq("Your event starts soon")
+      expect(message.user).to be_nil
+      expect(message.twilio_message_sid).to eq("SM101")
+      expect(message.automated_source).to eq("Broadcast message")
+      expect(ticket.reload.last_message_at).to be_present
+    end
+
+    it "does not append when the open ticket is on another channel" do
+      ticket.update!(channel: "whatsapp")
+
+      described_class.call(phone: phone, body: "Hello", twilio_sid: "SM102")
+
+      expect(ticket.ticket_messages.count).to eq(0)
+      expect(AutomatedSmsLog.count).to eq(1)
+    end
+
+    it "does not append when the ticket is closed" do
+      ticket.update!(status: "closed")
+
+      described_class.call(phone: phone, body: "Hello", twilio_sid: "SM103")
+
+      expect(ticket.ticket_messages.count).to eq(0)
+      expect(AutomatedSmsLog.count).to eq(1)
+    end
+  end
+
+  it "still creates the log when no ticket exists" do
+    described_class.call(phone: phone, body: "Hello", twilio_sid: "SM104")
+
+    expect(AutomatedSmsLog.count).to eq(1)
+    expect(TicketMessage.count).to eq(0)
+  end
+end

--- a/spec/services/twilio_service_spec.rb
+++ b/spec/services/twilio_service_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe TwilioService do
+  describe "#send_sms" do
+    subject(:service) { described_class.new(account_sid: "AC123", auth_token: "token", from_number: "+18005550000") }
+
+    let(:response) do
+      instance_double(Faraday::Response, success?: true, body: { sid: "SM200", status: "queued" }.to_json)
+    end
+
+    before do
+      allow(Setting).to receive(:twilio_enabled?).and_return(true)
+      connection = instance_double(Faraday::Connection)
+      allow(connection).to receive(:post).and_return(response)
+      allow(service).to receive(:connection).and_return(connection)
+    end
+
+    it "records the send for support chat history, preferring the redacted log body" do
+      expect(Support::RecordAutomatedSms).to receive(:call).with(
+        phone: "+14155551234",
+        body: "redacted body",
+        twilio_sid: "SM200",
+        source: "Guardian portal"
+      )
+
+      service.send_sms(to: "+14155551234", body: "real body", log_body: "redacted body", source: "Guardian portal")
+    end
+
+    it "records the actual body when no log body is given" do
+      expect(Support::RecordAutomatedSms).to receive(:call).with(
+        phone: "+14155551234",
+        body: "hello",
+        twilio_sid: "SM200",
+        source: nil
+      )
+
+      service.send_sms(to: "+14155551234", body: "hello")
+    end
+
+    it "does not fail the send when recording raises" do
+      allow(Support::RecordAutomatedSms).to receive(:call).and_raise(StandardError, "db down")
+
+      result = service.send_sms(to: "+14155551234", body: "hello")
+
+      expect(result[:sid]).to eq("SM200")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When someone replies to an automated text (a broadcast message, incident report update, guardian portal code…), the support agent sees only the inbound reply — e.g. just "Ok twin" — with no way to tell what the person is responding to.

## What this does

- **`AutomatedSmsLog`**: every SMS sent through `TwilioService#send_sms` is now recorded (normalized phone, body, Twilio SID, a `source` label, sent_at). Logging failures are swallowed and logged — they never fail the send or cause a job retry to double-send.
- **Live append**: if the recipient already has an open SMS ticket, the automated text is appended to the thread immediately as an automated `TicketMessage` (same `after_create_commit` broadcast path as agent/inbound messages, so it appears live in prod).
- **Backfill on new tickets**: when an inbound reply opens a *new* ticket, automated texts from the last 7 days (up to 10) are backfilled into the thread above the reply, deduped by Twilio SID against messages already shown in earlier tickets. Backfill only applies to SMS-channel tickets since automated sends go out as plain SMS.
- **UI**: automated messages render right-aligned as grey dashed-border bubbles with a gear avatar and an `Automated · <source>` label (e.g. "Automated · Broadcast message"), distinct from the blue agent bubbles. Meta text colours adjusted so they stay readable on the grey bubble.
- **Sources labelled** at each call site: Broadcast message, Incident reports, Guardian portal, Staff notifications.
- **Redaction**: the guardian portal verification code is logged as `[redacted]` so support agents can see the text was sent without seeing the sign-in code.

## Screenshots (dev)

Verified in the browser in light + dark and mobile + desktop: backfilled ticket shows the two automated texts above the reply, a mixed thread distinguishes automated (grey dashed) from agent (blue) bubbles, and the redacted portal code renders correctly.

## Tests

- `spec/services/support/record_automated_sms_spec.rb` — log creation, phone normalization, live append (open SMS ticket only; not closed/whatsapp)
- `spec/services/support/process_incoming_twilio_message_spec.rb` — backfill ordering, 7-day window, SID dedup across tickets, no backfill into existing/whatsapp tickets
- `spec/services/twilio_service_spec.rb` — records with log_body redaction, never fails the send
- Updated `send_support_ticket_sms_notification_job_spec` for the new `source:` kwarg

Note: `spec/requests/guardian_portal_center_spec.rb:217/:266` fail locally on main too — pre-existing `invite_last_used_at` schema.rb drift from #58, unrelated to this change.