### PR TITLE
Stop the concurrency specs leaking rows into the test database

### DIFF
--- a/spec/models/travel_leg_concurrency_spec.rb
+++ b/spec/models/travel_leg_concurrency_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "TravelLeg pickup concurrency", type: :model do
       departure_airport: "JFK",
       arrival_airport: "LHR"
     )
-    record_ids.concat([ event.id, participant.id, participant_event.id, travel.id, leg.id ])
+    record_ids.concat([ first_user.id, second_user.id, event.id, participant.id, participant_event.id, travel.id, leg.id ])
 
     first_has_lock = Queue.new
     release_first = Queue.new

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -181,22 +181,25 @@ RSpec.describe CsvImportService do
       end
 
       it "does not create associated records when data is missing" do
-        service.import(minimal_csv)
-
-        expect(Guardian.count).to eq(0)
-        expect(EmergencyContact.count).to eq(0)
-        expect(Dietary.count).to eq(0)
-        expect(Medical.count).to eq(0)
-        expect(Travel.count).to eq(0)
+        expect { service.import(minimal_csv) }
+          .to not_change(Guardian, :count)
+          .and not_change(EmergencyContact, :count)
+          .and not_change(Dietary, :count)
+          .and not_change(Medical, :count)
+          .and not_change(Travel, :count)
       end
     end
 
     context "with empty rows" do
       it "skips empty rows" do
-        result = service.import(empty_rows_csv)
+        result = nil
+
+        expect { result = service.import(empty_rows_csv) }
+          .to change(Participant, :count).by(2)
+          .and change(ParticipantEvent, :count).by(2)
 
         expect(result.imported_count).to eq(2)
-        expect(Participant.count).to eq(2)
+        expect(Participant.where(email: [ "valid@example.com", "another@example.com" ]).count).to eq(2)
       end
     end
 

--- a/spec/services/scan_recorder_spec.rb
+++ b/spec/services/scan_recorder_spec.rb
@@ -78,17 +78,24 @@ RSpec.describe ScanRecorder do
   end
 
   context "with concurrent attempts" do
+    # The racing threads each need their own connection, so the fixtures have to
+    # be visible outside the example's transaction: `before(:context)` commits
+    # them. Nothing rolls that back, so `after(:context)` has to delete every
+    # row (and every PaperTrail version) the setup created, or the leftovers
+    # survive into later runs and break other specs' table-wide counts.
     before(:context) do
       @concurrent_event = FactoryBot.create(:event, slug: "concurrent-scans-#{SecureRandom.hex(8)}")
       @concurrent_participant_event = FactoryBot.create(:participant_event, event: @concurrent_event)
+      @concurrent_participant = @concurrent_participant_event.participant
       @concurrent_context = @concurrent_participant_event.event.scan_contexts.find_by!(checks_in: true)
       @concurrent_user = FactoryBot.create(:user)
     end
 
     after(:context) do
-      @concurrent_participant_event.destroy!
-      @concurrent_event.destroy!
-      @concurrent_user.destroy!
+      records = [ @concurrent_participant_event, @concurrent_event, @concurrent_participant, @concurrent_user ]
+      record_ids = records.compact.map(&:id)
+      records.each(&:destroy!)
+      PaperTrail::Version.where(item_id: record_ids).delete_all
     end
 
     it "classifies exactly one attempt as the first scan" do


### PR DESCRIPTION
Two specs have to commit their fixtures so racing threads on separate connections can see them: ScanRecorder's "concurrent attempts" group uses before(:context), and the TravelLeg pickup spec turns off transactional tests. Nothing rolls those back, so whatever their teardown misses stays in the database forever.

ScanRecorder's after(:context) destroyed the participant_event, event and user but not the participant the factory built alongside them, so every run left one behind. Neither spec deleted the PaperTrail versions its committed writes generated. Locally the leftovers accumulate in the database shared across worktrees; CI starts clean, so it never noticed.

The cost lands on unrelated specs: the CSV import spec asserted table-wide counts, so its "skips empty rows" example failed with 12 participants instead of 2. Scope those assertions to what the example itself creates — count deltas and the fixture's own emails — so they stop depending on the rest of the database being empty.