### PR TITLE
Show registrations held by an unlinked participant record

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -19,11 +19,13 @@ module Admin
       @total_pages = [ (@total_count.to_f / @per_page).ceil, 1 ].max
       @page = (params[:page] || 1).to_i.clamp(1, @total_pages)
 
-      @users = scope.includes(:event_role_assignments, participant: :participant_events)
+      @users = scope.includes(:event_role_assignments)
         .with_attached_avatar
         .order(:email)
         .offset((@page - 1) * @per_page)
         .limit(@per_page)
+
+      @participant_records_by_user = participant_records_by_user(@users)
 
       # Someone who has never signed in has no User row at all, so a search by
       # their address comes back empty even though Attend knows exactly who
@@ -41,7 +43,7 @@ module Admin
 
     def show
       @event_role_assignments = @user.event_role_assignments.includes(:event).order("events.starts_at DESC")
-      @participant_events = @user.participant&.participant_events&.includes(:event)&.order("events.starts_at DESC") || []
+      load_participant_events
       @passports = @user.passports.includes(:paired_by, :revoked_by).order(created_at: :desc)
     end
 
@@ -61,7 +63,7 @@ module Admin
 
     def edit
       @event_role_assignments = @user.event_role_assignments.includes(:event).order("events.starts_at DESC")
-      @participant_events = @user.participant&.participant_events&.includes(:event)&.order("events.starts_at DESC") || []
+      load_participant_events
     end
 
     def update
@@ -83,6 +85,35 @@ module Admin
 
     def search_like(term)
       "%#{ActiveRecord::Base.sanitize_sql_like(term)}%"
+    end
+
+    def load_participant_events
+      @participant_records = @user.participant_records.includes(participant_events: :event).to_a
+      @participant_events = @participant_records
+        .flat_map(&:participant_events)
+        .select(&:event)
+        .sort_by { |pe| pe.event.starts_at || Time.at(0) }
+        .reverse
+    end
+
+    # One query for the whole page rather than one per row. Registrations are
+    # matched by email as well as by the account link (see
+    # User#participant_records), which no association can eager-load.
+    def participant_records_by_user(users)
+      users = users.to_a
+      return {} if users.empty?
+
+      emails = users.filter_map { |user| user.email&.downcase }.uniq
+      records = Participant
+        .where(user_id: users.map(&:id))
+        .or(Participant.where("LOWER(participants.email) IN (?)", emails))
+        .includes(participant_events: :event)
+        .to_a
+
+      users.to_h do |user|
+        email = user.email&.downcase
+        [ user.id, records.select { |p| p.user_id == user.id || (email.present? && p.email&.downcase == email) } ]
+      end
     end
 
     UNLINKED_PARTICIPANT_LIMIT = 25

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,20 @@ class User < ApplicationRecord
     global_role == "global_admin"
   end
 
+  # Every Participant row that is this person, not just the one `participant`
+  # points at. `participants.user_id` is only filled in when someone runs
+  # through onboarding, so an imported row keeps a null there — and when an
+  # admin later corrects a typo'd import address, the registrations end up on
+  # one row while the shell built at first sign-in holds the account link.
+  # Matching on the address as well is what stops admin pages reporting that an
+  # account has never registered for anything.
+  def participant_records
+    scope = Participant.where(user_id: id)
+    return scope if email.blank?
+
+    scope.or(Participant.where("LOWER(participants.email) = ?", email.downcase))
+  end
+
   def role_for_event(event)
     event_role_assignments.find_by(event: event)&.role
   end

