### PR TITLE
Filter and bulk-close support tickets

### DIFF
--- a/app/controllers/support/tickets_controller.rb
+++ b/app/controllers/support/tickets_controller.rb
@@ -3,12 +3,19 @@ module Support
     before_action :skip_require_event
     before_action :set_ticket, only: %i[show close reopen assign set_event set_subject]
     after_action :verify_authorized
+    # Each ticket in a batch is audited individually in #bulk_close, so the
+    # blanket one-record-per-request hook has nothing useful to record here.
+    skip_after_action :log_admin_action, only: :bulk_close
 
-    helper_method :can_link_ticket_to_event?
+    helper_method :can_link_ticket_to_event?, :ticket_filter_params
+
+    UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 
     def index
       authorize Ticket
-      @tickets = policy_scope(Ticket).recent_first.includes(:event, :assigned_to)
+      @tickets = filtered_tickets.includes(:event, :assigned_to)
+      @assignees = assignee_options
+      @filtering = ticket_filter_params.any?
     end
 
     def show
@@ -31,6 +38,29 @@ module Support
                             .where.not(id: @ticket.id)
                             .recent_first
                             .limit(10)
+    end
+
+    def bulk_close
+      authorize Ticket, :bulk_close?
+
+      ids = Array(params[:ticket_ids]).select { |id| id.to_s.match?(UUID_FORMAT) }
+      closed = 0
+
+      policy_scope(Ticket).where(id: ids, status: :open).find_each do |ticket|
+        next unless TicketPolicy.new(current_user, ticket).update?
+
+        ticket.close!(user: current_user)
+        log_bulk_close(ticket)
+        closed += 1
+      end
+
+      notice = if closed.zero?
+        "No tickets were closed."
+      else
+        "Closed #{closed} #{'ticket'.pluralize(closed)}."
+      end
+
+      redirect_to support_tickets_path(ticket_filter_params), notice: notice, status: :see_other
     end
 
     def close
@@ -91,6 +121,89 @@ module Support
     end
 
     private
+
+    # Filters the inbox by contact name, phone number, channel, assignee and
+    # status. Each one is skipped when its param is blank.
+    def filtered_tickets
+      scope = policy_scope(Ticket).recent_first
+      scope = scope.where(status: params[:status]) if Ticket.statuses.key?(params[:status])
+      scope = scope.where(channel: params[:channel]) if Ticket.channels.key?(params[:channel])
+      scope = filter_by_assignee(scope)
+      scope = filter_by_phone(scope)
+      filter_by_name(scope)
+    end
+
+    def filter_by_assignee(scope)
+      assignee = params[:assignee].to_s
+      return scope if assignee.blank?
+      return scope.where(assigned_to_id: nil) if assignee == "unassigned"
+      return scope.none unless assignee.match?(UUID_FORMAT)
+
+      scope.where(assigned_to_id: assignee)
+    end
+
+    # Phone numbers are stored in E.164 but staff type them however they like,
+    # so both sides are reduced to digits before matching.
+    def filter_by_phone(scope)
+      digits = params[:phone].to_s.gsub(/\D/, "")
+      return scope if digits.blank?
+
+      scope.where("regexp_replace(tickets.phone_number, '[^0-9]', '', 'g') LIKE ?", "%#{digits}%")
+    end
+
+    # Matches the linked contact shown in the Contact column, which is either a
+    # Participant or a Guardian.
+    def filter_by_name(scope)
+      query = params[:q].to_s.strip
+      return scope if query.blank?
+
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+      participants = Participant.where(
+        "legal_first_name ILIKE :name OR legal_last_name ILIKE :name OR preferred_name ILIKE :name " \
+        "OR (legal_first_name || ' ' || legal_last_name) ILIKE :name",
+        name: pattern
+      ).select(:id)
+      guardians = Guardian.where(
+        "legal_first_name ILIKE :name OR legal_last_name ILIKE :name " \
+        "OR (legal_first_name || ' ' || legal_last_name) ILIKE :name",
+        name: pattern
+      ).select(:id)
+
+      scope.where(subject_type: "Participant", subject_id: participants)
+           .or(scope.where(subject_type: "Guardian", subject_id: guardians))
+    end
+
+    def assignee_options
+      ids = policy_scope(Ticket).where.not(assigned_to_id: nil).distinct.pluck(:assigned_to_id)
+      User.where(id: ids).sort_by { |user| user.display_name_or_fallback.to_s.downcase }
+    end
+
+    def ticket_filter_params
+      @ticket_filter_params ||= params.permit(:q, :phone, :channel, :assignee, :status)
+                                      .to_h
+                                      .symbolize_keys
+                                      .compact_blank
+    end
+
+    # Admin::BaseController's blanket audit hook can only record one record per
+    # request, so each closed ticket is logged explicitly instead.
+    def log_bulk_close(ticket)
+      AuditLog.log!(
+        action: "close",
+        record: ticket,
+        actor: current_user,
+        event: ticket.event,
+        changed_fields: ticket.previous_changes.except("updated_at", "created_at"),
+        metadata: {
+          ip: request.remote_ip,
+          user_agent: request.user_agent,
+          controller: controller_name,
+          bulk: true
+        }
+      )
+    rescue => e
+      Rails.logger.error("[Support::Tickets] Failed to audit bulk close for #{ticket.id}: #{e.class} - #{e.message}")
+    end
 
     def set_ticket
       @ticket = Ticket.find(params[:id])

