### PR TITLE
Drop project-review claim from invitation emails

### DIFF
--- a/app/views/guardian_mailer/invitation.html.erb
+++ b/app/views/guardian_mailer/invitation.html.erb
@@ -1,6 +1,6 @@
 <p>Dear <%= @first_name %>,</p>
 
-<p>We're super excited to invite your child, <%= @child_first_name %> to Hack Club's <%= @event_name %>. We enjoyed reviewing their projects, and are happy to welcome them to <%= @location %> for a fun, engaging hackathon where they'll no doubt make new friends, and skills for life.</p>
+<p>We're super excited to invite your child, <%= @child_first_name %> to Hack Club's <%= @event_name %>. We're happy to welcome them to <%= @location %> for a fun, engaging hackathon where they'll no doubt make new friends, and skills for life.</p>
 
 <p style="margin: 24px 0;">
   <%= mail_button "Complete your child's onboarding", @portal_url %>

--- a/app/views/guardian_mailer/invitation.text.erb
+++ b/app/views/guardian_mailer/invitation.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @first_name %>,
 
-We're super excited to invite your child, <%= @child_first_name %> to Hack Club's <%= @event_name %>. We enjoyed reviewing their projects, and are happy to welcome them to <%= @location %> for a fun, engaging hackathon where they'll no doubt make new friends, and skills for life.
+We're super excited to invite your child, <%= @child_first_name %> to Hack Club's <%= @event_name %>. We're happy to welcome them to <%= @location %> for a fun, engaging hackathon where they'll no doubt make new friends, and skills for life.
 
 Complete your child's onboarding: <%= @portal_url %>
 

--- a/app/views/participant_mailer/invitation.html.erb
+++ b/app/views/participant_mailer/invitation.html.erb
@@ -1,6 +1,6 @@
 <p>Hi <%= @first_name %>!</p>
 
-<p>We're super excited to invite you to complete your onboarding materials for Hack Club's <%= @event_name %>. We enjoyed reviewing your projects, and now welcome you to <%= @location %> to join us for an amazing hackathon.</p>
+<p>We're super excited to invite you to complete your onboarding materials for Hack Club's <%= @event_name %>. We can't wait to welcome you to <%= @location %> for an amazing hackathon.</p>
 
 <p style="margin: 24px 0;">
   <%= mail_button "Complete your onboarding using Attend", @onboarding_url %>

--- a/app/views/participant_mailer/invitation.text.erb
+++ b/app/views/participant_mailer/invitation.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @first_name %>!
 
-We're super excited to invite you to complete your onboarding materials for Hack Club's <%= @event_name %>. We enjoyed reviewing your projects, and now welcome you to <%= @location %> to join us for an amazing hackathon.
+We're super excited to invite you to complete your onboarding materials for Hack Club's <%= @event_name %>. We can't wait to welcome you to <%= @location %> for an amazing hackathon.
 
 Complete your onboarding using Attend: <%= @onboarding_url %>
 


### PR DESCRIPTION
Not every event reviews projects before inviting participants, so the invitation emails shouldn't tell everyone we enjoyed reviewing theirs.

Removes that clause from both the participant and guardian invitation mailers (html + text variants), keeping the welcome-to-the-city sentence:

- participant: "...for Hack Club's {event}. We can't wait to welcome you to {location} for an amazing hackathon."
- guardian: "...to Hack Club's {event}. We're happy to welcome them to {location} for a fun, engaging hackathon..."

Copy-only change; no tests referenced the old wording.