--- a/app/services/duplicate_participant_scan.rb
+++ b/app/services/duplicate_participant_scan.rb
@@ -1,0 +1,103 @@
+# Finds humans who ended up with more than one Participant row under the same
+# email address, and works out which row should survive a merge.
+#
+# The usual cause: an import lands under a typo'd address, the person signs in
+# with their real one and gets a fresh row, and an admin corrects the imported
+# row's email afterwards — leaving the registrations on one row and the account
+# link on another. See ParticipantMergeService for what merging actually moves.
+#
+# Nothing here writes. `groups` returns Group structs; the caller decides what
+# to merge, and `Group#flags` says which pairs a human needs to look at first.
+class DuplicateParticipantScan
+  # A shared address is not proof of a shared identity — a parent's address on
+  # two children's imported rows looks exactly like one person registering
+  # twice. These are the signals that say "ask someone before merging".
+  Group = Struct.new(:email, :rows, :primary, :flags, keyword_init: true) do
+    def duplicates
+      rows - [ primary ]
+    end
+
+    def safe?
+      flags.empty?
+    end
+  end
+
+  # Onboarding writes this when OIDC claims are missing a name.
+  PLACEHOLDER = "Unknown"
+
+  def initialize(emails: nil)
+    @emails = emails&.map { |email| email.to_s.downcase.strip }&.reject(&:empty?)
+  end
+
+  def groups
+    duplicate_emails.map { |email| build_group(email) }
+  end
+
+  def duplicate_emails
+    scope = Participant.group("LOWER(email)").having("COUNT(*) > 1")
+    found = scope.count.keys.map { |email| email.to_s.downcase }.sort
+    return found if emails.nil?
+
+    found & emails
+  end
+
+  # Addresses the caller asked about that aren't actually duplicated (already
+  # merged, or a typo in the list).
+  def missing_emails
+    return [] if emails.nil?
+
+    emails - duplicate_emails
+  end
+
+  private
+
+  attr_reader :emails
+
+  def build_group(email)
+    rows = Participant.where("LOWER(email) = ?", email).order(:created_at).to_a
+    primary = pick_primary(rows)
+    Group.new(email: email, rows: rows, primary: primary, flags: flags_for(rows, primary))
+  end
+
+  # Keep the row the sign-in account already points at — that is the one the
+  # person's dashboard follows. Among several, keep whichever already holds the
+  # most registrations, so a merge moves as little as possible; ties go to the
+  # oldest row.
+  def pick_primary(rows)
+    linked = rows.select { |row| row.user_id.present? }
+    pool = linked.any? ? linked : rows
+    pool.max_by { |row| [ row.participant_events.count, -row.created_at.to_f ] }
+  end
+
+  def flags_for(rows, primary)
+    flags = []
+    flags << "name mismatch" unless names_agree?(rows)
+    flags << "date of birth mismatch" if rows.filter_map(&:date_of_birth).uniq.size > 1
+    flags << "linked to different accounts" if rows.filter_map(&:user_id).uniq.size > 1
+
+    # ParticipantMergeService doesn't carry public-profile fields across, so
+    # merging away the row that owns an enabled profile would silently delete
+    # someone's /p/ page and free up their slug.
+    if (rows - [ primary ]).any?(&:public_profile_enabled?) && !primary.public_profile_enabled?
+      flags << "duplicate owns the public profile"
+    end
+
+    flags
+  end
+
+  # Legal names are entered by hand on both sides — imports, OIDC claims and
+  # admins all disagree about spacing, case and which name is the "first" one.
+  # Agreement on the normalised full name, or on the first name alone, is enough
+  # to call it one person; anything else gets flagged for review.
+  def names_agree?(rows)
+    full = rows.map { |row| normalise([ row.legal_first_name, row.legal_last_name ].join(" ")) }
+    return true if full.uniq.size == 1
+
+    firsts = rows.map { |row| normalise(row.legal_first_name) }.reject { |name| name.empty? || name == normalise(PLACEHOLDER) }
+    firsts.any? && firsts.uniq.size == 1
+  end
+
+  def normalise(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]/, " ").squish
+  end
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -58,9 +58,13 @@
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
               <%= pluralize(user.event_role_assignments.size, "role") %>
-              <% attendee_event_count = user.participant&.participant_events&.size.to_i %>
+              <% records = @participant_records_by_user[user.id] || [] %>
+              <% attendee_event_count = records.sum { |record| record.participant_events.size } %>
               <% if attendee_event_count > 0 %>
                 <div class="text-xs text-gray-400">Attendee at <%= pluralize(attendee_event_count, "event") %></div>
+              <% end %>
+              <% if records.any? { |record| record.user_id != user.id } %>
+                <div class="text-xs text-amber-600">Unlinked participant record</div>
               <% end %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -223,8 +223,18 @@
         <tbody class="bg-white divide-y divide-gray-100">
           <% @participant_events.each do |pe| %>
             <tr>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+              <td class="px-6 py-4 text-sm text-gray-900">
                 <%= link_to pe.event.name, admin_event_participant_path(pe.event, pe), class: "text-[#ec3750] hover:text-blue-900" %>