--- a/app/javascript/controllers/bulk_select_controller.js
+++ b/app/javascript/controllers/bulk_select_controller.js
@@ -1,0 +1,59 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drives the "select tickets, then close them together" toolbar on the support
+// inbox. Rows are swapped in and out by Turbo broadcasts, so the tally is
+// recalculated whenever a checkbox target connects or disconnects.
+export default class extends Controller {
+  static targets = ["checkbox", "selectAll", "bar", "count"]
+
+  connect() {
+    this.refresh()
+  }
+
+  checkboxTargetConnected() {
+    this.refresh()
+  }
+
+  checkboxTargetDisconnected() {
+    this.refresh()
+  }
+
+  toggleAll() {
+    this.checkboxTargets.forEach((box) => { box.checked = this.selectAllTarget.checked })
+    this.refresh()
+  }
+
+  toggle() {
+    this.refresh()
+  }
+
+  refresh() {
+    const total = this.checkboxTargets.length
+    const selected = this.selectedCount
+
+    if (this.hasSelectAllTarget) {
+      this.selectAllTarget.checked = total > 0 && selected === total
+      this.selectAllTarget.indeterminate = selected > 0 && selected < total
+      this.selectAllTarget.disabled = total === 0
+    }
+
+    if (this.hasBarTarget) this.barTarget.classList.toggle("hidden", selected === 0)
+    if (this.hasCountTarget) this.countTarget.textContent = `${selected} ${this.noun(selected)} selected`
+  }
+
+  confirmClose(event) {
+    const selected = this.selectedCount
+
+    if (selected === 0 || !window.confirm(`Close ${selected} ${this.noun(selected)}?`)) {
+      event.preventDefault()
+    }
+  }
+
+  get selectedCount() {
+    return this.checkboxTargets.filter((box) => box.checked).length
+  }
+
+  noun(count) {
+    return count === 1 ? "ticket" : "tickets"
+  }
+}

--- a/app/policies/ticket_policy.rb
+++ b/app/policies/ticket_policy.rb
@@ -37,6 +37,12 @@ class TicketPolicy < ApplicationPolicy
     update?
   end
 
+  # The collection action itself only needs inbox access; each ticket in the
+  # batch is still checked against #update? before it is closed.
+  def bulk_close?
+    index?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.all if user.global_admin?

--- a/app/views/support/tickets/_ticket_row.html.erb
+++ b/app/views/support/tickets/_ticket_row.html.erb
@@ -1,4 +1,13 @@
 <tr id="<%= dom_id(ticket) %>">
+  <td class="pl-6 pr-2 py-4 whitespace-nowrap">
+    <% if ticket.open? %>
+      <%= check_box_tag "ticket_ids[]", ticket.id, false,
+            id: "select_#{dom_id(ticket)}",
+            class: "portal-check",
+            aria: { label: "Select ticket from #{ticket.phone_number}" },
+            data: { bulk_select_target: "checkbox", action: "change->bulk-select#toggle" } %>
+    <% end %>
+  </td>
   <td class="px-6 py-4 whitespace-nowrap">
     <% if ticket.open? %>
       <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Open</span>

--- a/app/views/support/tickets/index.html.erb
+++ b/app/views/support/tickets/index.html.erb
@@ -15,45 +15,103 @@
     </div>
   </div>
 
