### PR TITLE
Let support staff merge tickets together

### DIFF
--- a/app/assets/stylesheets/themes.css
+++ b/app/assets/stylesheets/themes.css
@@ -749,7 +749,10 @@
 
 /* keep system scrollbars + form controls consistent with theme */
 [data-theme]:not([data-theme="light"]):not([data-theme="catppuccin-latte"]) {
-  input, select, textarea {
+  /* checkboxes and radios are excluded: painting a background over a native
+   * control stops chromium drawing the box at all, leaving an invisible
+   * dark square. `color-scheme: dark` above already themes them. */
+  input:not([type="checkbox"]):not([type="radio"]), select, textarea {
     background-color: var(--bg-elev);
     color: var(--text-strong);
   }

--- a/app/controllers/support/tickets_controller.rb
+++ b/app/controllers/support/tickets_controller.rb
@@ -1,18 +1,20 @@
 module Support
   class TicketsController < Admin::BaseController
     before_action :skip_require_event
-    before_action :set_ticket, only: %i[show close reopen assign set_event set_subject]
+    before_action :set_ticket, only: %i[show close reopen assign set_event set_subject merge]
     after_action :verify_authorized
 
     helper_method :can_link_ticket_to_event?
 
     def index
       authorize Ticket
-      @tickets = policy_scope(Ticket).recent_first.includes(:event, :assigned_to)
+      @tickets = policy_scope(Ticket).unmerged.recent_first.includes(:event, :assigned_to)
     end
 
     def show
       authorize @ticket
+      return redirect_to_merge_root if @ticket.merged?
+
       @message = TicketMessage.new
       @note = Note.new
 
@@ -27,10 +29,13 @@ module Support
       end
 
       @previous_tickets = policy_scope(Ticket)
+                            .unmerged
                             .where(phone_number: @ticket.phone_number)
                             .where.not(id: @ticket.id)
                             .recent_first
                             .limit(10)
+
+      @merged_sources = @ticket.merged_tickets.includes(:merged_by).order(:merged_at)
     end
 
     def close
@@ -45,6 +50,8 @@ module Support
 
     def reopen
       authorize @ticket, :update?
+      return redirect_to_merge_root if @ticket.merged?
+
       @ticket.reopen!
 
       respond_to do |format|
@@ -90,7 +97,31 @@ module Support
       redirect_to support_ticket_path(@ticket), notice: "Contact linked."
     end
 
+    # Folds another ticket with the same phone number into this one, so a contact
+    # coming back to a closed ticket reads as one conversation.
+    def merge
+      authorize @ticket, :merge?
+      source = policy_scope(Ticket).find(params[:source_id])
+      authorize source, :merge?
+
+      result = ::Support::MergeTickets.call(source: source, target: @ticket, user: current_user)
+
+      notice = "Merged ##{source.id[0..7]} into this ticket " \
+               "(#{helpers.pluralize(result.moved_messages, 'message')})."
+      notice += " Ticket reopened." if result.reopened
+
+      redirect_to support_ticket_path(@ticket), notice: notice
+    rescue ::Support::MergeTickets::MergeError => e
+      redirect_to support_ticket_path(@ticket), alert: e.message
+    end
+
     private
+
+    def redirect_to_merge_root
+      root = @ticket.merge_root
+      redirect_to support_ticket_path(root),
+                  notice: "Ticket ##{@ticket.id[0..7]} was merged into ##{root.id[0..7]}."
+    end
 
     def set_ticket
       @ticket = Ticket.find(params[:id])

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -63,6 +63,7 @@ class AuditLog < ApplicationRecord
     ticket_assign: "assign",
     ticket_set_event: "set_event",
     ticket_set_subject: "set_subject",
+    ticket_merge: "merge",
     toggle_support_sms: "toggle_support_sms",
     update_support_sms_numbers: "update_support_sms_numbers",
     trigger_airtable_sync: "trigger_airtable_sync",

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,4 +1,6 @@
 class Ticket < ApplicationRecord
+  class MergedTicketError < StandardError; end
+
   include ActionView::RecordIdentifier
 
   has_paper_trail
@@ -10,9 +12,13 @@ class Ticket < ApplicationRecord
   belongs_to :assigned_to, class_name: "User", optional: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :closed_by, class_name: "User", optional: true
+  belongs_to :merged_into, class_name: "Ticket", optional: true
+  belongs_to :merged_by, class_name: "User", optional: true
 
   has_many :ticket_messages, dependent: :destroy
   has_many :notes, dependent: :nullify
+  has_many :merged_tickets, class_name: "Ticket", foreign_key: :merged_into_id,
+           inverse_of: :merged_into, dependent: :nullify
 
   enum :status, {
     open: "open",
@@ -30,6 +36,9 @@ class Ticket < ApplicationRecord
   validates :status, presence: true
 
   scope :recent_first, -> { order(last_message_at: :desc, created_at: :desc) }
+  # Merged tickets are tombstones: their thread now lives on another ticket, so
+  # they stay out of the inbox and out of inbound-message matching.
+  scope :unmerged, -> { where(merged_into_id: nil) }
 
   after_create_commit :broadcast_new_ticket
   after_update_commit :broadcast_ticket_update
@@ -53,6 +62,11 @@ class Ticket < ApplicationRecord
   end
 
   def broadcast_ticket_update
+    if merged?
+      broadcast_remove_to(:tickets_index, target: dom_id(self))
+      return
+    end
+
     broadcast_replace_to(
       :tickets_index,
       target: dom_id(self),
@@ -68,7 +82,26 @@ class Ticket < ApplicationRecord
   end
 
   def reopen!
+    raise MergedTicketError, "This ticket was merged into ##{merged_into_id&.first(8)}" if merged?
+
     update!(status: :open, closed_at: nil, closed_by: nil)
+  end
+
+  def merged?
+    merged_into_id.present?
+  end
+
+  # Where this ticket's thread actually lives now. Follows a chain of merges and
+  # stops on itself if the data ever loops back around.
+  def merge_root
+    ticket = self
+    seen = Set.new([ id ])
+
+    while (parent = ticket.merged_into) && seen.add?(parent.id)
+      ticket = parent
+    end
+
+    ticket
   end
 
   def matching_participants

--- a/app/models/ticket_message.rb
+++ b/app/models/ticket_message.rb
@@ -9,6 +9,8 @@ class TicketMessage < ApplicationRecord
 
   belongs_to :ticket
   belongs_to :user, optional: true
+  # Set when this message arrived on another ticket that was later merged in.
+  belongs_to :merged_from_ticket, class_name: "Ticket", optional: true
 
   enum :direction, {
     inbound: "inbound",

--- a/app/policies/ticket_policy.rb
+++ b/app/policies/ticket_policy.rb
@@ -37,6 +37,10 @@ class TicketPolicy < ApplicationPolicy
     update?
   end
 
+  def merge?
+    update?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.all if user.global_admin?

--- a/app/services/support/merge_tickets.rb
+++ b/app/services/support/merge_tickets.rb
@@ -1,0 +1,148 @@
+module Support
+  # Folds one ticket's thread into another so a single conversation with a contact
+  # reads as one thread — e.g. a closed ticket the same person replies to weeks later.
+  #
+  # The source keeps existing as a tombstone pointing at the target, so old links and
+  # audit history still resolve; every message it held moves to the target and is
+  # stamped with where it came from.
+  class MergeTickets
+    class MergeError < StandardError; end
+
+    Result = Struct.new(:target, :source, :moved_messages, :moved_notes, :reopened, keyword_init: true)
+
+    def self.call(source:, target:, user:)
+      new(source:, target:, user:).call
+    end
+
+    def initialize(source:, target:, user:)
+      @source = source
+      @target = target
+      @user = user
+    end
+
+    def call
+      validate!
+
+      moved_messages = 0
+      moved_notes = 0
+      reopened = false
+
+      Ticket.transaction do
+        @source.lock!
+        @target.lock!
+
+        # Re-check under the lock: a concurrent merge may have moved either side.
+        validate!
+
+        messages = TicketMessage.where(ticket_id: @source.id)
+        messages.where(merged_from_ticket_id: nil).update_all(merged_from_ticket_id: @source.id)
+        moved_messages = messages.update_all(ticket_id: @target.id, updated_at: Time.current)
+        moved_notes = Note.where(ticket_id: @source.id).update_all(ticket_id: @target.id, updated_at: Time.current)
+
+        reopened = reopen_target?
+        @target.update!(target_attributes(reopen: reopened))
+
+        @source.update!(
+          status: :closed,
+          closed_at: @source.closed_at || Time.current,
+          closed_by: @source.closed_by || @user,
+          merged_into: @target,
+          merged_at: Time.current,
+          merged_by: @user
+        )
+      end
+
+      record_merge_note(moved_messages)
+      broadcast_target_thread
+
+      Result.new(
+        target: @target.reload,
+        source: @source,
+        moved_messages: moved_messages,
+        moved_notes: moved_notes,
+        reopened: reopened
+      )
+    end
+
+    private
+
+    def validate!
+      raise MergeError, "A ticket can't be merged into itself." if @source.id == @target.id
+
+      if @source.merged?
+        raise MergeError, "#{short_id(@source)} was already merged into #{short_id(@source.merged_into)}."
+      end
+
+      if @target.merged?
+        raise MergeError,
+              "#{short_id(@target)} was merged into #{short_id(@target.merged_into)} — merge into that ticket instead."
+      end
+
+      if @source.phone_number != @target.phone_number
+        raise MergeError, "Tickets can only be merged when they're with the same phone number."
+      end
+    end
+
+    # The whole point of merging a fresh enquiry into an old thread is to pick the
+    # conversation back up, so an open source reopens a closed target.
+    def reopen_target?
+      @source.open? && @target.closed?
+    end
+
+    def target_attributes(reopen:)
+      attributes = {
+        last_inbound_at: [ @target.last_inbound_at, @source.last_inbound_at ].compact.max,
+        last_outbound_at: [ @target.last_outbound_at, @source.last_outbound_at ].compact.max,
+        last_message_at: [ @target.last_message_at, @source.last_message_at ].compact.max
+      }
+
+      # Fill in context the target never got, without overwriting a triage decision
+      # someone already made on it.
+      attributes[:event_id] = @source.event_id if @target.event_id.blank? && @source.event_id.present?
+      attributes[:assigned_to_id] = @source.assigned_to_id if @target.assigned_to_id.blank? && @source.assigned_to_id.present?
+      attributes[:twilio_to_number] = @source.twilio_to_number if @target.twilio_to_number.blank? && @source.twilio_to_number.present?
+
+      if @target.subject_type.blank? && @source.subject_type.present?
+        attributes[:subject_type] = @source.subject_type
+        attributes[:subject_id] = @source.subject_id
+      end
+
+      attributes.merge!(status: :open, closed_at: nil, closed_by_id: nil) if reopen
+
+      attributes
+    end
+
+    def record_merge_note(moved_messages)
+      return if @user.blank?
+
+      Note.create!(
+        ticket: @target,
+        event_id: @target.event_id,
+        author_user_id: @user.id,
+        note_type: "ops",
+        body: "Merged ticket #{short_id(@source)} into this ticket " \
+              "(#{ActionController::Base.helpers.pluralize(moved_messages, 'message')})."
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("[Support::MergeTickets] Couldn't record merge note: #{e.message}")
+    end
+
+    # Anyone already watching the target's thread needs the newly-arrived messages
+    # slotted into place, not just the people who reload the page.
+    def broadcast_target_thread
+      Turbo::StreamsChannel.broadcast_replace_to(
+        @target,
+        :messages,
+        target: "ticket_#{@target.id}_messages",
+        partial: "support/tickets/messages",
+        locals: { ticket: @target }
+      )
+    rescue => e
+      Rails.logger.warn("[Support::MergeTickets] Couldn't broadcast merged thread: #{e.class}: #{e.message}")
+    end
+
+    def short_id(ticket)
+      "##{ticket.id.first(8)}"
+    end
+  end
+end

--- a/app/services/support/process_incoming_signal_message.rb
+++ b/app/services/support/process_incoming_signal_message.rb
@@ -48,7 +48,7 @@ module Support
     private
 
     def find_or_create_ticket(phone:, signal_to:)
-      scope = Ticket.where(
+      scope = Ticket.unmerged.where(
         phone_number: phone,
         channel: "signal",
         status: "open"

--- a/app/services/support/process_incoming_twilio_message.rb
+++ b/app/services/support/process_incoming_twilio_message.rb
@@ -63,7 +63,7 @@ module Support
     def find_or_create_ticket(phone:, channel:, twilio_to:)
       twilio_to_normalized = twilio_to.to_s.sub(/\Awhatsapp:/, "")
 
-      scope = Ticket.where(
+      scope = Ticket.unmerged.where(
         phone_number: phone,
         channel: channel,
         status: "open"

--- a/app/services/support/send_ticket_message.rb
+++ b/app/services/support/send_ticket_message.rb
@@ -15,6 +15,10 @@ module Support
     end
 
     def call
+      if @ticket.merged?
+        raise DeliveryError, "This ticket was merged into ##{@ticket.merged_into_id.first(8)} — reply there instead."
+      end
+
       if @ticket.signal?
         send_via_signal
       else

--- a/app/toolboxes/tickets_toolbox.rb
+++ b/app/toolboxes/tickets_toolbox.rb
@@ -5,7 +5,7 @@ class TicketsToolbox < ApplicationToolbox
     param :limit, :integer, "Max results (default 30, max 100)", optional: true, default: 30
   end
   def index
-    scope = policy_scope(Ticket).recent_first.includes(:event, :assigned_to)
+    scope = policy_scope(Ticket).unmerged.recent_first.includes(:event, :assigned_to)
     scope = scope.where(status: params[:status]) if params[:status].present?
     scope = scope.where(assigned_to_id: current_user.id) if params[:assigned_to_me]
     limit = params[:limit].to_i.clamp(1, 100)
@@ -65,8 +65,31 @@ class TicketsToolbox < ApplicationToolbox
   def reopen
     @ticket = Ticket.find(params[:ticket_id])
     authorize! @ticket, :reopen?
+    halt error: "That ticket was merged into ##{@ticket.merged_into_id.first(8)} — work that one instead." if @ticket.merged?
     @ticket.reopen!
     render json: serialize_ticket(@ticket)
+  end
+
+  tool "Merge one ticket's thread into another. Both must be with the same phone number.",
+    access: :write, scope: "tickets:write" do
+    param :ticket_id, :string, "Ticket that survives and takes on the other thread"
+    param :source_ticket_id, :string, "Ticket to merge in — it closes and points at the surviving ticket"
+  end
+  def merge
+    @ticket = Ticket.find(params[:ticket_id])
+    source = Ticket.find(params[:source_ticket_id])
+    authorize! @ticket, :merge?
+    authorize! source, :merge?
+
+    begin
+      result = ::Support::MergeTickets.call(source: source, target: @ticket, user: current_user)
+    rescue ::Support::MergeTickets::MergeError => e
+      halt error: e.message
+    end
+
+    render json: serialize_ticket(result.target, full: true).merge(
+      merged: { from: source.id, messages_moved: result.moved_messages, reopened: result.reopened }
+    )
   end
 
   private
@@ -80,6 +103,7 @@ class TicketsToolbox < ApplicationToolbox
       event: t.event&.name,
       assigned_to: t.assigned_to&.display_name_or_fallback,
       last_message_at: t.last_message_at,
+      merged_into: t.merged_into_id,
       url: ticket_url(t)
     }
     return base unless full

--- a/app/views/support/tickets/_message.html.erb
+++ b/app/views/support/tickets/_message.html.erb
@@ -29,6 +29,12 @@
           <%= message.user.display_name_or_fallback %>
         </span>
       <% end %>
+      <% if message.merged_from_ticket_id.present? %>
+        <span class="text-xs font-mono <%= message.inbound? ? 'text-gray-400' : 'text-blue-200' %>"
+              title="Merged in from ticket #<%= message.merged_from_ticket_id[0..7] %>">
+          ⤵ #<%= message.merged_from_ticket_id[0..7] %>
+        </span>
+      <% end %>
       <span class="text-xs <%= message.inbound? ? 'text-gray-500' : 'text-blue-200' %>">
         <%= message.sent_at&.strftime("%H:%M") || message.created_at.strftime("%H:%M") %>
       </span>

--- a/app/views/support/tickets/_messages.html.erb
+++ b/app/views/support/tickets/_messages.html.erb
@@ -1,0 +1,5 @@
+<div class="flex-1 overflow-y-auto p-4 sm:p-6 space-y-4" id="ticket_<%= ticket.id %>_messages">
+  <% ticket.ticket_messages.order(created_at: :asc).each do |message| %>
+    <%= render "support/tickets/message", message: message %>
+  <% end %>
+</div>

--- a/app/views/support/tickets/show.html.erb
+++ b/app/views/support/tickets/show.html.erb
@@ -53,15 +53,19 @@
       </div>
     </div>
 
+    <% if @merged_sources.any? %>
+      <div class="flex-shrink-0 bg-blue-50 border-b border-blue-100 px-4 sm:px-6 py-2 text-xs text-blue-800">
+        Includes the thread<%= "s" if @merged_sources.many? %> from
+        <span class="font-mono"><%= @merged_sources.map { |merged| "##{merged.id.first(8)}" }.to_sentence %></span>,
+        merged in here.
+      </div>
+    <% end %>
+
     <!-- Messages -->
     <%= turbo_stream_from @ticket, :messages %>
     <%= turbo_stream_from "user_#{current_user.id}_notifications" %>
     <div id="user_notifications" class="hidden" data-controller="assigned-notification"></div>
-    <div class="flex-1 overflow-y-auto p-4 sm:p-6 space-y-4" id="ticket_<%= @ticket.id %>_messages">
-      <% @ticket.ticket_messages.order(created_at: :asc).each do |message| %>
-        <%= render "message", message: message %>
-      <% end %>
-    </div>
+    <%= render "messages", ticket: @ticket %>
 
     <!-- Reply form -->
     <% if @ticket.open? %>
@@ -219,20 +223,52 @@
           <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">Message History</h3>
           <div class="space-y-2">
             <% @previous_tickets.each do |ticket| %>
-              <%= link_to support_ticket_path(ticket), class: "block p-3 rounded-lg border hover:bg-gray-50 transition-colors #{ticket.open? ? 'border-green-200 bg-green-50' : 'border-gray-200 bg-gray-50'}" do %>
-                <div class="flex items-center justify-between mb-1">
-                  <span class="text-xs font-mono text-gray-500">#<%= ticket.id[0..7] %></span>
-                  <% if ticket.open? %>
-                    <span class="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">Open</span>
-                  <% else %>
-                    <span class="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">Closed</span>
+              <div class="p-3 rounded-lg border <%= ticket.open? ? "border-green-200 bg-green-50" : "border-gray-200 bg-gray-50" %>">
+                <%= link_to support_ticket_path(ticket), class: "block hover:opacity-75 transition-opacity" do %>
+                  <div class="flex items-center justify-between mb-1">
+                    <span class="text-xs font-mono text-gray-500">#<%= ticket.id[0..7] %></span>
+                    <% if ticket.open? %>
+                      <span class="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">Open</span>
+                    <% else %>
+                      <span class="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">Closed</span>
+                    <% end %>
+                  </div>
+                  <% if ticket.ticket_messages.any? %>
+                    <p class="text-sm text-gray-700 line-clamp-2"><%= ticket.ticket_messages.order(created_at: :desc).first&.body&.truncate(80) %></p>
                   <% end %>
-                </div>
-                <% if ticket.ticket_messages.any? %>
-                  <p class="text-sm text-gray-700 line-clamp-2"><%= ticket.ticket_messages.order(created_at: :desc).first&.body&.truncate(80) %></p>
+                  <p class="text-xs text-gray-500 mt-1"><%= time_ago_in_words(ticket.last_message_at || ticket.created_at) %> ago</p>
                 <% end %>
-                <p class="text-xs text-gray-500 mt-1"><%= time_ago_in_words(ticket.last_message_at || ticket.created_at) %> ago</p>
-              <% end %>
+                <%= button_to merge_support_ticket_path(@ticket, source_id: ticket.id),
+                      method: :patch,
+                      form: { data: { turbo_confirm: "Move ##{ticket.id[0..7]}'s messages into this ticket? That ticket will be closed and point here." } },
+                      class: "mt-2 w-full flex items-center justify-center gap-1 bg-white hover:bg-blue-50 border border-blue-200 text-blue-700 hover:text-blue-800 rounded-md py-1.5 text-xs font-medium" do %>
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 4v9a3 3 0 003 3h7m0 0l-3-3m3 3l-3 3M17 4v3"/></svg>
+                  Merge into this ticket
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <!-- Merged Tickets -->
+      <% if @merged_sources.any? %>
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wider mb-3">Merged In</h3>
+          <div class="space-y-2">
+            <% @merged_sources.each do |merged| %>
+              <div class="p-3 rounded-lg border border-blue-200 bg-blue-50 text-xs">
+                <div class="flex items-center justify-between">
+                  <span class="font-mono text-blue-900">#<%= merged.id[0..7] %></span>
+                  <span class="bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded">Merged</span>
+                </div>
+                <p class="text-blue-700 mt-1">
+                  <%= merged.merged_at&.strftime("%b %d, %Y %H:%M") || "—" %>
+                  <% if merged.merged_by.present? %>
+                    by <%= merged.merged_by.display_name_or_fallback %>
+                  <% end %>
+                </p>
+              </div>
             <% end %>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
         patch :assign
         patch :set_event
         patch :set_subject
+        patch :merge
       end
 
       resources :messages, only: :create, module: :tickets

--- a/db/migrate/20260825160000_add_ticket_merging.rb
+++ b/db/migrate/20260825160000_add_ticket_merging.rb
@@ -1,0 +1,9 @@
+class AddTicketMerging < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :tickets, :merged_into, foreign_key: { to_table: :tickets }, type: :uuid
+    add_reference :tickets, :merged_by, foreign_key: { to_table: :users }, type: :uuid
+    add_column :tickets, :merged_at, :datetime
+
+    add_reference :ticket_messages, :merged_from_ticket, foreign_key: { to_table: :tickets }, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1161,6 +1161,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
     t.datetime "created_at", null: false
     t.string "direction", null: false
     t.text "error_message"
+    t.uuid "merged_from_ticket_id"
     t.jsonb "raw_payload", default: {}
     t.datetime "sent_at"
     t.string "signal_message_sid"
@@ -1170,6 +1171,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
     t.datetime "updated_at", null: false
     t.uuid "user_id"
     t.index ["direction"], name: "index_ticket_messages_on_direction"
+    t.index ["merged_from_ticket_id"], name: "index_ticket_messages_on_merged_from_ticket_id"
     t.index ["signal_message_sid"], name: "index_ticket_messages_on_signal_message_sid", unique: true, where: "(signal_message_sid IS NOT NULL)"
     t.index ["ticket_id"], name: "index_ticket_messages_on_ticket_id"
     t.index ["twilio_message_sid"], name: "index_ticket_messages_on_twilio_message_sid", unique: true, where: "(twilio_message_sid IS NOT NULL)"
@@ -1187,6 +1189,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
     t.datetime "last_inbound_at"
     t.datetime "last_message_at"
     t.datetime "last_outbound_at"
+    t.datetime "merged_at"
+    t.uuid "merged_by_id"
+    t.uuid "merged_into_id"
     t.string "phone_number", null: false
     t.string "status", default: "open", null: false
     t.uuid "subject_id"
@@ -1198,6 +1203,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
     t.index ["closed_by_id"], name: "index_tickets_on_closed_by_id"
     t.index ["created_by_id"], name: "index_tickets_on_created_by_id"
     t.index ["event_id"], name: "index_tickets_on_event_id"
+    t.index ["merged_by_id"], name: "index_tickets_on_merged_by_id"
+    t.index ["merged_into_id"], name: "index_tickets_on_merged_into_id"
     t.index ["phone_number"], name: "index_tickets_on_phone_number"
     t.index ["status"], name: "index_tickets_on_status"
     t.index ["subject_type", "subject_id"], name: "index_tickets_on_subject_type_and_subject_id"
@@ -1449,11 +1456,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_135022) do
   add_foreign_key "slack_blasts", "events"
   add_foreign_key "slack_blasts", "users", column: "sent_by_user_id"
   add_foreign_key "ticket_messages", "tickets"
+  add_foreign_key "ticket_messages", "tickets", column: "merged_from_ticket_id"
   add_foreign_key "ticket_messages", "users"
   add_foreign_key "tickets", "events"
+  add_foreign_key "tickets", "tickets", column: "merged_into_id"
   add_foreign_key "tickets", "users", column: "assigned_to_id"
   add_foreign_key "tickets", "users", column: "closed_by_id"
   add_foreign_key "tickets", "users", column: "created_by_id"
+  add_foreign_key "tickets", "users", column: "merged_by_id"
   add_foreign_key "toolchest_oauth_access_grants", "toolchest_oauth_applications", column: "application_id"
   add_foreign_key "toolchest_oauth_access_tokens", "toolchest_oauth_applications", column: "application_id"
   add_foreign_key "travel_legs", "travels"

--- a/spec/requests/support/tickets_spec.rb
+++ b/spec/requests/support/tickets_spec.rb
@@ -152,6 +152,74 @@ RSpec.describe "Support::Tickets", type: :request do
     end
   end
 
+  describe "PATCH merge" do
+    def add_message(ticket, body)
+      TicketMessage.create!(ticket: ticket, direction: "inbound", channel: "whatsapp", body: body)
+    end
+
+    it "folds another ticket with the same number into the one being viewed" do
+      older = make_ticket(event: live_event, phone: live_ticket.phone_number)
+      older.close!(user: global_admin)
+      add_message(older, "Original question")
+
+      sign_in event_ops
+      patch merge_support_ticket_path(live_ticket), params: { source_id: older.id }
+
+      expect(response).to redirect_to(support_ticket_path(live_ticket))
+      expect(older.reload.merged_into).to eq(live_ticket)
+      expect(live_ticket.ticket_messages.map(&:body)).to include("Original question")
+    end
+
+    it "reopens the surviving ticket when the ticket merged in is open" do
+      older = make_ticket(event: live_event, phone: live_ticket.phone_number)
+      live_ticket.close!(user: global_admin)
+
+      sign_in event_ops
+      patch merge_support_ticket_path(live_ticket), params: { source_id: older.id }
+
+      expect(live_ticket.reload).to be_open
+    end
+
+    it "rejects tickets with a different phone number" do
+      sign_in global_admin
+      patch merge_support_ticket_path(live_ticket), params: { source_id: pending_ticket.id }
+
+      expect(flash[:alert]).to be_present
+      expect(pending_ticket.reload.merged_into).to be_nil
+    end
+
+    it "denies merging in a ticket the user cannot see" do
+      hidden = make_ticket(event: other_event, phone: live_ticket.phone_number)
+
+      sign_in event_ops
+      patch merge_support_ticket_path(live_ticket), params: { source_id: hidden.id }
+
+      expect(response).to have_http_status(:redirect)
+      expect(hidden.reload.merged_into).to be_nil
+    end
+
+    it "sends a merged ticket's page to the ticket that absorbed it" do
+      older = make_ticket(event: live_event, phone: live_ticket.phone_number)
+
+      sign_in event_ops
+      patch merge_support_ticket_path(live_ticket), params: { source_id: older.id }
+      get support_ticket_path(older)
+
+      expect(response).to redirect_to(support_ticket_path(live_ticket))
+    end
+
+    it "keeps merged tickets out of the inbox" do
+      older = make_ticket(event: live_event, phone: live_ticket.phone_number)
+
+      sign_in event_ops
+      patch merge_support_ticket_path(live_ticket), params: { source_id: older.id }
+      get support_tickets_path
+
+      expect(response.body).to include("ticket_#{live_ticket.id}")
+      expect(response.body).not_to include("ticket_#{older.id}")
+    end
+  end
+
   describe "POST notes" do
     it "lets active event staff add a note to a pending ticket" do
       sign_in event_ops

--- a/spec/services/support/merge_tickets_spec.rb
+++ b/spec/services/support/merge_tickets_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+
+RSpec.describe Support::MergeTickets do
+  let(:user) { User.create!(email: "merger@example.com", name: "Support Staffer") }
+  let(:phone) { "+14155559876" }
+
+  def make_ticket(status: "open", **attrs)
+    Ticket.create!(phone_number: phone, channel: "sms", status: status, **attrs)
+  end
+
+  def add_message(ticket, body, direction: "inbound")
+    TicketMessage.create!(ticket: ticket, direction: direction, channel: "sms", body: body)
+  end
+
+  def merge!(source:, target:)
+    described_class.call(source: source, target: target, user: user)
+  end
+
+  it "moves the source's messages onto the target, stamped with where they came from" do
+    target = make_ticket(status: "closed", closed_at: 1.day.ago)
+    source = make_ticket
+    add_message(target, "First question")
+    moved = add_message(source, "Another question")
+
+    result = merge!(source: source, target: target)
+
+    expect(result.moved_messages).to eq(1)
+    expect(target.ticket_messages.order(:created_at).map(&:body)).to eq([ "First question", "Another question" ])
+    expect(source.ticket_messages).to be_empty
+    expect(moved.reload.merged_from_ticket_id).to eq(source.id)
+  end
+
+  it "closes the source and points it at the target" do
+    target = make_ticket
+    source = make_ticket
+
+    merge!(source: source, target: target)
+
+    expect(source.reload).to be_closed
+    expect(source.merged_into).to eq(target)
+    expect(source.merged_by).to eq(user)
+    expect(source.merged_at).to be_present
+    expect(target.reload.merged_tickets).to include(source)
+  end
+
+  it "reopens a closed target when the ticket merged in is still open" do
+    target = make_ticket(status: "closed", closed_at: 2.days.ago, closed_by: user)
+    source = make_ticket
+
+    result = merge!(source: source, target: target)
+
+    expect(result.reopened).to be(true)
+    expect(target.reload).to be_open
+    expect(target.closed_at).to be_nil
+    expect(target.closed_by).to be_nil
+  end
+
+  it "leaves a closed target closed when the ticket merged in is also closed" do
+    target = make_ticket(status: "closed", closed_at: 2.days.ago)
+    source = make_ticket(status: "closed", closed_at: 1.day.ago)
+
+    result = merge!(source: source, target: target)
+
+    expect(result.reopened).to be(false)
+    expect(target.reload).to be_closed
+  end
+
+  it "moves the source's notes across" do
+    target = make_ticket
+    source = make_ticket
+    source.notes.create!(author_user_id: user.id, body: "Called them back", note_type: "ops")
+
+    result = merge!(source: source, target: target)
+
+    expect(result.moved_notes).to eq(1)
+    expect(target.reload.notes.map(&:body)).to include("Called them back")
+    expect(source.reload.notes).to be_empty
+  end
+
+  it "records the merge as a note on the target" do
+    target = make_ticket
+    source = make_ticket
+    add_message(source, "Hello again")
+
+    merge!(source: source, target: target)
+
+    expect(target.reload.notes.map(&:body)).to include(a_string_matching(/Merged ticket ##{source.id[0..7]}/))
+  end
+
+  it "fills in context the target is missing without overwriting its own" do
+    event = create(:event)
+    other_event = create(:event)
+    target = make_ticket
+    source = make_ticket(event: event, assigned_to: user)
+
+    merge!(source: source, target: target)
+    expect(target.reload.event).to eq(event)
+    expect(target.assigned_to).to eq(user)
+
+    second_source = make_ticket(event: other_event)
+    merge!(source: second_source, target: target)
+    expect(target.reload.event).to eq(event)
+  end
+
+  it "carries the latest activity timestamps onto the target" do
+    target = make_ticket(status: "closed", last_message_at: 3.days.ago, last_inbound_at: 3.days.ago)
+    source = make_ticket(last_message_at: 1.hour.ago, last_inbound_at: 1.hour.ago)
+
+    merge!(source: source, target: target)
+
+    expect(target.reload.last_message_at).to be_within(1.second).of(source.last_message_at)
+  end
+
+  it "refuses to merge a ticket into itself" do
+    ticket = make_ticket
+
+    expect { merge!(source: ticket, target: ticket) }.to raise_error(described_class::MergeError, /itself/)
+  end
+
+  it "refuses to merge tickets with different phone numbers" do
+    target = make_ticket
+    source = Ticket.create!(phone_number: "+14155550000", channel: "sms", status: "open")
+
+    expect { merge!(source: source, target: target) }.to raise_error(described_class::MergeError, /same phone number/)
+  end
+
+  it "refuses to merge a ticket that was already merged elsewhere" do
+    target = make_ticket
+    other = make_ticket
+    source = make_ticket
+    merge!(source: source, target: other)
+
+    expect { merge!(source: source, target: target) }.to raise_error(described_class::MergeError, /already merged/)
+  end
+
+  it "points at the surviving ticket when the target has itself been merged away" do
+    survivor = make_ticket
+    target = make_ticket
+    source = make_ticket
+    merge!(source: target, target: survivor)
+
+    expect { merge!(source: source, target: target) }
+      .to raise_error(described_class::MergeError, /merge into that ticket instead/)
+  end
+
+  describe "after merging" do
+    it "keeps the merged ticket out of the inbox and out of inbound matching" do
+      target = make_ticket(status: "closed")
+      source = make_ticket
+      merge!(source: source, target: target)
+
+      expect(Ticket.unmerged).not_to include(source)
+
+      Support::ProcessIncomingTwilioMessage.call(
+        "From" => phone, "To" => "+18005550100", "Body" => "Still there?", "MessageSid" => "SM999", "NumMedia" => "0"
+      )
+
+      expect(source.reload.ticket_messages).to be_empty
+    end
+
+    it "refuses to send a reply on the merged ticket" do
+      target = make_ticket
+      source = make_ticket
+      merge!(source: source, target: target)
+
+      expect { Support::SendTicketMessage.call(ticket: source.reload, body: "Hi", user: user) }
+        .to raise_error(Support::SendTicketMessage::DeliveryError, /merged into/)
+    end
+
+    it "resolves the chain of merges to the ticket holding the thread" do
+      survivor = make_ticket
+      middle = make_ticket
+      source = make_ticket
+
+      merge!(source: source, target: middle)
+      merge!(source: middle, target: survivor)
+
+      expect(source.reload.merge_root).to eq(survivor)
+    end
+  end
+end


### PR DESCRIPTION
A contact who replies to a closed ticket lands in a brand-new one, so a single conversation ends up split across threads. This adds merging: fold one ticket's messages and notes into another with the same phone number.

## How it works

Open the ticket you want to keep, and every other ticket with that phone number in the sidebar's **Message History** gets a "Merge into this ticket" button (behind a confirm dialog).

`Support::MergeTickets` then:

- moves the messages onto the target, stamped with `merged_from_ticket_id` so the thread shows a small `⤵ #abc12345` marker on borrowed messages — they interleave chronologically
- moves the notes across, and writes an ops note recording the merge
- **reopens a closed target when the ticket merged in is open**, which is the case this is for: closed ticket, contact comes back, conversation carries on
- backfills event / subject / assignee / from-number onto the target only where it had none, and carries over the newest activity timestamps
- refuses self-merges, already-merged tickets, and mismatched phone numbers

The merged ticket stays as a tombstone: its URL redirects to whatever absorbed it, so old links, notifications and audit history still resolve. It drops out of the inbox and out of inbound-message matching, and it can't be replied to or reopened. Chains resolve through `merge_root`, so A→B→C sends A's URL to C.

Also wired up: `merge?` on `TicketPolicy` (authorized on *both* tickets), a matching `tickets_merge` MCP tool, `ticket_merge` in the `AuditLog` action enum, and a "Merged In" panel on the survivor.

## Also in here

**Dark themes were painting checkboxes invisible.** themes.css set `background-color: var(--bg-elev)` on every `input` in the eight non-light themes, and painting a background over a native checkbox makes Chromium skip drawing the control — an unchecked box was a dark square on a dark surface. That hit the new bulk-select column on the support inbox, the guardian portal consents and custom documents, and the onboarding health/accommodation/travel steps. Checkboxes and radios are now excluded; each dark theme already declares `color-scheme: dark`, so the native controls theme themselves and the checked state picks up brand red from `accent-color`.

## Testing

- 15 new service specs and 6 new request specs; the support + toolbox suites pass (113 examples)
- rubocop clean
- browser pass in light and dark, desktop and mobile, including a real merge and the bulk-select checkboxes

## Not included

- **No undo.** A mis-merge is recoverable from the console via `merged_from_ticket_id` (and paper_trail), but there is no UI for it.
- **No merging across phone numbers**, so two numbers for the same person can't be combined — a merge across contacts would corrupt the thread.
- The checkbox fix was verified on the support inbox only; the other `portal-check` pages share the mechanism but weren't eyeballed.