+                <% if pe.participant.user_id != @user.id %>
+                  <div class="text-xs text-amber-600 mt-1">
+                    On a participant record that isn't linked to this account
+                    (<%= pe.participant.email %>) &mdash; their dashboard follows the
+                    linked record, not this one.
+                    <% if @user.participant %>
+                      <%= link_to "Merge the records", merge_admin_event_participant_path(pe.event, pe, duplicate_id: @user.participant.id), class: "underline" %>
+                    <% end %>
+                  </div>
+                <% end %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 <%= pe.status.titleize %>

--- a/lib/tasks/cleanup_duplicate_participants.rake
+++ b/lib/tasks/cleanup_duplicate_participants.rake
@@ -1,57 +1,82 @@
 namespace :participants do
-  desc "Find and merge duplicate participants by email"
+  desc "Report participants sharing an email address. APPLY=1 merges the unambiguous ones; " \
+       "EMAILS=a@b.com,c@d.com merges exactly that reviewed list, flags and all"
   task deduplicate: :environment do
-    puts "Finding duplicate participants by email..."
+    apply = ENV["APPLY"] == "1"
+    requested = ENV["EMAILS"]&.split(",")
+    scan = DuplicateParticipantScan.new(emails: requested)
+    groups = scan.groups
 
-    duplicates = Participant
-      .select("LOWER(email) as lower_email")
-      .group("LOWER(email)")
-      .having("COUNT(*) > 1")
-      .pluck(Arel.sql("LOWER(email)"))
-
-    if duplicates.empty?
-      puts "No duplicate participants found."
-      exit
+    puts apply ? "MODE: APPLY — merges will be written" : "MODE: dry run (re-run with APPLY=1 to merge)"
+    puts "Addresses with more than one participant row: #{groups.size}"
+    if scan.missing_emails.any?
+      puts "Not duplicated (already merged, or mistyped): #{scan.missing_emails.join(', ')}"
+    end
+    if groups.empty?
+      puts "Nothing to do."
+      next
     end
 
-    puts "Found #{duplicates.count} emails with duplicate participants.\n\n"
+    # Without an explicit list, only unambiguous groups are merged: a shared
+    # address alone doesn't prove a shared identity, and the flagged cases are
+    # the ones where merging the wrong pair would fuse two people's medical and
+    # waiver data. Reviewed groups go through EMAILS=.
+    reviewed = requested.present?
+    merged_rows = 0
+    skipped = []
+    failures = []
+    participants_before = Participant.count
+    events_before = ParticipantEvent.count
 
-    duplicates.each do |email|
-      participants = Participant.where("LOWER(email) = ?", email).order(:created_at).to_a
-      puts "=" * 60
-      puts "Email: #{email}"
-      puts "Found #{participants.count} duplicates:"
+    groups.each do |group|
+      puts "\n#{'=' * 70}\n#{group.email}"
+      group.rows.each do |row|
+        events = row.participant_events.includes(:event).map { |pe| "#{pe.event.slug}:#{pe.status}" }
+        marker = row == group.primary ? "keep" : "dup "
+        puts "  #{marker} #{row.id} #{[ row.legal_first_name, row.legal_last_name ].join(' ').squish.inspect} " \
+             "dob=#{row.date_of_birth || '—'} account=#{row.user&.email || 'none'}"
+        puts "       registrations=#{events.presence&.join(', ') || 'none'}" \
+             "#{row.public_profile_enabled? ? " public_profile=/p/#{row.public_profile_slug}" : ''}"
+      end
+      puts "  FLAGS: #{group.flags.join(', ')}" if group.flags.any?
 
-      participants.each_with_index do |p, i|
-        pe_count = p.participant_events.count
-        status = p.participant_events.map { |pe| "#{pe.event.name}: #{pe.status}" }.join(", ")
-        has_user = p.user_id.present? ? "linked to user #{p.user_id}" : "no user"
-        puts "  #{i + 1}. ID: #{p.id} | #{p.full_name} | #{pe_count} events | #{has_user}"
-        puts "     Status: #{status}" if status.present?
-        puts "     Created: #{p.created_at}"
+      if apply && !group.safe? && !reviewed
+        skipped << group
+        puts "  SKIPPED — needs review. Merge it with: " \
+             "bin/rails participants:deduplicate APPLY=1 EMAILS=#{group.email}"
+        next
       end
 
