### PR TITLE
Add a Limited event role that sees no addresses or exact birthdays

### DIFF
--- a/app/assets/stylesheets/themes.css
+++ b/app/assets/stylesheets/themes.css
@@ -543,6 +543,8 @@
 
   --color-teal-50:  color-mix(in oklab, #14b8a6 12%, var(--bg-elev));
   --color-teal-100: color-mix(in oklab, #14b8a6 20%, var(--bg-elev));
+  --color-teal-700: #5eead4;
+  --color-teal-800: #99f6e4;
 
   --color-sky-50:  color-mix(in oklab, #0ea5e9 12%, var(--bg-elev));
   --color-sky-100: color-mix(in oklab, #0ea5e9 20%, var(--bg-elev));

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -9,7 +9,15 @@ module Admin
 
     layout "admin"
 
-    helper_method :current_event, :available_events
+    helper_method :current_event, :available_events, :can_view_participant_pii?
+
+    # Views that render an exact date of birth or a home address gate on this;
+    # PII-restricted roles (Limited) get age and no address instead.
+    def can_view_participant_pii?
+      return @can_view_participant_pii if defined?(@can_view_participant_pii)
+
+      @can_view_participant_pii = current_user&.can_view_participant_pii?(current_event) || false
+    end
 
     def current_event
       @current_event

--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -8,7 +8,8 @@ module Admin
       @templates = current_event.export_templates.order(:name)
       # Only offer presets the current role can fully export (the legacy page
       # likewise hid export types the user couldn't run).
-      @presets = Exports::FieldRegistry::PRESETS.select { |_, preset| (preset[:columns] - permitted_keys).empty? }
+      preset_keys = Exports::FieldRegistry.preset_keys_for(role: current_role, global_admin: current_user.global_admin?)
+      @presets = Exports::FieldRegistry::PRESETS.select { |_, preset| (preset[:columns] - preset_keys).empty? }
       @prefill = resolve_prefill
     end
 

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -908,26 +908,39 @@ module Admin
     end
 
     def participant_params
-      params.require(:participant).permit(
+      permitted = [
         :legal_first_name, :legal_last_name, :preferred_name, :email,
         :date_of_birth, :phone, :pronouns, :tshirt_size, :headshot
-      )
+      ]
+      # The edit form hides the field for PII-restricted roles; dropping it here
+      # too means a hand-crafted POST can't write (or probe) a date of birth
+      # the same user isn't allowed to read back.
+      permitted.delete(:date_of_birth) unless can_view_participant_pii?
+
+      params.require(:participant).permit(*permitted)
     end
 
     def travel_params(direction)
       key = "travel_#{direction}"
       return { direction: direction } unless params[key].present?
 
-      permitted = params.require(key).permit(
+      allowed = [
         :mode, :carrier, :flight_number, :departure_city, :departure_time,
         :arrival_city, :arrival_time, :arrival_location, :booking_reference,
         :visa_status, :visa_notes, :is_unaccompanied_minor, :notes,
         :train_departure_station, :train_arrival_station,
         :bus_departure_location, :bus_arrival_location,
         :origin_address, :expected_arrival_time, :other_details,
-        travel_legs_attributes: [ :id, :position, :flight_code, :departure_airport, :arrival_airport,
-                                 :departure_time, :departure_time_zone, :arrival_time, :arrival_time_zone, :confirmation_code, :_destroy ]
-      ).merge(direction: direction)
+        { travel_legs_attributes: [ :id, :position, :flight_code, :departure_airport, :arrival_airport,
+                                    :departure_time, :departure_time_zone, :arrival_time, :arrival_time_zone,
+                                    :confirmation_code, :_destroy ] }
+      ]
+      # The pickup address is hidden from PII-restricted roles, so the form
+      # never renders the field — dropping it here as well stops a submit from
+      # blanking out an address the same user cannot read back.
+      allowed.delete(:origin_address) unless can_view_participant_pii?
+
+      permitted = params.require(key).permit(*allowed).merge(direction: direction)
 
       normalize_leg_times!(permitted)
       permitted
@@ -978,7 +991,7 @@ module Admin
       return true if current_user.global_admin?
 
       role = current_user.role_for_event(current_event)
-      %w[event_admin ops safeguarding_lead].include?(role)
+      %w[event_admin ops limited safeguarding_lead].include?(role)
     end
 
     def require_safeguarding_access

--- a/app/controllers/admin/rooming_wizard_controller.rb
+++ b/app/controllers/admin/rooming_wizard_controller.rb
@@ -346,7 +346,7 @@ module Admin
       respond_to do |format|
         format.html
         format.csv do
-          csv_data = Rooming::CsvExporter.new(@event).generate
+          csv_data = Rooming::CsvExporter.new(@event, include_date_of_birth: can_view_participant_pii?).generate
           send_data csv_data,
             filename: "#{@event.slug}_rooming_#{Date.current.iso8601}.csv",
             type: "text/csv"

--- a/app/controllers/admin/travel_calendar_controller.rb
+++ b/app/controllers/admin/travel_calendar_controller.rb
@@ -6,7 +6,7 @@ module Admin
     before_action :require_travel_enabled
 
     def show
-      @journeys = TravelCalendar::JourneyCache.fetch(current_event)
+      @journeys = TravelCalendar::JourneyCache.fetch(current_event, include_addresses: can_view_participant_pii?)
       @entries = @journeys
       @journeys_by_date = @journeys.select { |journey| journey[:agenda_date].present? }.group_by { |journey| journey[:agenda_date] }
       @unscheduled_journeys = @journeys.select { |journey| journey[:agenda_date].nil? }

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,6 +1,17 @@
 module Api
   module V1
     class EventsController < BaseController
+      # Reported when access is inherited rather than granted on the event
+      # itself. Neither is an EventRoleAssignment role; both act as event
+      # admins, and both outrank any stored role.
+      INHERITED_GLOBAL_ROLE = "global_admin".freeze
+      INHERITED_SERIES_ROLE = "series_member".freeze
+
+      # Someone can hold several roles on one event, so `role` reports the one
+      # with the widest access. Clients should key behaviour off the explicit
+      # capability flags rather than off this string.
+      ROLE_PRECEDENCE = %w[event_admin safeguarding_lead ops limited read_only].freeze
+
       def index
         events = if current_user.global_admin?
           Event.all
@@ -9,7 +20,8 @@ module Api
         end
 
         render json: {
-          events: events.order(:starts_at).map { |event| event_json(event) }
+          events: events.with_attached_logo.with_attached_banner
+                        .order(:starts_at).map { |event| event_json(event) }
         }
       end
 
@@ -25,8 +37,47 @@ module Api
           timezone: event.timezone_identifier,
           location_city: event.location_city,
           logo_url: attachment_url_for(event.logo),
-          banner_url: attachment_url_for(event.banner)
+          banner_url: attachment_url_for(event.banner),
+          # The caller's standing on this event, so a client can adapt its UI up
+          # front instead of discovering restrictions through error responses.
+          role: role_for(event),
+          can_view_participant_pii: can_view_participant_pii?(event)
         }
+      end
+
+      def role_for(event)
+        return INHERITED_GLOBAL_ROLE if current_user.global_admin?
+        return INHERITED_SERIES_ROLE if series_member?(event)
+
+        roles = roles_for(event)
+        ROLE_PRECEDENCE.find { |role| roles.include?(role) } || roles.first
+      end
+
+      # Mirrors User#can_view_participant_pii? against the preloaded roles, so a
+      # long event list doesn't cost two queries per row on app launch.
+      def can_view_participant_pii?(event)
+        return true if current_user.global_admin?
+        return true if series_member?(event)
+
+        roles_for(event).any? { |role| EventRoleAssignment::PII_RESTRICTED_ROLES.exclude?(role) }
+      end
+
+      def series_member?(event)
+        event.event_series_id.present? && member_series_ids.include?(event.event_series_id)
+      end
+
+      def roles_for(event)
+        roles_by_event_id.fetch(event.id, [])
+      end
+
+      def roles_by_event_id
+        @roles_by_event_id ||= current_user.event_role_assignments
+          .pluck(:event_id, :role)
+          .each_with_object({}) { |(event_id, role), acc| (acc[event_id] ||= []) << role }
+      end
+
+      def member_series_ids
+        @member_series_ids ||= current_user.series_role_assignments.pluck(:event_series_id).to_set
       end
 
       def attachment_url_for(attachment)

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -3,6 +3,12 @@ module Api
     class ParticipantsController < BaseController
       include Pundit::Authorization
 
+      # Roles without participant API access (read_only, limited) would
+      # otherwise surface Pundit's exception as a 500 to the mobile app.
+      rescue_from Pundit::NotAuthorizedError do
+        render json: { error: "Forbidden" }, status: :forbidden
+      end
+
       before_action :restrict_api_key_actions
       before_action :set_event
       before_action :set_participant_event, only: [ :show ]
@@ -291,16 +297,23 @@ module Api
         extra
       end
 
+      # `age` is always present; `date_of_birth` and `address` are omitted
+      # entirely for PII-restricted roles rather than sent as null, so a client
+      # can tell "not permitted" from "not on file".
       def personal_json(participant)
-        {
+        base = {
           legal_first_name: participant.legal_first_name,
           legal_last_name: participant.legal_last_name,
           preferred_name: participant.preferred_name,
-          date_of_birth: participant.date_of_birth&.iso8601,
           age: participant.date_of_birth ? age_from(participant.date_of_birth) : nil,
           tshirt_size: participant.tshirt_size,
           engagement_preference: participant.engagement_preference,
-          engagement_notes: participant.engagement_notes,
+          engagement_notes: participant.engagement_notes
+        }
+        return base unless include_pii?
+
+        base.merge(
+          date_of_birth: participant.date_of_birth&.iso8601,
           address: {
             line_1: participant.address_line_1,
             line_2: participant.address_line_2,
@@ -309,7 +322,7 @@ module Api
             postal_code: participant.postal_code,
             country: participant.country_of_residence
           }.compact_blank
-        }
+        )
       end
 
       def age_from(dob)
@@ -486,7 +499,7 @@ module Api
           expected_arrival_time: travel.expected_arrival_time&.iso8601,
           bus_departure_location: travel.bus_departure_location,
           bus_arrival_location: travel.bus_arrival_location,
-          origin_address: travel.origin_address,
+          **(include_pii? ? { origin_address: travel.origin_address } : {}),
           other_details: travel.other_details,
           notes: travel.notes,
           pickup_dismissed_at: travel.pickup_dismissed_at&.iso8601,
@@ -509,6 +522,16 @@ module Api
           travel_picked_up_at: leg.travel_picked_up_at&.iso8601,
           airport_picked_up_at: leg.travel_picked_up_at&.iso8601
         }
+      end
+
+      # Whether this caller gets exact dates of birth and addresses. Memoized
+      # for the same reason as can_view_sensitive_data? below. A nil
+      # current_user means an event API key, which never reaches the actions
+      # that serve these fields (see API_KEY_ALLOWED_ACTIONS).
+      def include_pii?
+        return @include_pii if defined?(@include_pii)
+
+        @include_pii = current_user.nil? || current_user.can_view_participant_pii?(@event)
       end
 
       # Memoized per request: participant_json calls this once per participant,

--- a/app/controllers/api/v1/travel_calendar_controller.rb
+++ b/app/controllers/api/v1/travel_calendar_controller.rb
@@ -5,7 +5,7 @@ module Api
       before_action :authorize_event
 
       def show
-        entries = TravelCalendar::JourneyCache.fetch(@event)
+        entries = TravelCalendar::JourneyCache.fetch(@event, include_addresses: include_addresses?)
 
         render json: {
           eventTimezone: event_timezone,
@@ -29,6 +29,11 @@ module Api
         else
           require_event_access!(@event)
         end
+      end
+
+      # No current_user means an event API key, which keeps the full payload.
+      def include_addresses?
+        current_user.nil? || current_user.can_view_participant_pii?(@event)
       end
 
       def event_timezone

--- a/app/helpers/admin/audit_logs_helper.rb
+++ b/app/helpers/admin/audit_logs_helper.rb
@@ -2,6 +2,15 @@ module Admin
   module AuditLogsHelper
     SENSITIVE_FIELD_PATTERNS = /password|token|secret|api_key|otp|access_key/i
 
+    # Columns holding an exact date of birth or a home address, on participants
+    # and guardians alike. PII-restricted roles (see
+    # EventRoleAssignment::PII_RESTRICTED_ROLES) can reach a participant's change
+    # history, and a changeset is just as revealing as the field itself.
+    PII_FIELDS = %w[
+      date_of_birth address_line_1 address_line_2 city state postal_code
+      country country_of_residence
+    ].freeze
+
     def audit_field_label(field)
       field.to_s.humanize
     end
@@ -19,12 +28,14 @@ module Admin
     end
 
     # Returns a hash of {field => [old, new]} from a PaperTrail::Version.
-    # Hides framework noise so the diff stays human-readable.
-    def audit_version_changes(version)
+    # Hides framework noise so the diff stays human-readable. Pass
+    # `hide_pii: true` to also drop dates of birth and addresses.
+    def audit_version_changes(version, hide_pii: false)
       raw = (version.respond_to?(:changeset) ? version.changeset : nil) || {}
-      raw.except("updated_at", "created_at", "encrypted_password", "remember_created_at",
+      cleaned = raw.except("updated_at", "created_at", "encrypted_password", "remember_created_at",
         "current_sign_in_at", "last_sign_in_at", "current_sign_in_ip", "last_sign_in_ip",
         "sign_in_count", "oidc_claims")
+      hide_pii ? cleaned.except(*PII_FIELDS) : cleaned
     rescue => e
       Rails.logger.warn("[AuditLog] Could not parse version #{version.id}: #{e.message}")
       {}

--- a/app/models/event_role_assignment.rb
+++ b/app/models/event_role_assignment.rb
@@ -9,9 +9,19 @@ class EventRoleAssignment < ApplicationRecord
   enum :role, {
     event_admin: "event_admin",
     ops: "ops",
+    limited: "limited",
     safeguarding_lead: "safeguarding_lead",
     read_only: "read_only"
   }
+
+  # Roles that do the job without seeing a participant's most identifying
+  # details: they get age instead of an exact date of birth, and no address of
+  # any kind — not the home address, not the travel pickup address. Medical
+  # records are deliberately NOT restricted; someone helping with a medical
+  # incident needs the conditions and medications. Enforced through
+  # User#can_view_participant_pii?, which every surface that renders or exports
+  # those fields checks.
+  PII_RESTRICTED_ROLES = %w[limited].freeze
 
   # Human-readable permission breakdown for each role, surfaced when adding or
   # reviewing staff. Keep in sync with the Pundit policies that enforce access.
@@ -42,6 +52,24 @@ class EventRoleAssignment < ApplicationRecord
         "Manage staff",
         "Add or remove participants",
         "Access full medical or safeguarding records"
+      ]
+    },
+    "limited" => {
+      label: "Limited",
+      summary: "Day-to-day logistics, without addresses or exact birthdays.",
+      can: [
+        "View and edit travel and accommodation",
+        "Manage groups and rooming",
+        "View full medical records, so they can help in an incident",
+        "View consents and notes",
+        "See age at the event, instead of a date of birth"
+      ],
+      cannot: [
+        "See exact dates of birth",
+        "See any address, at home or for travel pickup",
+        "Manage staff",
+        "Add or remove participants",
+        "Access safeguarding records"
       ]
     },
     "safeguarding_lead" => {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,9 @@ class User < ApplicationRecord
 
   enum :global_role, { no_role: "none", global_admin: "global_admin", read_only: "read_only" }, default: :no_role
 
+  # Event roles whose day-to-day work includes the support inbox.
+  SUPPORT_ROLES = %w[event_admin ops limited].freeze
+
   # `oidc_claims` holds PII straight from Hack Club Auth (phone number,
   # birthdate, home address). Encrypting the whole jsonb blob works because the
   # Active Record encryption envelope is itself JSON, so it round-trips through
@@ -296,8 +299,21 @@ class User < ApplicationRecord
 
   def admin?
     global_admin? ||
-      event_role_assignments.exists?(role: %w[event_admin ops safeguarding_lead]) ||
+      event_role_assignments.exists?(role: %w[event_admin ops limited safeguarding_lead]) ||
       series_role_assignments.exists?
+  end
+
+  # Whether this user may see participants' exact dates of birth and home
+  # addresses. False only for someone whose access comes entirely from
+  # PII-restricted roles (see EventRoleAssignment::PII_RESTRICTED_ROLES) —
+  # holding any other role, on the event in question or anywhere when no event
+  # is given, restores the full view. Fails closed for a user with no roles.
+  def can_view_participant_pii?(event = nil)
+    return true if global_admin?
+    return true if event ? series_member_for_event?(event) : series_role_assignments.exists?
+
+    assignments = event ? event_role_assignments.where(event: event) : event_role_assignments
+    assignments.where.not(role: EventRoleAssignment::PII_RESTRICTED_ROLES).exists?
   end
 
   def safeguarding_lead_for?(event)
@@ -316,11 +332,11 @@ class User < ApplicationRecord
       series_member_for_event?(event)
   end
 
-  # Events where this user can work support tickets (event_admin or ops,
-  # or any event in a series they belong to).
+  # Events where this user can work support tickets (event_admin, ops, or
+  # limited, or any event in a series they belong to).
   def support_staff_event_ids
     @support_staff_event_ids ||= (
-      event_role_assignments.where(role: %w[event_admin ops]).pluck(:event_id) +
+      event_role_assignments.where(role: SUPPORT_ROLES).pluck(:event_id) +
         series_event_ids
     ).uniq
   end
@@ -329,7 +345,7 @@ class User < ApplicationRecord
   # event staff only while one of their events is within its support window.
   def support_inbox_triage_access?
     global_admin? ||
-      event_role_assignments.where(role: %w[event_admin ops])
+      event_role_assignments.where(role: SUPPORT_ROLES)
                             .joins(:event).merge(Event.within_support_window)
                             .exists? ||
       Event.within_support_window.where(id: series_event_ids).exists?

--- a/app/policies/consent_policy.rb
+++ b/app/policies/consent_policy.rb
@@ -25,7 +25,7 @@ class ConsentPolicy < ApplicationPolicy
         scope.all
       elsif (event = Current.event)
         user_roles = user.event_role_assignments.where(event: event).pluck(:role)
-        if user_roles.intersect?(%w[event_admin ops safeguarding_lead read_only])
+        if user_roles.intersect?(%w[event_admin ops limited safeguarding_lead read_only])
           scope.joins(:participant_event).where(participant_events: { event_id: event.id })
         elsif user.participant
           scope.joins(:participant_event).where(participant_events: { event_id: event.id, participant_id: user.participant.id })

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -38,21 +38,24 @@ class EventPolicy < ApplicationPolicy
   def manage_rooming?
     return true if user.global_admin?
 
-    user.event_role_assignments.exists?(event: record, role: %w[event_admin ops]) ||
+    user.event_role_assignments.exists?(event: record, role: %w[event_admin ops limited]) ||
       user.series_member_for_event?(record)
   end
 
   def manage_groups?
     return true if user.global_admin?
 
-    user.event_role_assignments.exists?(event: record, role: %w[event_admin ops]) ||
+    user.event_role_assignments.exists?(event: record, role: %w[event_admin ops limited]) ||
       user.series_member_for_event?(record)
   end
 
+  # "limited" is included: the controller redacts dates of birth and addresses
+  # out of the payload for it (see Api::V1::ParticipantsController#include_pii?).
+  # "read_only" still gets nothing.
   def api_participants?
     return true if user.global_admin?
 
-    user.event_role_assignments.exists?(event: record, role: %w[event_admin ops safeguarding_lead]) ||
+    user.event_role_assignments.exists?(event: record, role: %w[event_admin ops limited safeguarding_lead]) ||
       user.series_member_for_event?(record)
   end
 

--- a/app/policies/medical_policy.rb
+++ b/app/policies/medical_policy.rb
@@ -13,13 +13,18 @@ class MedicalPolicy < ApplicationPolicy
     can_edit?
   end
 
+  # "limited" is here on purpose: the role exists to keep addresses and exact
+  # birthdays away from staff who don't need them, not to leave them guessing
+  # during a medical incident. Conditions and medications are the point.
   def show_full_details?
     return true if user.global_admin?
     return false unless event
 
-    has_role?("safeguarding_lead", "event_admin")
+    has_role?("safeguarding_lead", "event_admin", "limited")
   end
 
+  # The trimmed-down medical view: allergies and dietary needs, no conditions
+  # or medications.
   def show_limited?
     return true if user.global_admin?
     return false unless event
@@ -35,7 +40,7 @@ class MedicalPolicy < ApplicationPolicy
         scope.all
       elsif (event = Current.event)
         user_roles = user.event_role_assignments.where(event: event).pluck(:role)
-        if user_roles.intersect?(%w[event_admin ops safeguarding_lead])
+        if user_roles.intersect?(%w[event_admin ops limited safeguarding_lead])
           scope.joins(:participant_event).where(participant_events: { event_id: event.id })
         elsif user.participant
           scope.joins(:participant_event).where(participant_events: { event_id: event.id, participant_id: user.participant.id })
@@ -54,7 +59,7 @@ class MedicalPolicy < ApplicationPolicy
     return true if user.global_admin?
     return false unless event
 
-    return true if has_role?("safeguarding_lead", "event_admin", "ops")
+    return true if has_role?("safeguarding_lead", "event_admin", "ops", "limited")
     return true if owns_record?
 
     false

--- a/app/policies/participant_event_policy.rb
+++ b/app/policies/participant_event_policy.rb
@@ -38,37 +38,37 @@ class ParticipantEventPolicy < ApplicationPolicy
   def view_travel?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops", "safeguarding_lead")
+    has_role?("event_admin", "ops", "limited", "safeguarding_lead")
   end
 
   def update_travel?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops")
+    has_role?("event_admin", "ops", "limited")
   end
 
   def view_accommodation?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops", "safeguarding_lead")
+    has_role?("event_admin", "ops", "limited", "safeguarding_lead")
   end
 
   def update_accommodation?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops")
+    has_role?("event_admin", "ops", "limited")
   end
 
   def view_medical?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops", "safeguarding_lead")
+    has_role?("event_admin", "ops", "limited", "safeguarding_lead")
   end
 
   def update_medical?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops", "safeguarding_lead")
+    has_role?("event_admin", "ops", "limited", "safeguarding_lead")
   end
 
   def view_safeguarding?
@@ -86,7 +86,7 @@ class ParticipantEventPolicy < ApplicationPolicy
   def view_consents?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "safeguarding_lead", "ops")
+    has_role?("event_admin", "safeguarding_lead", "ops", "limited")
   end
 
   def reset_waiver?
@@ -96,7 +96,7 @@ class ParticipantEventPolicy < ApplicationPolicy
   def view_notes?
     return true if user.global_admin?
     return false unless record.event == Current.event
-    has_role?("event_admin", "ops", "safeguarding_lead")
+    has_role?("event_admin", "ops", "limited", "safeguarding_lead")
   end
 
   def resync_external?
@@ -119,7 +119,7 @@ class ParticipantEventPolicy < ApplicationPolicy
         scope.all
       elsif (event = Current.event)
         user_roles = user.event_role_assignments.where(event: event).pluck(:role)
-        if user_roles.intersect?(%w[event_admin ops safeguarding_lead])
+        if user_roles.intersect?(%w[event_admin ops limited safeguarding_lead])
           scope.where(event: event)
         elsif user.participant
           scope.where(event: event, participant: user.participant)
@@ -144,7 +144,7 @@ class ParticipantEventPolicy < ApplicationPolicy
     # Staff can only view within their current event context
     return false unless record.event == Current.event
 
-    has_role?("event_admin", "ops", "safeguarding_lead")
+    has_role?("event_admin", "ops", "limited", "safeguarding_lead")
   end
 
   def can_edit?
@@ -154,7 +154,7 @@ class ParticipantEventPolicy < ApplicationPolicy
     # Staff can only edit within their current event context
     return false unless record.event == Current.event
 
-    has_role?("event_admin", "ops")
+    has_role?("event_admin", "ops", "limited")
   end
 
   def owns_record?

--- a/app/services/exports/field_registry.rb
+++ b/app/services/exports/field_registry.rb
@@ -16,7 +16,8 @@ module Exports
   class FieldRegistry
     CATEGORIES = {
       "identity"           => { label: "Identity", tier: :identity, description: "Participant name and email" },
-      "basic"              => { label: "Participant", tier: :general, description: "Contact details, address, and profile information" },
+      "basic"              => { label: "Participant", tier: :general, description: "Contact details, address, and profile information",
+                                pii_restricted_description: "Contact details and profile information" },
       "event_status"       => { label: "Event Status", tier: :general, description: "Registration status, check-in, and onboarding progress" },
       "travel"             => { label: "Travel", tier: :general, description: "Inbound and outbound travel details" },
       "flight_legs"        => { label: "Flight Legs", tier: :general, description: "Per-leg flight details (only in one-row-per-flight-leg mode)" },
@@ -34,10 +35,27 @@ module Exports
     # exports, which included name + email in medical/dietary/accommodation
     # CSVs for safeguarding leads).
     TIER_ROLES = {
-      identity: %w[event_admin ops safeguarding_lead],
-      general: %w[event_admin ops],
+      identity: %w[event_admin ops limited safeguarding_lead],
+      general: %w[event_admin ops limited],
       sensitive: %w[event_admin safeguarding_lead]
     }.freeze
+
+    # Fields the PII-restricted roles never get, whatever tier they sit in (see
+    # EventRoleAssignment::PII_RESTRICTED_ROLES). "Age at Event Start" stays, so
+    # a Limited exporter can still do the rooming and minor-count work that
+    # needs an age. The travel origin addresses are here too: for a car
+    # journey that field is the participant's doorstep.
+    PII_RESTRICTED_FIELD_KEYS = %w[
+      participant.date_of_birth
+      participant.address_line_1
+      participant.address_line_2
+      participant.city
+      participant.state
+      participant.postal_code
+      participant.country_of_residence
+      travel.inbound.origin_address
+      travel.outbound.origin_address
+    ].freeze
 
     ROW_MODES = %w[participant flight_leg].freeze
 
@@ -344,12 +362,34 @@ module Exports
       end
 
       def categories_for(role:, global_admin: false)
-        CATEGORIES.select { |_, config| global_admin || TIER_ROLES.fetch(config[:tier]).include?(role) }
+        reachable = CATEGORIES.select { |_, config| global_admin || TIER_ROLES.fetch(config[:tier]).include?(role) }
+        return reachable if global_admin || !pii_restricted?(role)
+
+        # Don't promise an address the field list won't deliver.
+        reachable.transform_values do |config|
+          config[:pii_restricted_description] ? config.merge(description: config[:pii_restricted_description]) : config
+        end
+      end
+
+      # Preset eligibility ignores the PII field filter, so a PII-restricted
+      # role is still offered the presets its categories cover — loading one
+      # strips the fields it can't have and says so, which beats the preset
+      # silently disappearing.
+      def preset_keys_for(role:, global_admin: false)
+        permitted = categories_for(role: role, global_admin: global_admin).keys
+        FIELDS.values.select { |f| permitted.include?(f.category) }.map(&:key)
       end
 
       def fields_for(role:, global_admin: false)
         permitted = categories_for(role: role, global_admin: global_admin).keys
-        FIELDS.values.select { |f| permitted.include?(f.category) }
+        fields = FIELDS.values.select { |f| permitted.include?(f.category) }
+        return fields if global_admin || !pii_restricted?(role)
+
+        fields.reject { |f| PII_RESTRICTED_FIELD_KEYS.include?(f.key) }
+      end
+
+      def pii_restricted?(role)
+        EventRoleAssignment::PII_RESTRICTED_ROLES.include?(role)
       end
 
       def permitted_keys(role:, global_admin: false)

--- a/app/services/rooming/csv_exporter.rb
+++ b/app/services/rooming/csv_exporter.rb
@@ -1,7 +1,11 @@
 module Rooming
   class CsvExporter
-    def initialize(event)
+    # `include_date_of_birth: false` drops the DOB column entirely, for the
+    # PII-restricted roles that can run rooming but not see exact birthdays.
+    # Age at Event is kept either way — it's what the sheet is actually for.
+    def initialize(event, include_date_of_birth: true)
       @event = event
+      @include_date_of_birth = include_date_of_birth
     end
 
     def generate
@@ -10,41 +14,51 @@ module Rooming
         .order(:name, :created_at)
 
       CSV.generate do |csv|
-        csv << [
+        csv << row(
           "Room Number",
           "Legal First Name",
           "Legal Last Name",
           "Date of Birth",
           "Age at Event"
-        ]
+        )
 
         rooms.each do |room|
           if room.staff_only? && room.staff_names.present?
             room.staff_names.split(/[,;]/).map(&:strip).reject(&:blank?).each do |staff_name|
-              csv << [
+              csv << row(
                 room.name || room.display_name,
                 staff_name,
                 "(Staff)",
                 nil,
                 nil
-              ]
+              )
             end
           else
             room.room_assignments.each do |assignment|
               participant = assignment.participant_event.participant
               age = participant.age_on(@event.starts_at&.to_date || Date.current)
 
-              csv << [
+              csv << row(
                 room.name || room.display_name,
                 participant.legal_first_name,
                 participant.legal_last_name,
                 participant.date_of_birth&.iso8601,
                 age
-              ]
+              )
             end
           end
         end
       end
+    end
+
+    private
+
+    # Positional so the header and body can't drift out of step: the fourth
+    # value is always the date of birth, and it's dropped or kept as one.
+    def row(room, first_name, last_name, date_of_birth, age)
+      values = [ room, first_name, last_name, date_of_birth, age ]
+      values.delete_at(3) unless @include_date_of_birth
+      values
     end
   end
 end

--- a/app/services/travel_calendar/journey_cache.rb
+++ b/app/services/travel_calendar/journey_cache.rb
@@ -3,10 +3,17 @@ module TravelCalendar
     EXPIRY = 5.minutes
 
     class << self
-      def fetch(event)
-        Rails.cache.fetch(cache_key(event), expires_in: EXPIRY) do
+      # `include_addresses: false` blanks the pickup address a car journey
+      # carries as its route, for the PII-restricted roles (see
+      # EventRoleAssignment::PII_RESTRICTED_ROLES). Redaction happens on the way
+      # out rather than in the builder so the cache stays a single entry shared
+      # by every role.
+      def fetch(event, include_addresses: true)
+        journeys = Rails.cache.fetch(cache_key(event), expires_in: EXPIRY) do
           JourneyBuilder.new(event: event).call
         end
+
+        include_addresses ? journeys : redact_pickup_addresses(journeys)
       end
 
       def clear(event)
@@ -20,6 +27,17 @@ module TravelCalendar
       end
 
       private
+
+      # New hashes, not edits to the cached ones: the development memory_store
+      # hands back the very objects it is holding, so mutating in place would
+      # strip the address for every other reader too.
+      def redact_pickup_addresses(journeys)
+        journeys.map do |journey|
+          next journey unless journey[:mode] == "car" && journey[:route].present?
+
+          journey.merge(route: "Address hidden")
+        end
+      end
 
       def cache_key(event)
         cache_key_for(event.id)

--- a/app/toolboxes/participants_toolbox.rb
+++ b/app/toolboxes/participants_toolbox.rb
@@ -45,13 +45,22 @@ class ParticipantsToolbox < ApplicationToolbox
   end
   def update
     @participant = accessible_participants.find(params[:participant_id])
-    @participant.update!(params.permit(:preferred_name, :email, :phone,
-                                       :pronouns, :tshirt_size, :city, :state,
-                                       :country_of_residence).to_h)
+    permitted = %i[preferred_name email phone pronouns tshirt_size city state country_of_residence]
+    permitted -= %i[city state country_of_residence] unless view_pii?
+    @participant.update!(params.permit(*permitted).to_h)
     render json: serialize_participant(@participant, full: true)
   end
 
   private
+
+  # Whether this account may see exact dates of birth and addresses at all.
+  # Participants here aren't scoped to one event, so a PII-restricted role on
+  # one event doesn't hide anything for someone who is ops elsewhere.
+  def view_pii?
+    return @view_pii if defined?(@view_pii)
+
+    @view_pii = current_user.can_view_participant_pii?
+  end
 
   # Participants reachable through the events this connection can access.
   def accessible_participants
@@ -86,11 +95,9 @@ class ParticipantsToolbox < ApplicationToolbox
     base.merge(
       phone: p.phone,
       slack_user_id: p.slack_user_id,
-      date_of_birth: p.date_of_birth,
-      city: p.city,
-      state: p.state,
-      country_of_residence: p.country_of_residence,
       tshirt_size: p.tshirt_size,
+      **(view_pii? ? { date_of_birth: p.date_of_birth, city: p.city, state: p.state,
+                       country_of_residence: p.country_of_residence } : {}),
       registrations: p.participant_events
         .where(current_user.global_admin? && permitted_event_ids.nil? ? {} : { event_id: accessible_events.select(:id) })
         .includes(:event).map { |pe|

--- a/app/views/admin/event_staff/index.html.erb
+++ b/app/views/admin/event_staff/index.html.erb
@@ -27,6 +27,7 @@
                   <%= case assignment.role
                       when 'event_admin' then 'bg-purple-100 text-purple-800'
                       when 'ops' then 'bg-blue-100 text-blue-800'
+                      when 'limited' then 'bg-teal-100 text-teal-800'
                       when 'safeguarding_lead' then 'bg-red-100 text-red-800'
                       when 'read_only' then 'bg-gray-100 text-gray-800'
                       end %>">
@@ -59,11 +60,12 @@
 
   <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
     <h3 class="text-sm font-medium text-blue-800 mb-2">Role Permissions</h3>
+    <%# Driven off ROLE_DETAILS so this legend can't drift from what the roles
+        actually do — the full can/cannot breakdown is on the Add Staff page. %>
     <ul class="text-sm text-blue-700 space-y-1">
-      <li><strong>Event Admin:</strong> Full access to this event, including staff management</li>
-      <li><strong>Ops:</strong> Can manage travel, accommodation, and operational data</li>
-      <li><strong>Safeguarding Lead:</strong> Can access medical and safeguarding information</li>
-      <li><strong>Read Only:</strong> Can view all event data but cannot make changes</li>
+      <% EventRoleAssignment::ROLE_DETAILS.each do |_role, details| %>
+        <li><strong><%= details[:label] %>:</strong> <%= details[:summary] %></li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -199,6 +199,7 @@
                   <%= case assignment.role
                       when 'event_admin' then 'bg-purple-100 text-purple-800'
                       when 'ops' then 'bg-blue-100 text-blue-800'
+                      when 'limited' then 'bg-teal-100 text-teal-800'
                       when 'safeguarding_lead' then 'bg-red-100 text-red-800'
                       when 'read_only' then 'bg-gray-100 text-gray-800'
                       end %>">

--- a/app/views/admin/participants/_participant_card.html.erb
+++ b/app/views/admin/participants/_participant_card.html.erb
@@ -34,10 +34,12 @@
   </div>
 
   <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-    <div>
-      <span class="text-gray-500">Date of Birth:</span>
-      <span class="text-gray-900"><%= participant.date_of_birth&.strftime("%B %d, %Y") %></span>
-    </div>
+    <% if can_view_participant_pii? %>
+      <div>
+        <span class="text-gray-500">Date of Birth:</span>
+        <span class="text-gray-900"><%= participant.date_of_birth&.strftime("%B %d, %Y") %></span>
+      </div>
+    <% end %>
     <% if defined?(event) && event %>
       <div>
         <span class="text-gray-500">Age at Event:</span>

--- a/app/views/admin/participants/_table_row.html.erb
+++ b/app/views/admin/participants/_table_row.html.erb
@@ -22,9 +22,11 @@
   <td class="px-2 py-1.5 text-gray-500 whitespace-nowrap" data-column="pronouns">
     <%= pe.participant.pronouns.presence || "—" %>
   </td>
-  <td class="px-2 py-1.5 text-gray-500 whitespace-nowrap" data-column="dob">
-    <%= pe.participant.date_of_birth&.strftime("%Y-%m-%d") || "—" %>
-  </td>
+  <% if can_view_participant_pii? %>
+    <td class="px-2 py-1.5 text-gray-500 whitespace-nowrap" data-column="dob">
+      <%= pe.participant.date_of_birth&.strftime("%Y-%m-%d") || "—" %>
+    </td>
+  <% end %>
   <td class="px-2 py-1.5 whitespace-nowrap" data-column="age">
     <% age = pe.participant.age_on(current_event.starts_at&.to_date || Date.current) %>
     <% if age %>

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -60,10 +60,12 @@
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <%= f.label :date_of_birth, "Date of Birth", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.date_field :date_of_birth, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
-          </div>
+          <% if can_view_participant_pii? %>
+            <div>
+              <%= f.label :date_of_birth, "Date of Birth", class: "block text-sm font-medium text-gray-700 mb-1" %>
+              <%= f.date_field :date_of_birth, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
+            </div>
+          <% end %>
           <div>
             <%= f.label :phone, class: "block text-sm font-medium text-gray-700 mb-1" %>
             <%= f.telephone_field :phone, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>

--- a/app/views/admin/participants/history.html.erb
+++ b/app/views/admin/participants/history.html.erb
@@ -12,7 +12,7 @@
     <% if @versions.any? %>
       <div class="divide-y divide-gray-100">
         <% @versions.each do |version| %>
-          <% changes = audit_version_changes(version) %>
+          <% changes = audit_version_changes(version, hide_pii: !can_view_participant_pii?) %>
           <details class="group">
             <summary class="px-4 sm:px-6 py-3 flex items-center gap-3 cursor-pointer hover:bg-gray-50 list-none">
               <span class="text-xs text-gray-500 font-mono w-40 flex-shrink-0 hidden sm:block"><%= version.created_at.strftime("%Y-%m-%d %H:%M") %></span>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -16,10 +16,12 @@
             <dt class="text-sm text-gray-500">Phone</dt>
             <dd class="text-gray-900"><%= @participant.phone || "—" %></dd>
           </div>
-          <div>
-            <dt class="text-sm text-gray-500">Date of Birth</dt>
-            <dd class="text-gray-900"><%= @participant.date_of_birth&.strftime("%B %d, %Y") %></dd>
-          </div>
+          <% if can_view_participant_pii? %>
+            <div>
+              <dt class="text-sm text-gray-500">Date of Birth</dt>
+              <dd class="text-gray-900"><%= @participant.date_of_birth&.strftime("%B %d, %Y") %></dd>
+            </div>
+          <% end %>
           <div>
             <dt class="text-sm text-gray-500">Age at Event</dt>
             <dd class="text-gray-900">
@@ -33,10 +35,12 @@
             <dt class="text-sm text-gray-500">Pronouns</dt>
             <dd class="text-gray-900"><%= @participant.pronouns || "—" %></dd>
           </div>
-          <div>
-            <dt class="text-sm text-gray-500">Address</dt>
-            <dd class="text-gray-900"><%= [@participant.address_line_1, @participant.address_line_2, @participant.city, @participant.state, @participant.postal_code, @participant.country_of_residence].compact.reject(&:blank?).join(", ").presence || "—" %></dd>
-          </div>
+          <% if can_view_participant_pii? %>
+            <div>
+              <dt class="text-sm text-gray-500">Address</dt>
+              <dd class="text-gray-900"><%= [@participant.address_line_1, @participant.address_line_2, @participant.city, @participant.state, @participant.postal_code, @participant.country_of_residence].compact.reject(&:blank?).join(", ").presence || "—" %></dd>
+            </div>
+          <% end %>
         </dl>
       </section>
 
@@ -69,7 +73,10 @@
                     <div><span class="text-gray-500">Arrival:</span> <%= [ flight_local_time(last_leg.arrival_time, last_leg.arrival_airport), last_leg.arrival_airport ].compact.join(" - ") %></div>
                     <div><span class="text-gray-500">Flight:</span> <%= first_leg.flight_code %></div>
                   <% elsif @travel_inbound.car? %>
-                    <div><span class="text-gray-500">From:</span> <%= @travel_inbound.origin_address %></div>
+                    <div><span class="text-gray-500">From:</span>
+                      <% if can_view_participant_pii? %><%= @travel_inbound.origin_address %>
+                      <% else %><span class="italic text-gray-400" title="Pickup addresses are hidden for your role">Address hidden</span><% end %>
+                    </div>
                     <div><span class="text-gray-500">Arrival:</span> <%= @travel_inbound.expected_arrival_time&.strftime("%b %d, %Y %H:%M") %></div>
                   <% elsif @travel_inbound.train? %>
                     <div><span class="text-gray-500">From:</span> <%= @travel_inbound.train_departure_station %></div>
@@ -97,7 +104,10 @@
                     <div><span class="text-gray-500">Departure:</span> <%= flight_local_time(first_leg.departure_time, first_leg.departure_airport) %> - <%= first_leg.departure_airport %></div>
                     <div><span class="text-gray-500">Flight:</span> <%= first_leg.flight_code %></div>
                   <% elsif @travel_outbound.car? %>
-                    <div><span class="text-gray-500">To:</span> <%= @travel_outbound.origin_address %></div>
+                    <div><span class="text-gray-500">To:</span>
+                      <% if can_view_participant_pii? %><%= @travel_outbound.origin_address %>
+                      <% else %><span class="italic text-gray-400" title="Pickup addresses are hidden for your role">Address hidden</span><% end %>
+                    </div>
                     <div><span class="text-gray-500">Departure:</span> <%= @travel_outbound.departure_time&.strftime("%b %d, %Y %H:%M") %></div>
                   <% elsif @travel_outbound.train? %>
                     <div><span class="text-gray-500">To:</span> <%= @travel_outbound.train_arrival_station %></div>

--- a/app/views/admin/participants/table.html.erb
+++ b/app/views/admin/participants/table.html.erb
@@ -113,7 +113,7 @@
               ["email", "Email"],
               ["phone", "Phone"],
               ["pronouns", "Pronouns"],
-              ["dob", "Date of Birth"],
+              *(can_view_participant_pii? ? [["dob", "Date of Birth"]] : []),
               ["age", "Age"],
               ["status", "Status"],
               ["tshirt", "T-Shirt"],
@@ -223,10 +223,12 @@
                 data-column="pronouns" data-action="click->data-table#sort" data-sort-field="pronouns">
               <div class="flex items-center gap-1">Pronouns <%= render_sort_icon("pronouns", @sort_field, @sort_direction) %></div>
             </th>
-            <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 whitespace-nowrap"
-                data-column="dob" data-action="click->data-table#sort" data-sort-field="date_of_birth">
-              <div class="flex items-center gap-1">DOB <%= render_sort_icon("date_of_birth", @sort_field, @sort_direction) %></div>
-            </th>
+            <% if can_view_participant_pii? %>
+              <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 whitespace-nowrap"
+                  data-column="dob" data-action="click->data-table#sort" data-sort-field="date_of_birth">
+                <div class="flex items-center gap-1">DOB <%= render_sort_icon("date_of_birth", @sort_field, @sort_direction) %></div>
+              </th>
+            <% end %>
             <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-column="age">Age</th>
             <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 whitespace-nowrap"
                 data-column="status" data-action="click->data-table#sort" data-sort-field="status">

--- a/app/views/admin/participants/travel.html.erb
+++ b/app/views/admin/participants/travel.html.erb
@@ -154,10 +154,12 @@
           <!-- Car fields -->
           <% if @travel_inbound.car? %>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 border-t pt-4 mt-4">
-              <div data-controller="address-autocomplete">
-                <%= f.label :origin_address, "Travelling From", class: "block text-sm font-medium text-gray-700 mb-1" %>
-                <%= f.text_field :origin_address, class: "w-full rounded-md border border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", data: { address_autocomplete_target: "input" } %>
-              </div>
+              <% if can_view_participant_pii? %>
+                <div data-controller="address-autocomplete">
+                  <%= f.label :origin_address, "Travelling From", class: "block text-sm font-medium text-gray-700 mb-1" %>
+                  <%= f.text_field :origin_address, class: "w-full rounded-md border border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", data: { address_autocomplete_target: "input" } %>
+                </div>
+              <% end %>
               <div>
                 <%= f.label :expected_arrival_time, "Expected Arrival Time", class: "block text-sm font-medium text-gray-700 mb-1" %>
                 <%= f.datetime_local_field :expected_arrival_time, class: "w-full rounded-md border border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2" %>
@@ -262,10 +264,12 @@
           <!-- Car fields -->
           <% if @travel_outbound.car? %>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 border-t pt-4 mt-4">
-              <div data-controller="address-autocomplete">
-                <%= f.label :origin_address, "Travelling To", class: "block text-sm font-medium text-gray-700 mb-1" %>
-                <%= f.text_field :origin_address, class: "w-full rounded-md border border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", data: { address_autocomplete_target: "input" } %>
-              </div>
+              <% if can_view_participant_pii? %>
+                <div data-controller="address-autocomplete">
+                  <%= f.label :origin_address, "Travelling To", class: "block text-sm font-medium text-gray-700 mb-1" %>
+                  <%= f.text_field :origin_address, class: "w-full rounded-md border border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2", data: { address_autocomplete_target: "input" } %>
+                </div>
+              <% end %>
               <div>
                 <%= f.label :departure_time, "Departure Time", class: "block text-sm font-medium text-gray-700 mb-1" %>
                 <%= f.datetime_local_field :departure_time, class: "w-full rounded-md border border-gray-300  focus:border-[#ec3750] focus:ring-[#ec3750] px-3 py-2" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,6 +42,14 @@ if Rails.env.development?
   EventRoleAssignment.find_or_create_by!(user: ops_staff, event: event, role: "ops")
   puts "Created ops staff: #{ops_staff.email}"
 
+  limited_staff = User.find_or_create_by!(email: "limited@hackclub.com") do |u|
+    u.name = "Limited Staff"
+    u.password = "password123"
+    u.global_role = "no_role"
+  end
+  EventRoleAssignment.find_or_create_by!(user: limited_staff, event: event, role: "limited")
+  puts "Created limited staff: #{limited_staff.email}"
+
   safeguarding = User.find_or_create_by!(email: "safeguarding@hackclub.com") do |u|
     u.name = "Safeguarding Lead"
     u.password = "password123"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -359,6 +359,56 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#can_view_participant_pii?" do
+    let(:event) { create(:event) }
+    let(:user) { create(:user) }
+
+    it "is false when the only role on the event is a PII-restricted one" do
+      create(:event_role_assignment, user: user, event: event, role: "limited")
+
+      expect(user.can_view_participant_pii?(event)).to be(false)
+    end
+
+    it "is true when the user also holds an unrestricted role on that event" do
+      create(:event_role_assignment, user: user, event: event, role: "limited")
+      create(:event_role_assignment, user: user, event: event, role: "ops")
+
+      expect(user.can_view_participant_pii?(event)).to be(true)
+    end
+
+    it "is scoped per event" do
+      other_event = create(:event)
+      create(:event_role_assignment, user: user, event: event, role: "limited")
+      create(:event_role_assignment, user: user, event: other_event, role: "ops")
+
+      expect(user.can_view_participant_pii?(event)).to be(false)
+      expect(user.can_view_participant_pii?(other_event)).to be(true)
+    end
+
+    it "falls back to any unrestricted role when no event is given" do
+      create(:event_role_assignment, user: user, event: event, role: "limited")
+      expect(user.can_view_participant_pii?).to be(false)
+
+      create(:event_role_assignment, user: user, event: create(:event), role: "ops")
+      expect(user.reload.can_view_participant_pii?).to be(true)
+    end
+
+    it "is true for global admins and series members" do
+      expect(create(:user, global_role: "global_admin").can_view_participant_pii?(event)).to be(true)
+
+      series_event = create(:event, event_series: create(:event_series))
+      series_user = create(:user)
+      SeriesRoleAssignment.create!(user: series_user, event_series: series_event.event_series, role: "organizer")
+      create(:event_role_assignment, user: series_user, event: series_event, role: "limited")
+
+      expect(series_user.can_view_participant_pii?(series_event)).to be(true)
+    end
+
+    it "fails closed for a user with no roles at all" do
+      expect(user.can_view_participant_pii?(event)).to be(false)
+    end
+  end
+
   describe "#placeholder_account?" do
     it "is true for a user created by an admin invite" do
       expect(create(:user).placeholder_account?).to be(true)

--- a/spec/requests/admin/limited_role_spec.rb
+++ b/spec/requests/admin/limited_role_spec.rb
@@ -1,0 +1,321 @@
+require "rails_helper"
+
+# The Limited event role does everything Ops does, minus a participant's exact
+# date of birth and any address -- home or travel pickup. Medical records are
+# deliberately full: the role has to be able to help in an incident. These specs
+# pin the redaction on every surface that renders or exports a restricted field.
+RSpec.describe "Limited event role", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:event) { create(:event, accommodation_enabled: false) }
+  let(:participant) do
+    create(:participant,
+      legal_first_name: "Dorothy", legal_last_name: "Vaughan",
+      date_of_birth: Date.new(2009, 3, 14),
+      address_line_1: "12 Langley Road", city: "Hampton", state: "VA",
+      postal_code: "23666", country_of_residence: "USA")
+  end
+  let!(:participant_event) { create(:participant_event, event: event, participant: participant) }
+
+  def sign_in_with_role(role, email: "#{role}-limited-spec@example.com")
+    user = User.create!(email: email, name: role.titleize)
+    EventRoleAssignment.create!(user: user, event: event, role: role)
+    sign_in user
+    user
+  end
+
+  describe "the participant profile" do
+    it "shows age but not the exact date of birth or address" do
+      sign_in_with_role("limited")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Age at Event")
+      expect(response.body).not_to include("Date of Birth", "March 14, 2009")
+      expect(response.body).not_to include("12 Langley Road", "23666")
+    end
+
+    it "still shows both to ops" do
+      sign_in_with_role("ops")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).to include("Date of Birth", "March 14, 2009")
+      expect(response.body).to include("12 Langley Road", "23666")
+    end
+  end
+
+  describe "the participant table" do
+    it "drops the DOB column" do
+      sign_in_with_role("limited")
+
+      get table_admin_event_participants_path(event.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(">Age<")
+      expect(response.body).not_to include('data-column="dob"', "2009-03-14")
+    end
+  end
+
+  describe "the edit form" do
+    it "omits the date of birth field and ignores it when posted" do
+      sign_in_with_role("limited")
+
+      get edit_admin_event_participant_path(event.slug, participant_event)
+      expect(response.body).not_to include("participant[date_of_birth]")
+
+      patch admin_event_participant_path(event.slug, participant_event),
+        params: { participant: { preferred_name: "Dot", date_of_birth: "1990-01-01" } }
+
+      expect(participant.reload.preferred_name).to eq("Dot")
+      expect(participant.date_of_birth).to eq(Date.new(2009, 3, 14))
+    end
+  end
+
+  describe "the change history" do
+    it "hides date of birth and address changes" do
+      PaperTrail.request(whodunnit: nil) { participant.update!(date_of_birth: Date.new(2008, 1, 2), city: "Newport") }
+      sign_in_with_role("limited")
+
+      get history_admin_event_participant_path(event.slug, participant_event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("2008-01-02", "Newport")
+    end
+  end
+
+  describe "exports" do
+    it "does not offer the DOB or address columns" do
+      sign_in_with_role("limited")
+
+      get admin_event_exports_path(event_slug: event.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("participant.age_at_event", "travel.inbound.mode")
+      expect(response.body).not_to include("participant.date_of_birth", "participant.address_line_1",
+        "participant.postal_code")
+    end
+
+    it "still offers the participants preset, stripping the DOB column from it" do
+      sign_in_with_role("limited")
+
+      get admin_event_exports_path(event_slug: event.slug)
+      expect(response.body).to include("preset=participants")
+
+      get admin_event_exports_path(event_slug: event.slug, preset: "participants")
+      expect(response.body).to include("not authorized to export", "Date of Birth")
+      expect(response.body).not_to include("participant.date_of_birth")
+    end
+
+    it "describes the Participant category without promising an address" do
+      sign_in_with_role("limited")
+
+      get admin_event_exports_path(event_slug: event.slug)
+
+      expect(response.body).to include("Contact details and profile information")
+      expect(response.body).not_to include("Contact details, address, and profile information")
+    end
+
+    it "refuses an export that asks for them anyway" do
+      sign_in_with_role("limited")
+
+      post admin_event_exports_path(event_slug: event.slug),
+        params: { columns: [ "participant.email", "participant.date_of_birth" ], row_mode: "participant" }
+
+      expect(response).to redirect_to(admin_event_exports_path(event.slug))
+      expect(flash[:alert]).to include("not authorized to export", "Date of Birth")
+    end
+  end
+
+  describe "the rooming sheet" do
+    it "leaves the date of birth column out of the CSV" do
+      room = event.rooms.create!(name: "101", capacity: 2)
+      room.room_assignments.create!(participant_event: participant_event)
+      sign_in_with_role("limited")
+
+      get export_csv_admin_event_rooming_wizard_path(event.slug, format: :csv)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.lines.first).to include("Age at Event")
+      expect(response.body).not_to include("Date of Birth", "2009-03-14")
+    end
+  end
+
+  describe "travel pickup addresses" do
+    let!(:travel) do
+      participant_event.travels.create!(direction: "inbound", mode: "car",
+        origin_address: "12 Langley Road, Hampton VA", expected_arrival_time: 1.week.from_now)
+    end
+
+    it "hides the address on the participant profile" do
+      sign_in_with_role("limited")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).to include("Address hidden")
+      expect(response.body).not_to include("12 Langley Road")
+    end
+
+    it "omits the field from the travel form and ignores it when posted" do
+      sign_in_with_role("limited")
+
+      get travel_admin_event_participant_path(event.slug, participant_event)
+      expect(response.body).not_to include("travel_inbound[origin_address]")
+
+      patch travel_admin_event_participant_path(event.slug, participant_event),
+        params: { travel_inbound: { mode: "car", origin_address: "" } }
+
+      expect(travel.reload.origin_address).to eq("12 Langley Road, Hampton VA")
+    end
+
+    it "replaces the car route on the travel calendar" do
+      participant_event.update!(status: "complete")
+      TravelCalendar::JourneyCache.clear(event)
+      sign_in_with_role("limited")
+
+      get admin_event_travel_path(event.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Address hidden")
+      expect(response.body).not_to include("12 Langley Road")
+    end
+
+    it "leaves the calendar route intact for ops" do
+      participant_event.update!(status: "complete")
+      TravelCalendar::JourneyCache.clear(event)
+      sign_in_with_role("ops")
+
+      get admin_event_travel_path(event.slug)
+
+      expect(response.body).to include("12 Langley Road")
+    end
+
+    it "does not offer the origin address export columns" do
+      sign_in_with_role("limited")
+
+      get admin_event_exports_path(event_slug: event.slug)
+
+      expect(response.body).to include("travel.inbound.mode")
+      expect(response.body).not_to include("travel.inbound.origin_address",
+        "travel.outbound.origin_address")
+    end
+  end
+
+  describe "medical records" do
+    it "gets the full clinical detail, not the trimmed ops view" do
+      user = sign_in_with_role("limited")
+      medical = participant_event.create_medical!(medical_conditions: "Type 1 diabetes",
+        medications: "Insulin", allergies: "Peanuts")
+
+      Current.event = event
+      expect(MedicalPolicy.new(user, medical).show_full_details?).to be(true)
+
+      get medical_admin_event_participant_path(event.slug, participant_event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Type 1 diabetes", "Insulin")
+    end
+  end
+
+  describe "the participants API" do
+    let(:limited_user) { User.create!(email: "limited-api@example.com", name: "Limited") }
+    let(:token) { MobileToken.generate_for(limited_user) }
+
+    before do
+      EventRoleAssignment.create!(user: limited_user, event: event, role: "limited")
+      participant_event.travels.create!(direction: "inbound", mode: "car",
+        origin_address: "12 Langley Road, Hampton VA")
+    end
+
+    def show_payload
+      get api_v1_event_participant_path(event_id: event.slug, id: participant_event.id),
+        headers: { "Authorization" => "Bearer #{token.token}" }
+      expect(response).to have_http_status(:ok)
+      JSON.parse(response.body)["participant"]
+    end
+
+    it "serves the payload with age but no date of birth or address" do
+      personal = show_payload["personal"]
+
+      expect(personal["age"]).to be_present
+      expect(personal).not_to have_key("date_of_birth")
+      expect(personal).not_to have_key("address")
+    end
+
+    it "omits the travel pickup address" do
+      travel = show_payload["travel_inbound"]
+
+      expect(travel["mode"]).to eq("car")
+      expect(travel).not_to have_key("origin_address")
+    end
+
+    it "leaves both in place for ops" do
+      ops = User.create!(email: "ops-api@example.com", name: "Ops")
+      EventRoleAssignment.create!(user: ops, event: event, role: "ops")
+      ops_token = MobileToken.generate_for(ops)
+
+      get api_v1_event_participant_path(event_id: event.slug, id: participant_event.id),
+        headers: { "Authorization" => "Bearer #{ops_token.token}" }
+
+      payload = JSON.parse(response.body)["participant"]
+      expect(payload["personal"]["date_of_birth"]).to eq("2009-03-14")
+      expect(payload["travel_inbound"]["origin_address"]).to eq("12 Langley Road, Hampton VA")
+    end
+
+    it "still refuses read_only entirely, with a 403 rather than a 500" do
+      read_only = User.create!(email: "readonly-api@example.com", name: "Read Only")
+      EventRoleAssignment.create!(user: read_only, event: event, role: "read_only")
+
+      get api_v1_event_participants_path(event_id: event.slug),
+        headers: { "Authorization" => "Bearer #{MobileToken.generate_for(read_only).token}" }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "the events API" do
+    it "reports the role and the PII capability so the app can adapt up front" do
+      EventRoleAssignment.create!(user: (u = User.create!(email: "limited-events@example.com", name: "L")),
+        event: event, role: "limited")
+
+      get api_v1_events_path, headers: { "Authorization" => "Bearer #{MobileToken.generate_for(u).token}" }
+
+      expect(response).to have_http_status(:ok)
+      payload = JSON.parse(response.body)["events"].find { |e| e["id"] == event.id }
+      expect(payload["role"]).to eq("limited")
+      expect(payload["can_view_participant_pii"]).to be(false)
+    end
+
+    it "reports the widest role when someone holds several, and restores PII" do
+      u = User.create!(email: "multi-events@example.com", name: "M")
+      EventRoleAssignment.create!(user: u, event: event, role: "limited")
+      EventRoleAssignment.create!(user: u, event: event, role: "event_admin")
+
+      get api_v1_events_path, headers: { "Authorization" => "Bearer #{MobileToken.generate_for(u).token}" }
+
+      payload = JSON.parse(response.body)["events"].find { |e| e["id"] == event.id }
+      expect(payload["role"]).to eq("event_admin")
+      expect(payload["can_view_participant_pii"]).to be(true)
+    end
+
+    # Series membership outranks a stored role, so someone who is Limited on the
+    # event but also a series member gets the full view and is labelled as such.
+    # (An index quirk keeps series-only members out of this list entirely — see
+    # EventsController#index, which uses assigned_events rather than the scope
+    # EventPolicy uses.)
+    it "labels inherited access without pretending it is a stored role" do
+      series = create(:event_series)
+      event.update!(event_series: series)
+      u = User.create!(email: "series-events@example.com", name: "S")
+      EventRoleAssignment.create!(user: u, event: event, role: "limited")
+      SeriesRoleAssignment.create!(user: u, event_series: series, role: "organizer")
+
+      get api_v1_events_path, headers: { "Authorization" => "Bearer #{MobileToken.generate_for(u).token}" }
+
+      payload = JSON.parse(response.body)["events"].find { |e| e["id"] == event.id }
+      expect(payload["role"]).to eq("series_member")
+      expect(payload["can_view_participant_pii"]).to be(true)
+    end
+  end
+end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Events", type: :request do
+  let(:user) { User.create!(email: "events-api@example.com", name: "Staff") }
+  let(:headers) { { "Authorization" => "Bearer #{MobileToken.generate_for(user).token}" } }
+
+  def count_queries
+    count = 0
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      count += 1 unless payload[:name].to_s.match?(/SCHEMA|TRANSACTION/)
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
+  # The mobile app hits this on launch, and it now resolves a role and a PII
+  # capability per event. Both come from plucks memoized for the whole request,
+  # and the logo/banner attachments are preloaded, so the cost must stay flat.
+  it "costs the same number of queries however many events the user has" do
+    4.times { |i| EventRoleAssignment.create!(user: user, event: create(:event), role: i.zero? ? "limited" : "ops") }
+    get api_v1_events_path, headers: headers
+    expect(response).to have_http_status(:ok)
+    baseline = count_queries { get api_v1_events_path, headers: headers }
+
+    8.times { EventRoleAssignment.create!(user: user, event: create(:event), role: "ops") }
+    grown = count_queries { get api_v1_events_path, headers: headers }
+
+    expect(JSON.parse(response.body)["events"].size).to eq(12)
+    expect(grown).to eq(baseline)
+  end
+end


### PR DESCRIPTION
Some staff need the roster, travel, and rooming without needing to know where
a participant lives or the day they were born. Limited is a fifth event role
with Ops' permissions minus both: age is shown in place of the date of birth,
and every address is withheld — the home address and the travel pickup
address, which for a car journey is the participant's doorstep.

Medical records are deliberately not restricted. Conditions, medications, and
the emergency action plan are exactly what the role needs during an incident,
so MedicalPolicy#show_full_details? includes it alongside safeguarding leads.

User#can_view_participant_pii? is the single gate, false only when every role
a user holds in scope is PII-restricted, and it fails closed for a user with
no roles. Adding a future role to EventRoleAssignment::PII_RESTRICTED_ROLES
carries it to every surface: the profile, table, edit and travel forms and
their strong params, the change history (a PaperTrail changeset leaks a field
just as well as the field does), CSV exports, the rooming sheet, both travel
calendars, and MCP.

The mobile API redacts rather than refuses, so the app keeps working: the
restricted keys are omitted rather than nulled, so a client can tell "not
permitted" from "not on file", and age is always served. GET /api/v1/events
now reports role and can_view_participant_pii per event so the app can adapt
its UI up front instead of discovering restrictions through errors. read_only
still gets nothing there, now as a 403 rather than an unrescued Pundit 500.

Travel calendar redaction happens on the way out of JourneyCache rather than
in JourneyBuilder, so one cached entry still serves every role, and it builds
new hashes because a memory_store hands back the objects it holds.

Two things found along the way: the events endpoint the app calls on launch
cost two ActiveStorage queries per event, now flat; and text-teal-800 had no
dark-theme override, so the new role badge was unreadable until the teal
family was completed. The Event Staff role legend now reads from ROLE_DETAILS
instead of hand-written copy that would have silently omitted the new role.