-  <%= turbo_stream_from :tickets_index %>
+  <%# Live updates would push rows straight past an active filter, so the
+      index stream is only subscribed to on the unfiltered inbox. %>
+  <%= turbo_stream_from :tickets_index unless @filtering %>
   <%= turbo_stream_from :tickets_notifications %>
   <%= turbo_stream_from "user_#{current_user.id}_notifications" %>
   <div id="ticket_notifications" class="hidden" data-ticket-notifications-target="notifications"></div>
   <div id="user_notifications" class="hidden" data-ticket-notifications-target="notifications"></div>
 
-  <% if @tickets.any? %>
-    <div class="bg-white shadow rounded-lg overflow-hidden flex-1">
-      <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Channel</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Contact</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Message</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assigned To</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"></th>
-            </tr>
-          </thead>
-          <tbody id="tickets" class="bg-white divide-y divide-gray-200 text-sm">
-            <% @tickets.each do |ticket| %>
-              <%= render "ticket_row", ticket: ticket %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
+  <div class="bg-white shadow rounded-lg overflow-hidden flex-1 flex flex-col">
+    <div class="p-4 border-b border-gray-200">
+      <%= form_with url: support_tickets_path, method: :get, class: "grid grid-cols-2 lg:grid-cols-6 gap-3 sm:gap-4", data: { turbo_frame: "_top" } do |f| %>
+        <div class="col-span-2">
+          <%= f.label :q, "Contact name", class: "portal-label" %>
+          <%= f.text_field :q, value: params[:q], placeholder: "Jane Doe", class: "portal-input" %>
+        </div>
+        <div>
+          <%= f.label :phone, "Phone", class: "portal-label" %>
+          <%= f.text_field :phone, value: params[:phone], placeholder: "555 0100", class: "portal-input" %>
+        </div>
+        <div>
+          <%= f.label :channel, "Channel", class: "portal-label" %>
+          <%= f.select :channel, [["All channels", ""], ["SMS", "sms"], ["WhatsApp", "whatsapp"], ["Signal", "signal"]], { selected: params[:channel] }, class: "portal-select" %>
+        </div>
+        <div>
+          <%= f.label :assignee, "Assigned to", class: "portal-label" %>
+          <% assignee_options = [["Anyone", ""], ["Unassigned", "unassigned"]] + @assignees.map { |user| [user.display_name_or_fallback, user.id] } %>
+          <%= f.select :assignee, assignee_options, { selected: params[:assignee] }, class: "portal-select" %>
+        </div>
+        <div>
+          <%= f.label :status, "Status", class: "portal-label" %>
+          <%= f.select :status, [["All statuses", ""], ["Open", "open"], ["Closed", "closed"]], { selected: params[:status] }, class: "portal-select" %>
+        </div>
+        <div class="col-span-2 lg:col-span-6 flex items-center gap-2">
+          <%= f.button "Filter", name: nil, class: "portal-btn portal-btn-primary" %>
+          <% if @filtering %>
+            <%= link_to "Clear", support_tickets_path, class: "portal-btn portal-btn-secondary" %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
-  <% else %>
-    <div class="bg-white shadow rounded-lg p-6 text-center text-gray-500 flex-1 flex items-center justify-center">
-      <div>
-        <svg class="mx-auto h-12 w-12 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
-        </svg>
-        <p class="text-lg font-medium">No tickets yet</p>
-        <p class="mt-1 text-sm">Tickets will appear here when messages are received via Twilio.</p>
+
+    <% if @tickets.any? %>
+      <%= form_with url: bulk_close_support_tickets_path, method: :patch,
+                    class: "flex-1 flex flex-col min-h-0",
+                    data: { controller: "bulk-select" } do %>
+        <% ticket_filter_params.each do |key, value| %>
+          <%= hidden_field_tag key, value, id: "filter_#{key}" %>
+        <% end %>
+
+        <div data-bulk-select-target="bar" class="hidden flex items-center justify-between gap-4 px-6 py-3 bg-(--accent-soft) border-b border-gray-200">
+          <span class="text-sm font-semibold text-gray-900" data-bulk-select-target="count">0 tickets selected</span>
+          <%= button_tag "Close selected", name: nil, class: "portal-btn portal-btn-primary", data: { action: "click->bulk-select#confirmClose" } %>
+        </div>
+
+        <div class="overflow-x-auto overflow-y-auto flex-1">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="pl-6 pr-2 py-3 text-left">
+                  <%= check_box_tag "select_all_tickets", "1", false,
+                        class: "portal-check",
+                        aria: { label: "Select all open tickets" },
+                        data: { bulk_select_target: "selectAll", action: "change->bulk-select#toggleAll" } %>
+                </th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Channel</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Contact</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Message</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assigned To</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"></th>
+              </tr>
+            </thead>
+            <tbody id="tickets" class="bg-white divide-y divide-gray-200 text-sm">
+              <% @tickets.each do |ticket| %>
+                <%= render "ticket_row", ticket: ticket %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="p-6 text-center text-gray-500 flex-1 flex items-center justify-center">
+        <div>
+          <svg class="mx-auto h-12 w-12 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/>
+          </svg>
+          <% if @filtering %>
+            <p class="text-lg font-medium">No tickets match these filters</p>
+            <p class="mt-1 text-sm">Try widening or <%= link_to "clearing", support_tickets_path, class: "portal-link" %> them.</p>
+          <% else %>
+            <p class="text-lg font-medium">No tickets yet</p>
+            <p class="mt-1 text-sm">Tickets will appear here when messages are received via Twilio.</p>
+          <% end %>
+        </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,10 @@ Rails.application.routes.draw do
   # Support / Chat system
   namespace :support do
     resources :tickets, only: %i[index show] do