-      # Determine the "primary" participant to keep:
-      # Prefer one linked to a user, then one with most participant_events, then most recent
-      primary = participants.find { |p| p.user_id.present? } ||
-                participants.max_by { |p| [ p.participant_events.count, p.created_at ] }
-
-      duplicates_to_merge = participants - [ primary ]
-
-      puts "\n  → Keeping: #{primary.id} (#{primary.full_name})"
-      puts "  → Merging #{duplicates_to_merge.count} duplicate(s) into primary\n\n"
-
-      ActiveRecord::Base.transaction do
-        duplicates_to_merge.each do |dup|
-          ParticipantMergeService.new(primary: primary, duplicate: dup).merge!.each do |action|
-            puts "    #{action}"
-          end
-          puts "    Deleted duplicate #{dup.id}"
-        end
+      group.duplicates.each do |duplicate|
+        service = ParticipantMergeService.new(primary: group.primary, duplicate: duplicate)
+        actions = apply ? service.merge! : service.preview
+        puts "  #{apply ? 'MERGED' : 'would merge'} #{duplicate.id}:"
+        actions.each { |action| puts "        - #{action}" }
+        puts "        - empty row, deleted with nothing to transfer" if actions.empty?
+        merged_rows += 1
+      rescue ActiveRecord::RecordInvalid, ParticipantMergeService::Error => e
+        # Each merge is its own transaction, so a failure here leaves that pair
+        # untouched and the rest of the run still lands.
+        puts "  FAILED #{duplicate.id} — nothing changed for this pair: #{e.class}: #{e.message}"
+        failures << [ group.email, duplicate.id, "#{e.class}: #{e.message}" ]
       end
     end
 
-    puts "\n" + "=" * 60
-    puts "Deduplication complete!"
+    puts "\n#{'=' * 70}"
+    puts "#{apply ? 'Merged' : 'Would merge'} #{merged_rows} duplicate row(s)"
+    if apply
+      puts "Participants: #{participants_before} -> #{Participant.count}"
+      puts "Registrations: #{events_before} -> #{ParticipantEvent.count}"
+      puts "Addresses still duplicated: #{DuplicateParticipantScan.new.duplicate_emails.size}"
+    end
+    if skipped.any?
+      puts "\nSkipped, needing review (#{skipped.size}):"
+      skipped.each { |group| puts "  #{group.email} — #{group.flags.join(', ')}" }
+      puts "Review them, then re-run with EMAILS=#{skipped.map(&:email).join(',')}"
+    end
+    if failures.any?
+      puts "\nFailed (#{failures.size}) — nothing was written for these:"
+      failures.each { |email, id, message| puts "  #{email} #{id}: #{message}" }
+    end
   end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -20,6 +20,37 @@ RSpec.describe "Admin::Users", type: :request do
       expect(response.body).to include("Attendee at 1 event")
     end
 
+    it "counts registrations held by a participant record with no account link" do
+      # The shape a corrected import typo leaves behind: the person signed in
+      # and got a bare participant row, while every registration sits on the
+      # imported row whose email an admin fixed after the fact.
+      event = create(:event)
+      user = User.create!(email: "afnan@example.com", name: "Afnan")
+      create(:participant, user: user, email: user.email)
+      imported = create(:participant, user: nil, email: "Afnan@example.com")
+      create(:participant_event, participant: imported, event: event, status: "invited")
+
+      sign_in global_admin
+      get admin_users_path(search: "afnan@example.com")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Attendee at 1 event")
+      expect(response.body).to include("Unlinked participant record")
+    end
+
+    it "counts each registration once when the record is both linked and email-matched" do
+      event = create(:event)
+      user = User.create!(email: "single@example.com", name: "Single")
+      participant = create(:participant, user: user, email: user.email)
+      create(:participant_event, participant: participant, event: event, status: "complete")
+
+      sign_in global_admin
+      get admin_users_path(search: "single@example.com")
+
+      expect(response.body).to include("Attendee at 1 event")
+      expect(response.body).not_to include("Unlinked participant record")
+    end
+
     it "omits the attendee line for users with no participant record" do
       sign_in global_admin
       get admin_users_path(search: "ga-users@example.com")
@@ -100,6 +131,40 @@ RSpec.describe "Admin::Users", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("No user account matches")
       expect(response.body).not_to include("Participants without an account")
