### PR TITLE
Add missing invite_last_used_at column to schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -505,6 +505,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
     t.integer "emergency_contact_priority"
     t.boolean "emergency_medical_consent"
     t.uuid "guardian_id", null: false
+    t.datetime "invite_last_used_at"
     t.string "invite_token_ciphertext"
     t.string "invite_token_digest"
     t.datetime "invite_token_sent_at"


### PR DESCRIPTION
## What

`db/schema.rb` was missing `invite_last_used_at` on `guardian_participant_events`. One line added.

## Why

[PR #58](https://github.com/hackclub/attend/pull/58) (`adecf31d`) added both the migration and the model code that reads the column:

- [`db/migrate/20260824120000_add_invite_last_used_at_to_guardian_participant_events.rb`](db/migrate/20260824120000_add_invite_last_used_at_to_guardian_participant_events.rb)
- [`app/models/guardian_participant_event.rb:77`](app/models/guardian_participant_event.rb#L77) and `:87`

The schema dump that landed on `main`, though, was produced from a dev database where the `schema_migrations` row for `20260824120000` existed while the column did not — so the dump recorded the table without it. Because the migration was already marked as run, it could never re-run and repair itself.

## Impact

**Production is fine.** It runs the migration files directly, not `schema.rb`:

```
column_exists=true
migration_row=1
non_null=1557   # accepted_at backfill applied
```

The breakage was limited to anything that loads structure from `schema.rb` — every freshly prepared test database. `spec/requests/guardian_portal_center_spec.rb:217` and `:266` failed with `NameError: undefined method 'invite_last_used_at'` at `guardian_participant_event.rb:77`.

## Verification

Repaired the shared dev DB (deleted the stale `schema_migrations` row, re-ran `db:migrate:up VERSION=20260824120000`) and confirmed the real dump places the line in exactly this position. The dump also pulled in unrelated tables from other in-flight branches on that shared database, so this commit carries only the intended line.

```
$ bundle exec rspec spec/requests/guardian_portal_center_spec.rb \
    spec/models/guardian_participant_event_spec.rb \
    spec/requests/guardian_portal_invite_window_spec.rb \
    spec/jobs/send_pending_guardian_invites_job_spec.rb

53 examples, 0 failures
```

Schema version line is unchanged (`2026_08_25_135022`) — this migration predates it, so no version bump is warranted.