### PR TITLE
Show the WhatsApp reply window in the support composer

### DIFF
--- a/app/javascript/controllers/whatsapp_window_controller.js
+++ b/app/javascript/controllers/whatsapp_window_controller.js
@@ -1,0 +1,61 @@
+import { Controller } from "@hotwired/stimulus"
+
+// WhatsApp only accepts freeform replies for 24 hours after the contact's last
+// inbound message; outside that window Meta rejects the send (Twilio 63016).
+// The server renders the state on page load — this keeps it honest while the
+// page stays open, since the window can lapse and a new inbound reopens it.
+export default class extends Controller {
+  static targets = ["closed", "open", "countdown", "input", "submit"]
+  static values = { expiresAt: String }
+
+  connect() {
+    this.render()
+    this.timer = setInterval(() => this.render(), 30000)
+  }
+
+  disconnect() {
+    clearInterval(this.timer)
+  }
+
+  // Announced by whatsapp-window-ping when an inbound message shows up.
+  inboundReceived(event) {
+    const receivedAt = new Date(event.detail.at)
+    if (isNaN(receivedAt)) return
+
+    const expiresAt = new Date(receivedAt.getTime() + 24 * 60 * 60 * 1000)
+    if (expiresAt <= this.expiresAt()) return
+
+    this.expiresAtValue = expiresAt.toISOString()
+    this.render()
+  }
+
+  render() {
+    const expiresAt = this.expiresAt()
+    const open = expiresAt !== null && expiresAt > new Date()
+
+    this.closedTargets.forEach((el) => el.classList.toggle("hidden", open))
+    this.openTargets.forEach((el) => el.classList.toggle("hidden", !open))
+    this.inputTargets.forEach((el) => { el.disabled = !open })
+    this.submitTargets.forEach((el) => { el.disabled = !open })
+
+    if (open) {
+      this.countdownTargets.forEach((el) => { el.textContent = this.remaining(expiresAt) })
+    }
+  }
+
+  expiresAt() {
+    if (!this.expiresAtValue) return null
+
+    const parsed = new Date(this.expiresAtValue)
+    return isNaN(parsed) ? null : parsed
+  }
+
+  remaining(expiresAt) {
+    const minutes = Math.max(0, Math.round((expiresAt - new Date()) / 60000))
+    if (minutes < 60) return `${minutes} min`
+
+    const hours = Math.floor(minutes / 60)
+    const rest = minutes % 60
+    return rest === 0 ? `${hours} hr` : `${hours} hr ${rest} min`
+  }
+}

--- a/app/javascript/controllers/whatsapp_window_ping_controller.js
+++ b/app/javascript/controllers/whatsapp_window_ping_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Inbound WhatsApp messages reopen the 24-hour freeform reply window. They
+// arrive over Turbo Streams, so each one announces itself and the composer's
+// whatsapp-window controller re-enables the form without a page reload.
+export default class extends Controller {
+  static values = { at: String }
+
+  connect() {
+    window.dispatchEvent(
+      new CustomEvent("whatsapp:inbound", { detail: { at: this.atValue } })
+    )
+  }
+}

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -71,6 +71,29 @@ class Ticket < ApplicationRecord
     update!(status: :open, closed_at: nil, closed_by: nil)
   end
 
+  # WhatsApp only accepts freeform outbound messages within 24 hours of the
+  # contact's last inbound message. After that Meta rejects anything that
+  # isn't a pre-approved template, and Twilio reports error 63016.
+  WHATSAPP_FREEFORM_WINDOW = 24.hours
+
+  def whatsapp_window_expires_at
+    return nil unless whatsapp?
+    return nil if last_inbound_at.blank?
+
+    last_inbound_at + WHATSAPP_FREEFORM_WINDOW
+  end
+
+  def whatsapp_window_open?
+    expires_at = whatsapp_window_expires_at
+
+    expires_at.present? && expires_at.future?
+  end
+
+  # True when a plain text reply would be rejected by WhatsApp.
+  def freeform_reply_blocked?
+    whatsapp? && !whatsapp_window_open?
+  end
+
   def matching_participants
     Participant.where(phone: phone_number).includes(:participant_events, :events)
   end

--- a/app/services/support/send_ticket_message.rb
+++ b/app/services/support/send_ticket_message.rb
@@ -61,6 +61,12 @@ module Support
     end
 
     def send_via_twilio
