### PR TITLE
Complete minors whose guardian finished before they submitted

### DIFF
--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -293,7 +293,13 @@ class OnboardingController < ApplicationController
 
       @participant_event.update!(status: :awaiting_guardian)
 
-      if current_event.guardian_invites_locked? || Setting.waiver_sending_paused?
+      # The guardian can finish everything — waiver and portal — before the
+      # participant hits submit. Every other completion hook already ran and
+      # bailed on the missing code of conduct, so accepting it here can be the
+      # last piece; nothing else would re-check.
+      if @participant_event.mark_complete_if_eligible!
+        redirect_to dashboard_path, notice: completion_notice("Registration submitted — you're all set!")
+      elsif current_event.guardian_invites_locked? || Setting.waiver_sending_paused?
         redirect_to dashboard_path, notice: completion_notice("Registration submitted! We'll notify you when waivers are ready to sign.")
       elsif waiver_participant_portion_signed?
         # Already signed during the documents step

--- a/lib/tasks/repair_stuck_completions.rake
+++ b/lib/tasks/repair_stuck_completions.rake
@@ -1,0 +1,55 @@
+namespace :stuck_completions do
+  desc <<~DESC
+    Complete participants whose db status never caught up with reality.
+
+    `OnboardingController#complete` used to set minors to `awaiting_guardian`
+    and stop there. If the guardian signed the waiver and finished the portal
+    *before* the participant hit submit, every `mark_complete_if_eligible!`
+    hook had already run and bailed on the missing code of conduct — and the
+    submit itself never re-checked. Those rows sit at `awaiting_guardian`
+    forever: `display_status` says "Complete", but the dashboard hides the
+    boarding pass / QR because it gates on the raw `complete?` enum.
+
+    Fixed at the source in `OnboardingController#complete`; this repairs the
+    rows already stuck. Completion here is a pure status flip — ParticipantEvent
+    has no status callbacks, so no mail or webhook fires.
+
+    ENV:
+      EVENT=<slug>   only this event (default: every event)
+      ALL_EVENTS=1   include events that have already ended (default: skip)
+      APPLY=1        actually write (default: dry run)
+  DESC
+  task repair: :environment do
+    apply = ENV["APPLY"] == "1"
+
+    scope = ParticipantEvent
+      .where(status: [ :invited, :in_progress, :awaiting_guardian ])
+      .includes(:event, :participant, :consents, :guardian_participant_events)
+
+    if ENV["EVENT"].present?
+      scope = scope.where(event: Event.find_by!(slug: ENV.fetch("EVENT")))
+    elsif ENV["ALL_EVENTS"] != "1"
+      scope = scope.joins(:event).where("events.ends_at IS NULL OR events.ends_at >= ?", Time.current)
+    end
+
+    # eligible_for_completion? walks consents/guardians/custom documents, so it
+    # can't be pushed into SQL — filter in Ruby off the preloaded association.
+    stuck = scope.select(&:eligible_for_completion?)
+
+    puts "#{stuck.size} stuck participant#{'s' unless stuck.size == 1} (apply=#{apply}):"
+    stuck.group_by { |pe| pe.event }.sort_by { |event, _| event.slug }.each do |event, rows|
+      puts "  #{event.slug} (#{rows.size}):"
+      rows.each { |pe| puts "    - #{pe.participant.email} [#{pe.status}] #{pe.id}" }
+    end
+
+    unless apply
+      puts "Dry run — set APPLY=1 to write."
+      exit
+    end
+
+    PaperTrail.request.whodunnit = "rake stuck_completions:repair"
+
+    completed = stuck.count { |pe| pe.mark_complete_if_eligible! }
+    puts "Completed #{completed} of #{stuck.size}."
+  end
+end