+    end
+  end
+
+  describe "GET show" do
+    it "lists registrations held by an unlinked participant record and offers the merge" do
+      event = create(:event, name: "Sunbeam Dhaka")
+      user = User.create!(email: "afnan@example.com", name: "Afnan")
+      shell = create(:participant, user: user, email: user.email)
+      imported = create(:participant, user: nil, email: "Afnan@example.com")
+      participant_event = create(:participant_event, participant: imported, event: event, status: "invited")
+
+      sign_in global_admin
+      get admin_user_path(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Sunbeam Dhaka")
+      expect(response.body).to include("isn't linked to this account")
+      expect(response.body).to include(
+        merge_admin_event_participant_path(event, participant_event, duplicate_id: shell.id)
+      )
+    end
+
+    it "does not flag registrations on the account's own participant record" do
+      event = create(:event, name: "Sunbeam Dallas")
+      user = User.create!(email: "own@example.com", name: "Own")
+      participant = create(:participant, user: user, email: user.email)
+      create(:participant_event, participant: participant, event: event, status: "complete")
+
+      sign_in global_admin
+      get admin_user_path(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Sunbeam Dallas")
+      expect(response.body).not_to include("isn't linked to this account")
     end
   end
 end

--- a/spec/services/duplicate_participant_scan_spec.rb
+++ b/spec/services/duplicate_participant_scan_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe DuplicateParticipantScan do
+  def participant(email:, user: nil, first: "Afnan", last: "Rahman", dob: "2009-07-17", **attrs)
+    create(:participant, email: email, user: user, legal_first_name: first, legal_last_name: last,
+           date_of_birth: dob, **attrs)
+  end
+
+  # Scans are scoped to the addresses each example creates: the shared test
+  # database carries rows from other runs whose factory-sequenced addresses
+  # collide, so a table-wide assertion here would be flaky.
+  def scan_for(*emails)
+    described_class.new(emails: emails)
+  end
+
+  it "ignores addresses held by a single participant" do
+    participant(email: "solo@example.com")
+
+    expect(scan_for("solo@example.com").duplicate_emails).to be_empty
+  end
+
+  it "matches duplicates regardless of the case the address was stored in" do
+    participant(email: "Afnan@example.com")
+    participant(email: "afnan@example.com")
+
+    expect(scan_for("afnan@example.com").duplicate_emails).to eq([ "afnan@example.com" ])
+  end
+
+  describe "picking the row to keep" do
+    it "keeps the row the sign-in account points at, even with no registrations" do
+      user = User.create!(email: "afnan@example.com", name: "Afnan")
+      shell = participant(email: user.email, user: user)
+      imported = participant(email: user.email)
+      create(:participant_event, participant: imported)
+
+      group = scan_for("afnan@example.com").groups.sole
+
+      expect(group.primary).to eq(shell)
+      expect(group.duplicates).to eq([ imported ])
+    end
+
+    it "prefers the linked row holding the most registrations when several are linked" do
+      user = User.create!(email: "afnan@example.com", name: "Afnan")
+      empty = participant(email: user.email, user: user)
+      registered = participant(email: user.email, user: user)
+      create(:participant_event, participant: registered)
+
+      group = scan_for("afnan@example.com").groups.sole
+
+      expect(group.primary).to eq(registered)
+      expect(group.duplicates).to eq([ empty ])
+    end
+
+    it "falls back to the most-registered row when no account is linked" do
+      bare = participant(email: "afnan@example.com")
+      registered = participant(email: "afnan@example.com")
+      create(:participant_event, participant: registered)
+
+      expect(scan_for("afnan@example.com").groups.sole.primary).to eq(registered)
+    end
+  end
+
+  describe "flags" do
+    it "treats spacing, case and swapped preferred names as the same person" do
+      participant(email: "afnan@example.com", first: "Afnan", last: "Rahman")
+      participant(email: "afnan@example.com", first: "afnan ", last: " rahman")
+
+      expect(scan_for("afnan@example.com").groups.sole).to be_safe
+    end
+
+    it "accepts a differing surname when the first name matches" do
+      participant(email: "jenin@example.com", first: "Julian", last: "Henin")
+      participant(email: "jenin@example.com", first: "Julian", last: "Jenin")
+
+      expect(scan_for("jenin@example.com").groups.sole.flags).to be_empty
+    end
+
+    it "flags rows whose names don't agree at all" do
+      participant(email: "family@example.com", first: "Hiba", last: "Malik")
+      participant(email: "family@example.com", first: "Hunain", last: "Malik")
+
+      expect(scan_for("family@example.com").groups.sole.flags).to include("name mismatch")
+    end
+
+    it "flags a differing date of birth" do
+      participant(email: "afnan@example.com", dob: "2009-07-17")
+      participant(email: "afnan@example.com", dob: "2009-06-05")
+
+      expect(scan_for("afnan@example.com").groups.sole.flags).to include("date of birth mismatch")
+    end
+
+    it "flags rows linked to two different accounts" do
+      one = User.create!(email: "afnan@example.com", name: "One")
+      two = User.create!(email: "afnan-alt@example.com", name: "Two")
+      participant(email: "afnan@example.com", user: one)
+      participant(email: "afnan@example.com", user: two)
+
+      expect(scan_for("afnan@example.com").groups.sole.flags).to include("linked to different accounts")
+    end
+
+    it "flags a duplicate that owns the public profile the merge would delete" do
+      user = User.create!(email: "afnan@example.com", name: "Afnan")
+      participant(email: user.email, user: user)
+      registered = participant(email: user.email, public_profile_enabled: true, public_profile_slug: "afnan")
+      create(:participant_event, participant: registered)
+
+      expect(scan_for("afnan@example.com").groups.sole.flags).to include("duplicate owns the public profile")
+    end
+
+    it "does not flag the profile when the surviving row owns it" do
+      user = User.create!(email: "afnan@example.com", name: "Afnan")
+      participant(email: user.email, user: user, public_profile_enabled: true, public_profile_slug: "afnan")
+      participant(email: user.email)
+
+      expect(scan_for("afnan@example.com").groups.sole.flags).to be_empty
+    end
+  end
+
+  describe "restricting to a reviewed list" do
+    it "scans only the addresses asked for and reports the rest" do
+      participant(email: "afnan@example.com")
+      participant(email: "afnan@example.com")
+      participant(email: "other@example.com")
+      participant(email: "other@example.com")
+
+      scan = described_class.new(emails: [ " Afnan@example.com ", "already-merged@example.com" ])
+
+      expect(scan.duplicate_emails).to eq([ "afnan@example.com" ])
+      expect(scan.groups.map(&:email)).to eq([ "afnan@example.com" ])
+      expect(scan.missing_emails).to eq([ "already-merged@example.com" ])
+    end
+  end
+end


### PR DESCRIPTION
`/admin/users` reported **0 events** for an account that plainly had a registration. The count wasn't wrong so much as looking at the wrong row — the person had two `Participant` records under one address:

| row | account link | registrations |
|---|---|---|
| the imported row | none | one event, invited |
| the row created at sign-in | the account | none |

From `paper_trail` on prod:

1. An import creates a participant under a mistyped address, plus the registration.
2. Hours later they sign in with their real address; onboarding's email lookup misses, so `build_participant` creates a second, empty row and links the account to that.
3. An admin corrects the imported row's address afterwards, until it matches.

Now both rows share an address, the registration hangs off the unlinked one, and anything keyed on `participants.user_id` sees nothing. The person's own dashboard follows the shell too, which is why prod carries `invited` ghosts sitting beside `complete` rows for the same human — they re-register instead of picking up the invite.

## Changes

**`User#participant_records`** resolves every row that is this person: linked by `user_id` **or** matching email. The admin index and show/edit pages use it, count each registration once, and say what they found — the index flags the unlinked record, and the attendance table explains that the dashboard follows the linked row, with a link into the existing merge tool prefilled with the shell as the duplicate.

**`participants:deduplicate`** was a footgun: it merged every participant sharing an email the moment it was invoked, no dry run, no way to look first. A shared address isn't proof of a shared identity — a parent's address on two children's imported rows looks identical to one person registering twice, and that pattern is real in this data. The scan moves into `DuplicateParticipantScan`, which picks the row to keep and flags what a human must decide: disagreeing names, differing birthdays, rows linked to two accounts, and a duplicate owning the public profile a merge would delete. The task reports by default; `APPLY=1` merges only unambiguous groups and prints the command for the rest; `EMAILS=a@b.com,c@d.com` merges exactly that reviewed list.

No auto-merging in the app itself, deliberately. HCA sign-in does tie an address to an account, but the code can't tell that pair apart from two siblings on one parent's address.

## Verification

- 25 examples across `spec/services/duplicate_participant_scan_spec.rb` and `spec/requests/admin/users_spec.rb`; `spec/services spec/requests/admin spec/models` green apart from one pre-existing local failure (`csv_import_service_spec.rb:195` asserts a table-wide `Participant.count` and trips over rows left in the shared test DB — unrelated, green on a clean database).
- Browser pass over the index, show and edit pages plus the merge tool it links to, light/dark and mobile/desktop.
- Rake task exercised in dev across all three shapes: dry run, `APPLY=1` skipping flagged groups, and `EMAILS=` merging a reviewed one.

