### PR TITLE
Stop claiming signed-in people have no account

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -88,7 +88,15 @@ module Admin
     UNLINKED_PARTICIPANT_LIMIT = 25
 
     def unlinked_participants_matching(term)
+      # `user_id` only gets filled in when someone runs through onboarding, so a
+      # null there doesn't mean "no account" — the person may well have signed
+      # in and be listed in the table above. Match on the email instead, or the
+      # panel ends up telling admins nobody signed in right below the account
+      # that did.
       Participant.where(user_id: nil)
+        .where.not(
+          "EXISTS (SELECT 1 FROM users WHERE LOWER(users.email) = LOWER(participants.email))"
+        )
         .where(
           "email ILIKE :term OR preferred_name ILIKE :term " \
           "OR CONCAT(legal_first_name, ' ', legal_last_name) ILIKE :term",

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe "Admin::Users", type: :request do
       expect(response.body).not_to include("Participants without an account")
     end
 
+    it "does not list participants whose account exists but was never linked" do
+      # Signing in creates the User; `participant.user_id` only gets filled in
+      # once they start onboarding, so the two can co-exist unlinked.
+      User.create!(email: "afnan@example.com", name: "Afnan")
+      participant = create(:participant, user: nil, email: "Afnan@example.com")
+      create(:participant_event, participant: participant)
+
+      sign_in global_admin
+      get admin_users_path(search: "afnan@example.com")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Participants without an account")
+    end
+
     it "skips the participant fallthrough when filtering by role" do
       create(:participant, user: nil, email: "roleless@example.com")
 


### PR DESCRIPTION
The user search's "Participants without an account" panel treated a null participants.user_id as proof that nobody had signed in, but that column only gets filled in once someone starts onboarding for an event. Signing in alone just creates the User row, so a person could appear in both tables at once — with the panel insisting there was no account to show directly beneath their account.

Check for a User with the same email instead of trusting the link.