--- a/spec/requests/onboarding_minor_completion_spec.rb
+++ b/spec/requests/onboarding_minor_completion_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+# A guardian can finish their whole side — waiver plus portal — before the
+# participant gets round to hitting submit. Every `mark_complete_if_eligible!`
+# hook fires on the guardian's actions and bails on the not-yet-accepted code
+# of conduct, so submitting has to be the thing that re-checks. When it didn't,
+# these rows sat at `awaiting_guardian` forever and the dashboard hid their
+# boarding pass (it gates the QR on the raw `complete?` enum, not display_status).
+RSpec.describe "Onboarding completion for minors", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:event) { create(:event) }
+  let(:user) { create(:user) }
+  let(:participant) do
+    create(:participant, user: user, email: user.email, date_of_birth: 15.years.ago.to_date)
+  end
+  let(:participant_event) do
+    create(:participant_event, participant: participant, event: event,
+      status: :in_progress, onboarding_step: 99)
+  end
+
+  before { sign_in user }
+
+  def submit
+    post complete_onboarding_path(event_id: event.id),
+      params: { code_of_conduct_accepted: "1", code_of_conduct_signature: "Test Minor" }
+  end
+
+  context "when the guardian finished everything first" do
+    before do
+      create(:guardian_participant_event, participant_event: participant_event, status: :completed)
+      create(:consent, :signed, participant_event: participant_event)
+      create(:consent, :freedom_waiver, :signed, participant_event: participant_event)
+    end
+
+    it "completes the participant on submit instead of parking them at awaiting_guardian" do
+      expect { submit }.to change { participant_event.reload.status }.to("complete")
+
+      expect(participant_event.onboarding_completed_at).to be_present
+      expect(response).to redirect_to(dashboard_path)
+      expect(flash[:notice]).to include("you're all set")
+    end
+
+    it "does not invite the guardian who has already finished" do
+      # :never_sent so an invite would actually be enqueued if submit fell
+      # through to the "waiver already signed" branch instead of completing.
+      participant_event.guardian_participant_events.update_all(invite_token_sent_at: nil)
+      allow(GuardianMailer).to receive(:invitation).and_call_original
+
+      submit
+
+      expect(GuardianMailer).not_to have_received(:invitation)
+    end
+
+    context "and the event's guardian invites are locked" do
+      let(:event) { create(:event, guardian_invites_locked: true) }
+
+      it "still completes them rather than promising a waiver that is already signed" do
+        expect { submit }.to change { participant_event.reload.status }.to("complete")
+      end
+    end
+  end
+
+  context "when the guardian still has work to do" do
+    before do
+      create(:guardian_participant_event, participant_event: participant_event, status: :pending)
+    end
+
+    it "parks the participant at awaiting_guardian" do
+      expect { submit }.to change { participant_event.reload.status }.to("awaiting_guardian")
+
+      expect(participant_event.onboarding_completed_at).to be_nil
+    end
+  end
+
+  context "when the freedom waiver is still outstanding" do
+    before do
+      create(:guardian_participant_event, participant_event: participant_event, status: :completed)
+      create(:consent, :signed, participant_event: participant_event)
+    end
+
+    it "parks the participant at awaiting_guardian" do
+      expect { submit }.to change { participant_event.reload.status }.to("awaiting_guardian")
+    end
+  end
+end


### PR DESCRIPTION
## The bug

A participant's boarding pass QR was missing on the dashboard ([participant `76a8b053`](https://attend.hackclub.com/admin/events/sunbeam-dhaka/participants/76a8b053-1e65-431b-b5ba-9a2bd0aa1e44), Sunbeam Dhaka). Her db `status` was `awaiting_guardian` while `display_status` said **Complete**, so the admin badge looked fine but `dashboard/show.html.erb` hides the whole pass — it gates on the raw `complete?` enum.

`OnboardingController#complete` set minors to `awaiting_guardian` and stopped there — `mark_complete_if_eligible!` only ever ran in the adult branch. So when the ordering is:

1. guardian signs the waiver → `Consent` callback calls `mark_complete_if_eligible!` → **false**, `code_of_conduct_accepted_at` still nil
2. guardian portal completed → `GuardianPortalController` calls it again → **false**, same reason
3. participant finally hits submit → sets `code_of_conduct_accepted_at`, and nothing re-checks

…the row is stuck at `awaiting_guardian` forever. Nothing else would ever fire.

## The fix

Submit re-checks eligibility right after the status update, and skips the guardian invite when the guardian is already done (it was re-firing `send_guardian_invites` at guardians who'd finished).

## Backfill

`rake stuck_completions:repair` — dry run by default, `EVENT=<slug>` / `ALL_EVENTS=1` / `APPLY=1`.

Already run against prod on 2026-08-26 via the pod: **23 rows completed, 0 remaining** — 20 on upcoming events (14 of them `sunbeam-karachi-division`) and 3 on past events. Paper-trailed as `console backfill: stuck completions 2026-08-26`. Worth re-running after this deploys to catch anyone who got stuck in the interim.

Completion is side-effect-free beyond a `WalletPassUpdateJob` per row — `ParticipantEvent` has no status callbacks, so no mail goes out.

## Tests

`spec/requests/onboarding_minor_completion_spec.rb` — guardian-finished-first, invites-locked, plus negatives for a pending guardian and an outstanding freedom waiver. Verified they fail without the controller change.