+      collection do
+        patch :bulk_close
+      end
+
       member do
         patch :close
         patch :reopen

--- a/spec/requests/support/tickets_spec.rb
+++ b/spec/requests/support/tickets_spec.rb
@@ -98,6 +98,150 @@ RSpec.describe "Support::Tickets", type: :request do
     end
   end
 
+  describe "GET index filters" do
+    let!(:participant) do
+      Participant.create!(legal_first_name: "Ada", legal_last_name: "Lovelace", email: "ada@example.com", phone: "+15550009999")
+    end
+    let!(:guardian) do
+      Guardian.create!(legal_first_name: "Grace", legal_last_name: "Hopper", email: "grace@example.com", phone: "+15550008888")
+    end
+
+    before do
+      live_ticket.update!(subject: participant, assigned_to: event_ops, channel: "sms")
+      other_ticket.update!(subject: guardian, channel: "signal")
+    end
+
+    it "filters by the linked contact's name" do
+      sign_in global_admin
+      get support_tickets_path, params: { q: "lovel" }
+
+      expect(response.body).to include(live_ticket.phone_number)
+      expect(response.body).not_to include(other_ticket.phone_number)
+    end
+
+    it "matches guardians as well as participants" do
+      sign_in global_admin
+      get support_tickets_path, params: { q: "Grace Hopper" }
+
+      expect(response.body).to include(other_ticket.phone_number)
+      expect(response.body).not_to include(live_ticket.phone_number)
+    end
+
+    it "filters by phone number ignoring formatting" do
+      sign_in global_admin
+      get support_tickets_path, params: { phone: "(555) 000-2222" }
+
+      expect(response.body).to include(live_ticket.phone_number)
+      expect(response.body).not_to include(pending_ticket.phone_number)
+    end
+
+    it "filters by channel" do
+      sign_in global_admin
+      get support_tickets_path, params: { channel: "signal" }
+
+      expect(response.body).to include(other_ticket.phone_number)
+      expect(response.body).not_to include(live_ticket.phone_number)
+    end
+
+    it "filters by assignee" do
+      sign_in global_admin
+      get support_tickets_path, params: { assignee: event_ops.id }
+
+      expect(response.body).to include(live_ticket.phone_number)
+      expect(response.body).not_to include(other_ticket.phone_number)
+    end
+
+    it "filters by unassigned tickets" do
+      sign_in global_admin
+      get support_tickets_path, params: { assignee: "unassigned" }
+
+      expect(response.body).to include(other_ticket.phone_number)
+      expect(response.body).not_to include(live_ticket.phone_number)
+    end
+
+    it "filters by status" do
+      live_ticket.close!(user: global_admin)
+
+      sign_in global_admin
+      get support_tickets_path, params: { status: "closed" }
+
+      expect(response.body).to include(live_ticket.phone_number)
+      expect(response.body).not_to include(other_ticket.phone_number)
+    end
+
+    it "ignores an assignee that is not a valid id" do
+      sign_in global_admin
+      get support_tickets_path, params: { assignee: "not-a-uuid" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(live_ticket.phone_number)
+    end
+
+    it "combines every filter without blowing up" do
+      sign_in global_admin
+      get support_tickets_path, params: { q: "ada", phone: "555", channel: "sms", assignee: "not-a-uuid", status: "open" }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "still scopes filtered results to what the user may see" do
+      sign_in event_ops
+      get support_tickets_path, params: { channel: "signal" }
+
+      expect(response.body).not_to include(other_ticket.phone_number)
+    end
+  end
+
+  describe "PATCH bulk_close" do
+    it "closes every selected ticket the user may update" do
+      sign_in global_admin
+      patch bulk_close_support_tickets_path, params: { ticket_ids: [ pending_ticket.id, live_ticket.id ] }
+
+      expect(response).to redirect_to(support_tickets_path)
+      expect(pending_ticket.reload).to be_closed
+      expect(live_ticket.reload).to be_closed
+      expect(flash[:notice]).to eq("Closed 2 tickets.")
+    end
+
+    it "skips tickets outside the user's scope" do
+      sign_in event_ops
+      patch bulk_close_support_tickets_path, params: { ticket_ids: [ live_ticket.id, other_ticket.id ] }
+
+      expect(live_ticket.reload).to be_closed
+      expect(other_ticket.reload).to be_open
+      expect(flash[:notice]).to eq("Closed 1 ticket.")
+    end
+
+    it "denies staff outside their support window" do
+      sign_in past_event_admin
+      patch bulk_close_support_tickets_path, params: { ticket_ids: [ pending_ticket.id ] }
+
+      expect(pending_ticket.reload).to be_open
+    end
+
+    it "tolerates ids that are not valid uuids" do
+      sign_in global_admin
+      patch bulk_close_support_tickets_path, params: { ticket_ids: [ "", "nope", pending_ticket.id ] }
+
+      expect(pending_ticket.reload).to be_closed
+    end
+
+    it "keeps the active filters on the redirect" do
+      sign_in global_admin
+      patch bulk_close_support_tickets_path, params: { ticket_ids: [ pending_ticket.id ], channel: "whatsapp", status: "open" }
+
+      expect(response).to redirect_to(support_tickets_path(channel: "whatsapp", status: "open"))
+    end
+
+    it "audits each closed ticket" do
+      sign_in global_admin
+
+      expect {
+        patch bulk_close_support_tickets_path, params: { ticket_ids: [ pending_ticket.id, live_ticket.id ] }
+      }.to change { AuditLog.where(action: "close", record_type: "Ticket").count }.by(2)
+    end
+  end
+
   describe "PATCH close" do
     it "lets active event staff close a pending ticket" do
       sign_in event_ops


### PR DESCRIPTION
Closes tickets in batches and makes the support inbox searchable. Previously the index was one flat, unfilterable table and every close was its own page load.

## Filtering

A filter bar over the index, each param skipped when blank and all composed on top of the existing `policy_scope` — event staff still see only their own events plus the triage queue.

| Filter | Behaviour |
|---|---|
| Contact name | matches the linked subject — Participant (including preferred name) or Guardian |
| Phone | both sides reduced to digits, so `(555) 000-2222` matches `+15550002222` |
| Channel | SMS / WhatsApp / Signal |
| Assigned to | anyone, unassigned, or a specific user (only users who actually hold tickets in your scope) |
| Status | open / closed |

Status isn't in the original ask, but bulk-closing amongst already-closed rows isn't much use, so it's in.

## Bulk close

Per-row checkboxes on open tickets, a select-all in the header, and a toolbar showing the count with a confirm-guarded **Close selected**. `PATCH /support/tickets/bulk_close` re-checks `TicketPolicy#update?` per ticket rather than trusting the submitted ids, so a staffer who selects rows they can't touch closes only the ones they can. Active filters ride along as hidden fields and survive the redirect.

## Two things worth knowing

**Audit logging.** `Admin::BaseController`'s blanket hook can only record one record per request, and `bulk_close` isn't in the `AuditLog` action enum — it raised. The hook is skipped for this action and each closed ticket is logged explicitly as `close` with `bulk: true` in the metadata, so per-ticket history stays intact.

**Live updates are off while filtering.** The `tickets_index` Turbo stream would prepend brand-new tickets straight past an active filter, so the index only subscribes to it when unfiltered. Filtered views are a snapshot until reload.

## Styling

The filter bar and toolbar use the `portal-*` component layer, not literal hexes. An earlier hex-styled pass rendered as unstyled text on the dark theme — themes.css's unlayered `input` rules beat Tailwind utilities regardless of specificity. `portal-*` resolves through semantic tokens and works in all eight themes.

## Verification

31 request specs pass (11 new for the filters, 6 for bulk close, including scope enforcement, invalid uuids, filter retention, and audit rows). Rubocop clean.

Checked in the browser across light/dark and desktop/mobile, including a real bulk close of two tickets — flash read "Closed 2 tickets." with filters preserved. Dev data restored afterwards.