+      if @ticket.freeform_reply_blocked?
+        raise DeliveryError,
+              "WhatsApp only accepts freeform replies for 24 hours after the contact's last message, " \
+              "and that window has closed. Ask them to message us again, or reach them by SMS or email."
+      end
+
       client = Twilio::REST::Client.new(
         Rails.application.credentials.dig(:twilio, :account_sid) || ENV.fetch("TWILIO_ACCOUNT_SID"),
         Rails.application.credentials.dig(:twilio, :auth_token) || ENV.fetch("TWILIO_AUTH_TOKEN")

--- a/app/views/support/tickets/_message.html.erb
+++ b/app/views/support/tickets/_message.html.erb
@@ -1,4 +1,8 @@
-<div id="<%= dom_id(message) %>" class="flex items-end gap-2 <%= message.inbound? ? 'justify-start' : 'justify-end' %>">
+<div id="<%= dom_id(message) %>" class="flex items-end gap-2 <%= message.inbound? ? 'justify-start' : 'justify-end' %>"
+  <% if message.inbound? && message.whatsapp? %>
+    data-controller="whatsapp-window-ping"
+    data-whatsapp-window-ping-at-value="<%= (message.sent_at || message.created_at).iso8601 %>"
+  <% end %>>
   <% if message.outbound? && message.user.present? %>
     <div class="order-2 w-8 h-8 rounded-full bg-gray-700 flex items-center justify-center text-white text-xs font-medium flex-shrink-0" title="<%= message.user.display_name_or_fallback %>">
       <%= message.user.display_name_or_fallback.split.map(&:first).join.upcase[0..1] %>

--- a/app/views/support/tickets/show.html.erb
+++ b/app/views/support/tickets/show.html.erb
@@ -65,10 +65,31 @@
 
     <!-- Reply form -->
     <% if @ticket.open? %>
-      <div class="flex-shrink-0 bg-white border-t border-gray-200 p-3 sm:p-4 pb-16 sm:pb-4">
+      <% window_expires_at = @ticket.whatsapp_window_expires_at %>
+      <% window_open = @ticket.whatsapp_window_open? %>
+      <div class="flex-shrink-0 bg-white border-t border-gray-200 p-3 sm:p-4 pb-16 sm:pb-4"
+           <% if @ticket.whatsapp? %>
+             data-controller="whatsapp-window"
+             data-whatsapp-window-expires-at-value="<%= window_expires_at&.iso8601 %>"
+             data-action="whatsapp:inbound@window->whatsapp-window#inboundReceived"
+           <% end %>>
+        <% if @ticket.whatsapp? %>
+          <div data-whatsapp-window-target="closed" class="<%= "hidden" if window_open %> mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+            <p class="font-medium">WhatsApp reply window closed</p>
+            <p class="mt-0.5">
+              WhatsApp only allows freeform replies within 24 hours of the contact's last message.
+              Sending now fails with error 63016 — ask them to message us again, or reach them by SMS or email.
+            </p>
+          </div>
+          <p data-whatsapp-window-target="open" class="<%= "hidden" unless window_open %> mb-2 text-xs text-gray-500">
+            Freeform replies accepted for another
+            <span data-whatsapp-window-target="countdown"><%= distance_of_time_in_words(Time.current, window_expires_at) if window_expires_at.present? %></span>.
+          </p>
+        <% end %>
         <%= form_with url: support_ticket_messages_path(@ticket), class: "flex gap-2 sm:gap-3" do |f| %>
-          <%= text_area_tag "ticket_message[body]", nil, rows: 2, class: "flex-1 border border-gray-300 rounded-lg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none", placeholder: "Type your reply..." %>
-          <%= f.submit "Send", class: "bg-blue-600 text-white px-4 sm:px-6 py-2 rounded-lg hover:bg-blue-700 font-medium cursor-pointer self-end" %>
+          <%= text_area_tag "ticket_message[body]", nil, rows: 2, disabled: @ticket.freeform_reply_blocked?, data: { whatsapp_window_target: "input" }, class: "flex-1 border border-gray-300 rounded-lg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none disabled:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed", placeholder: "Type your reply..." %>
+          <%# a <button> rather than f.submit: themes.css paints bare inputs in every dark theme, which would swallow the disabled styling %>
+          <%= f.button "Send", name: nil, disabled: @ticket.freeform_reply_blocked?, data: { whatsapp_window_target: "submit" }, class: "bg-blue-600 hover:bg-blue-700 text-[#ffffff] px-4 sm:px-6 py-2 rounded-lg font-medium cursor-pointer self-end transition-colors disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed disabled:hover:bg-gray-300" %>
         <% end %>
       </div>
     <% end %>

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Ticket do
+  describe "WhatsApp freeform reply window" do
+    it "stays open for 24 hours after the last inbound message" do
+      ticket = Ticket.create!(
+        phone_number: "+14155551234",
+        channel: "whatsapp",
+        status: "open",
+        last_inbound_at: 3.hours.ago
+      )
+
+      expect(ticket).to be_whatsapp_window_open
+      expect(ticket).not_to be_freeform_reply_blocked
+      expect(ticket.whatsapp_window_expires_at).to be_within(1.second).of(ticket.last_inbound_at + 24.hours)
+    end
+
+    it "closes once the last inbound message is more than 24 hours old" do
+      ticket = Ticket.create!(
+        phone_number: "+14155551234",
+        channel: "whatsapp",
+        status: "open",
+        last_inbound_at: 25.hours.ago
+      )
+
+      expect(ticket).not_to be_whatsapp_window_open
+      expect(ticket).to be_freeform_reply_blocked
+    end
+
+    it "treats a ticket with no inbound message as closed" do
+      ticket = Ticket.create!(phone_number: "+14155551234", channel: "whatsapp", status: "open")
+
+      expect(ticket.whatsapp_window_expires_at).to be_nil
+      expect(ticket).to be_freeform_reply_blocked
+    end
+
+    it "does not apply to SMS or Signal tickets" do
+      sms = Ticket.create!(phone_number: "+14155551234", channel: "sms", status: "open", last_inbound_at: 3.days.ago)
+      signal = Ticket.create!(phone_number: "+14155555678", channel: "signal", status: "open", last_inbound_at: 3.days.ago)
+
+      expect(sms.whatsapp_window_expires_at).to be_nil
+      expect(sms).not_to be_freeform_reply_blocked
+      expect(signal).not_to be_freeform_reply_blocked
+    end
+  end
+end

--- a/spec/requests/support/tickets_spec.rb
+++ b/spec/requests/support/tickets_spec.rb
@@ -98,6 +98,35 @@ RSpec.describe "Support::Tickets", type: :request do
     end
   end
 
+  describe "GET show WhatsApp reply window" do
+    it "warns and disables the composer when the 24-hour window has closed" do
+      live_ticket.update!(last_inbound_at: 30.hours.ago)
+      sign_in global_admin
+      get support_ticket_path(live_ticket)
+
+      expect(response.body).to include("WhatsApp reply window closed")
+      expect(response.body).to include("disabled=\"disabled\"")
+    end
+
+    it "shows the remaining time and leaves the composer usable inside the window" do
+      live_ticket.update!(last_inbound_at: 2.hours.ago)
+      sign_in global_admin
+      get support_ticket_path(live_ticket)
+
+      expect(response.body).to include("Freeform replies accepted for another")
+      expect(response.body).not_to include("disabled=\"disabled\"")
+    end
+
+    it "does not mention the window on SMS tickets" do
+      sms_ticket = Ticket.create!(channel: "sms", phone_number: "+15550009999", status: "open", event: live_event, last_inbound_at: 5.days.ago)
+      sign_in global_admin
+      get support_ticket_path(sms_ticket)
+
+      expect(response.body).not_to include("WhatsApp reply window closed")
+      expect(response.body).not_to include("disabled=\"disabled\"")
+    end
+  end
+
   describe "GET index filters" do
     let!(:participant) do
       Participant.create!(legal_first_name: "Ada", legal_last_name: "Lovelace", email: "ada@example.com", phone: "+15550009999")

--- a/spec/services/support/send_ticket_message_spec.rb
+++ b/spec/services/support/send_ticket_message_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Support::SendTicketMessage do
+  let(:user) { User.create!(email: "agent@example.com", name: "Agent") }
+
+  describe "WhatsApp freeform reply window" do
+    let(:twilio_message) { double("Twilio message", sid: "SM999", status: "queued") }
+    let(:twilio_messages) { double("Twilio messages") }
+
+    before do
+      allow(Rails.application.credentials).to receive(:dig).and_call_original
+      allow(Rails.application.credentials).to receive(:dig).with(:twilio, :account_sid).and_return("AC123")
+      allow(Rails.application.credentials).to receive(:dig).with(:twilio, :auth_token).and_return("token")
+      allow(twilio_messages).to receive(:create).and_return(twilio_message)
+      allow(Twilio::REST::Client).to receive(:new).and_return(double("Twilio client", messages: twilio_messages))
+    end
+
+    it "refuses to send when the window has closed, without calling Twilio" do
+      ticket = Ticket.create!(
+        phone_number: "+14155551234",
+        channel: "whatsapp",
+        status: "open",
+        last_inbound_at: 25.hours.ago
+      )
+
+      expect {
+        described_class.call(ticket: ticket, body: "Hi there", user: user)
+      }.to raise_error(described_class::DeliveryError, /24 hours/)
+
+      expect(twilio_messages).not_to have_received(:create)
+      expect(ticket.ticket_messages).to be_empty
+    end
+
+    it "sends when the contact messaged us within the last 24 hours" do
+      ticket = Ticket.create!(
+        phone_number: "+14155551234",
+        channel: "whatsapp",
+        status: "open",
+        last_inbound_at: 2.hours.ago
+      )
+
+      message = described_class.call(ticket: ticket, body: "Hi there", user: user)
+
+      expect(message.twilio_message_sid).to eq("SM999")
+      expect(twilio_messages).to have_received(:create).with(hash_including(to: "whatsapp:+14155551234"))
+    end
+
+    it "does not gate SMS tickets on the window" do
+      ticket = Ticket.create!(
+        phone_number: "+14155551234",
+        channel: "sms",
+        status: "open",
+        last_inbound_at: 5.days.ago
+      )
+
+      expect {
+        described_class.call(ticket: ticket, body: "Hi there", user: user)
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Why

WhatsApp only accepts freeform messages within **24 hours of the contact's last inbound message**. Outside that window Meta rejects the send and Twilio returns error **63016** — and because Twilio's status callback sends `ErrorCode` with an empty `ErrorMessage`, the failure showed up in the chat history as a bare `63016:` under the bubble. Agents had no way to know a thread had gone cold until the send failed.

Worth knowing: the window is opened and reset *only* by inbound messages. Our own replies never extend it, so an instant auto-reply always succeeds but buys no extra time.

## What changed

- `Ticket#whatsapp_window_expires_at` / `#whatsapp_window_open?` / `#freeform_reply_blocked?` — the 24-hour rule in one place, SMS and Signal unaffected.
- The support composer now shows which state a WhatsApp ticket is in: a countdown ("Freeform replies accepted for another 22 hr 29 min") while it's open, an amber banner naming error 63016 plus a disabled textarea and send button once it's closed.
- State is rendered server-side and kept honest client-side by `whatsapp_window_controller.js`: a page left open sees the window lapse, and `whatsapp_window_ping_controller.js` rides in with each inbound message over Turbo Streams so a customer replying re-enables the form with no reload.
- `Support::SendTicketMessage` refuses blocked sends before calling Twilio, so a stale page gets a readable `DeliveryError` in the existing error banner instead of `63016:`.

Sending via a pre-approved Meta/Twilio content template is still unsupported — this PR makes the limit visible, it doesn't lift it. Lifting it means an approved template plus `content_sid`/`content_variables` in `SendTicketMessage`.

One incidental change: the Send control moved from `f.submit` to `f.button`, because `themes.css` paints bare `<input>` in every dark theme and would have swallowed the disabled styling.

## Verification

- New specs: model window helpers, the service guard (asserts Twilio is never called), and request specs for both composer states + an SMS control. 61 examples green across `spec/models/ticket_spec.rb`, `spec/services/support`, `spec/requests/support`; rubocop clean over `app` + `spec`.
- Browser pass at desktop and mobile widths in light and dark themes.
- Drove the live reopen for real: loaded a closed-window ticket, POSTed an inbound `/twilio/incoming` webhook, and watched the banner disappear and Send re-enable without a reload.
- Forced a submit past the disabled button and confirmed the guard renders the readable error and creates no message.