### PR TITLE
Add a "Need Help?" button to the homepage

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -73,6 +73,9 @@
                   Report an incident <span aria-hidden="true" class="ml-1 transition-transform group-hover:translate-x-0.5">→</span>
                 <% end %>
               </div>
+              <a href="mailto:attend@hackclub.com" class="group mt-4 inline-flex min-h-11 items-center rounded-lg border border-[#ec3750] px-4 py-2.5 text-sm font-bold text-[#ec3750] hover:bg-[#ec3750] hover:text-[var(--accent-on)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ec3750] transition-colors">
+                Need Help? <span aria-hidden="true" class="ml-2 transition-transform group-hover:translate-x-0.5">→</span>
+              </a>
             </div>
 
             <% if Rails.env.development? %>


### PR DESCRIPTION
The non-staff section on the homepage pointed people to the guardian portal and incident reporting, but there was nowhere to go for anything else.

Adds a "Need Help?" button under those links that opens a mail draft to attend@hackclub.com. Styled as an outlined button rather than a third text link, so it reads as a distinct fallback door instead of blending into the two specific ones above it.

Verified visually at desktop and mobile widths.