### PR TITLE
Validate phone numbers strictly instead of only checking length

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -719,3 +719,12 @@
     }
   }
 }
+
+/* intl-tel-input wraps the field in a `.iti` div that is `display: inline-block`,
+ * so a `w-full` phone input collapses to the wrapper's shrink-to-fit width and
+ * ends up narrower than the fields beside it. The wrapper has to carry the
+ * width instead. Applies to every form using the `phone-input` controller. */
+.iti {
+  display: block;
+  width: 100%;
+}

--- a/app/controllers/admin/guardians_controller.rb
+++ b/app/controllers/admin/guardians_controller.rb
@@ -15,8 +15,8 @@ module Admin
 
       participant = @participant_event.participant
       if guardian_params[:phone].present? && participant.phone.present?
-        guardian_phone_parsed = Phonelib.parse(guardian_params[:phone])
-        if guardian_phone_parsed.valid? && guardian_phone_parsed.e164 == participant.phone
+        guardian_phone_e164 = PhoneNormalizer.normalize(guardian_params[:phone])
+        if guardian_phone_e164 && guardian_phone_e164 == participant.phone
           @guardian.errors.add(:phone, "cannot be the same as the participant's phone number")
           render :edit, status: :unprocessable_entity
           return

--- a/app/controllers/admin/search_controller.rb
+++ b/app/controllers/admin/search_controller.rb
@@ -83,8 +83,7 @@ module Admin
     def phone_query_e164(query)
       return unless query.delete(" ().-").match?(/\A\+?\d{7,15}\z/)
 
-      parsed = Phonelib.parse(query)
-      parsed.e164 if parsed.valid?
+      PhoneNormalizer.normalize(query)
     end
 
     def slack_id_query(query)

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -86,8 +86,10 @@ module Admin
       end
     end
 
+    # `default_country: nil` keeps this strict E.164 — an outbound sender
+    # number typed without a country code must be rejected, not guessed at.
     def valid_phone_number?(number)
-      number.present? && number.match?(/\A\+[1-9]\d{6,14}\z/)
+      PhoneNormalizer.valid?(number, default_country: nil)
     end
   end
 end

--- a/app/controllers/guardian_portal_center_controller.rb
+++ b/app/controllers/guardian_portal_center_controller.rb
@@ -165,10 +165,10 @@ class GuardianPortalCenterController < ApplicationController
 
       [ "email", input.downcase ]
     else
-      parsed = Phonelib.parse(input)
-      return nil unless parsed.valid?
+      e164 = PhoneNormalizer.normalize(input)
+      return nil unless e164
 
-      [ "phone", parsed.e164 ]
+      [ "phone", e164 ]
     end
   end
 

--- a/app/controllers/guardian_portal_controller.rb
+++ b/app/controllers/guardian_portal_controller.rb
@@ -520,8 +520,8 @@ class GuardianPortalController < ApplicationController
     when "details"
       details = step_params("details")
       if details[:phone].present? && @participant.phone.present?
-        guardian_phone_parsed = Phonelib.parse(details[:phone])
-        if guardian_phone_parsed.valid? && guardian_phone_parsed.e164 == @participant.phone
+        guardian_phone_e164 = PhoneNormalizer.normalize(details[:phone])
+        if guardian_phone_e164 && guardian_phone_e164 == @participant.phone
           @guardian.errors.add(:phone, "cannot be the same as the participant's phone number")
           return false
         end

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -545,8 +545,8 @@ class OnboardingController < ApplicationController
 
     # Skip autosave if guardian phone matches participant phone
     if guardian_attrs[:phone].present? && @participant_event.participant.phone.present?
-      guardian_phone_parsed = Phonelib.parse(guardian_attrs[:phone])
-      return if guardian_phone_parsed.valid? && guardian_phone_parsed.e164 == @participant_event.participant.phone
+      guardian_phone_e164 = PhoneNormalizer.normalize(guardian_attrs[:phone])
+      return if guardian_phone_e164 && guardian_phone_e164 == @participant_event.participant.phone
     end
 
     relationship = params[:guardian_relationship]
@@ -763,8 +763,8 @@ class OnboardingController < ApplicationController
 
     # Ensure guardian phone is not the same as the participant's phone
     if guardian_attrs[:phone].present? && @participant_event.participant.phone.present?
-      guardian_phone_parsed = Phonelib.parse(guardian_attrs[:phone])
-      if guardian_phone_parsed.valid? && guardian_phone_parsed.e164 == @participant_event.participant.phone
+      guardian_phone_e164 = PhoneNormalizer.normalize(guardian_attrs[:phone])
+      if guardian_phone_e164 && guardian_phone_e164 == @participant_event.participant.phone
         flash.now[:alert] = "Guardian phone number cannot be the same as the participant's phone number."
         return false
       end

--- a/app/javascript/controllers/phone_input_controller.js
+++ b/app/javascript/controllers/phone_input_controller.js
@@ -1,12 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
+const ITI_VERSION = "25.3.1"
+const ITI_BASE = `https://cdn.jsdelivr.net/npm/intl-tel-input@${ITI_VERSION}/build`
+
 export default class extends Controller {
   static targets = ["input"]
 
   connect() {
-    this.loadIntlTelInput().then(() => {
-      this.initializeInputs()
-    })
+    this.loadIntlTelInput()
+      .then(() => this.initializeInputs())
+      .catch(() => {
+        // The CDN is unreachable. Server-side validation still rejects bad
+        // numbers, so degrade to a plain text field rather than blocking.
+        console.warn("[phone-input] intl-tel-input failed to load; falling back to server validation")
+      })
   }
 
   // Injects the intl-tel-input CSS/JS on demand so pages without phone
@@ -18,14 +25,14 @@ export default class extends Controller {
     if (!document.querySelector("link[data-intl-tel-input]")) {
       const link = document.createElement("link")
       link.rel = "stylesheet"
-      link.href = "https://cdn.jsdelivr.net/npm/intl-tel-input@25.3.1/build/css/intlTelInput.css"
+      link.href = `${ITI_BASE}/css/intlTelInput.css`
       link.dataset.intlTelInput = "true"
       document.head.appendChild(link)
     }
 
     window._intlTelInputLoadPromise ||= new Promise((resolve, reject) => {
       const script = document.createElement("script")
-      script.src = "https://cdn.jsdelivr.net/npm/intl-tel-input@25.3.1/build/js/intlTelInput.min.js"
+      script.src = `${ITI_BASE}/js/intlTelInput.min.js`
       script.onload = resolve
       script.onerror = reject
       document.head.appendChild(script)
@@ -34,73 +41,225 @@ export default class extends Controller {
     return window._intlTelInputLoadPromise
   }
 
+  // Region subtag of the browser's locale ("en-AU" -> "au"), falling back to
+  // US to match the server's PhoneNormalizer::DEFAULT_COUNTRY.
+  localeCountry() {
+    const locales = navigator.languages?.length ? navigator.languages : [ navigator.language ]
+
+    for (const locale of locales) {
+      if (!locale) continue
+
+      try {
+        // `maximize()` fills in the likely region for a bare language tag,
+        // so "fr" resolves to FR rather than falling through to the default.
+        const parsed = new Intl.Locale(locale)
+        const region = parsed.region || parsed.maximize().region
+        if (region) return region.toLowerCase()
+      } catch {
+        // Malformed locale string; try the next one.
+      }
+    }
+
+    return "us"
+  }
+
+  get inputs() {
+    return this.hasInputTarget
+      ? this.inputTargets
+      : Array.from(this.element.querySelectorAll('input[type="tel"]'))
+  }
+
   initializeInputs() {
-    const inputs = this.hasInputTarget ? this.inputTargets : this.element.querySelectorAll('input[type="tel"]')
-    
-    inputs.forEach(input => {
+    this.inputs.forEach(input => {
       if (input.dataset.phoneInitialized) return
       if (!window.intlTelInput) return
 
       const iti = window.intlTelInput(input, {
-        initialCountry: "auto",
-        geoIpLookup: callback => {
-          fetch("https://ipapi.co/json")
-            .then(res => res.json())
-            .then(data => callback(data.country_code))
-            .catch(() => callback("us"))
-        },
+        // Was `initialCountry: "auto"` with a geoIpLookup against ipapi.co.
+        // That host is not in the CSP connect-src allowlist, so the fetch was
+        // blocked and the catch fell back to "us" for *everyone* — which is a
+        // direct cause of country-code-less numbers: someone abroad types their
+        // national number under a US flag and it is stored as +1<national>.
+        // The browser's own locale is a better guess, costs no request, and
+        // doesn't send a reporter's IP to a third party from the confidential
+        // incident-report form.
+        initialCountry: this.localeCountry(),
         countryOrder: ["us", "gb", "ca", "au", "de", "at"],
         separateDialCode: true,
         nationalMode: true,
+        // Explicit: intl-tel-input can restrict `isValidNumber()` to a set of
+        // number types, and a MOBILE-only setting rejects every landline. SMS
+        // matters, but a landline must still be storable — never narrow this.
+        validationNumberTypes: null,
+        // The dial code sits in its own chip, so any author-supplied E.164
+        // placeholder would read as a doubled country code ("+1  +1555…").
+        // Let the library show a national-format example for the country.
+        autoPlaceholder: "aggressive",
         formatOnDisplay: true,
         showFlags: true,
-        loadUtils: () => import("https://cdn.jsdelivr.net/npm/intl-tel-input@25.3.1/build/js/utils.js")
+        loadUtils: () => import(`${ITI_BASE}/js/utils.js`)
       })
 
-      // If user pastes/types a full international number, let the library parse it
-      input.addEventListener('input', () => {
-        const val = input.value.trim()
-        if (val.startsWith('+')) {
-          iti.setNumber(val)
-        }
-      })
+      input.iti = iti
+      // `isValidNumber()` needs utils; until they land it returns null and we
+      // must not treat that as "invalid" or we'd block every submission.
+      input.dataset.phoneUtilsReady = "false"
+      iti.promise
+        .then(() => { input.dataset.phoneUtilsReady = "true" })
+        .catch(() => { input.dataset.phoneUtilsReady = "false" })
 
-      // If input has an existing value (e.g., from server), parse it to set the country
-      // and display only the national number (without the dial code prefix)
-      // Wait for utils to load before parsing the number
+      // An existing server value is full E.164; hand it to the library so it
+      // selects the right country and shows just the national part.
       if (input.value) {
         const initialValue = input.value
-        iti.promise.then(() => {
-          iti.setNumber(initialValue)
-        })
+        iti.promise.then(() => iti.setNumber(initialValue)).catch(() => {})
       }
 
-      // Before form submission, replace input value with full E.164 number
-      const form = input.closest('form')
-      if (form && !form.dataset.phoneSubmitHandlerAttached) {
-        form.dataset.phoneSubmitHandlerAttached = 'true'
-        form.addEventListener('submit', () => {
-          // Update all phone inputs with their full international numbers
-          form.querySelectorAll('input[type="tel"]').forEach(telInput => {
-            if (telInput.iti && telInput.iti.isValidNumber()) {
-              telInput.value = telInput.iti.getNumber()
-            }
-          })
-        })
-      }
+      // Pasting a full international number should re-select the country.
+      input.addEventListener("paste", event => {
+        const pasted = (event.clipboardData || window.clipboardData)?.getData("text")?.trim()
+        if (!pasted || !pasted.startsWith("+")) return
 
+        event.preventDefault()
+        iti.setNumber(pasted)
+        this.clearError(input)
+      })
+
+      input.addEventListener("input", () => this.clearError(input))
+      input.addEventListener("blur", () => this.validateInput(input, { silent: false }))
+
+      this.attachSubmitHandler(input)
       input.dataset.phoneInitialized = "true"
-      input.iti = iti
     })
   }
 
+  attachSubmitHandler(input) {
+    const form = input.closest("form")
+    if (!form || form.dataset.phoneSubmitHandlerAttached) return
+
+    form.dataset.phoneSubmitHandlerAttached = "true"
+    form.addEventListener("submit", event => {
+      let firstInvalid = null
+
+      form.querySelectorAll('input[type="tel"]').forEach(telInput => {
+        if (!telInput.iti) return
+
+        const ok = this.validateInput(telInput, { silent: false })
+        if (!ok && !firstInvalid) firstInvalid = telInput
+        // Rewrite to E.164 whether or not the whole form submits: if it does
+        // go through, the server must never receive bare national digits.
+        this.writeE164(telInput)
+      })
+
+      if (firstInvalid) {
+        event.preventDefault()
+        event.stopPropagation()
+        firstInvalid.focus()
+      }
+    })
+  }
+
+  // Replaces the visible national-format value with the full E.164 number.
+  // `separateDialCode` keeps the dial code out of the field, so submitting the
+  // raw value is what produced country-code-less numbers like "0555550100".
+  writeE164(input) {
+    const iti = input.iti
+    if (!iti || !input.value.trim()) return
+
+    const number = iti.getNumber()
+    if (number && number.startsWith("+")) {
+      input.value = number
+      return
+    }
+
+    // Utils never loaded, so `getNumber()` can't build E.164. Prefix the
+    // selected country's dial code by hand rather than sending bare digits.
+    const dialCode = iti.getSelectedCountryData()?.dialCode
+    const digits = input.value.replace(/\D/g, "").replace(/^0+/, "")
+    if (dialCode && digits) input.value = `+${dialCode}${digits}`
+  }
+
+  // Returns true when the field may be submitted.
+  validateInput(input, { silent }) {
+    const iti = input.iti
+    if (!iti) return true
+
+    const filled = input.value.trim().length > 0
+    if (!filled) {
+      this.clearError(input)
+      return !input.required
+    }
+
+    // Without utils there is nothing trustworthy to check against; let the
+    // server be the gate instead of guessing.
+    if (input.dataset.phoneUtilsReady !== "true") {
+      this.clearError(input)
+      return true
+    }
+
+    if (this.looksDialable(iti)) {
+      this.clearError(input)
+      return true
+    }
+
+    if (!silent) this.showError(input, "Enter a valid phone number, including the country code.")
+    return false
+  }
+
+  // Mirrors the server's Phonelib `valid?` as closely as the browser allows.
+  //
+  // `isValidNumber()` alone is only a length check since intl-tel-input v24, so
+  // it happily accepts a national number that lost its country code (typing
+  // "0555550100" with the US flag selected yields "+10555550100"). Requiring a
+  // known number type closes that gap: libphonenumber can't classify a number
+  // that matches no real range, so those come back UNKNOWN (-1).
+  //
+  // `isValidNumberPrecise()` is NOT the answer here — it only accepts numbers
+  // typed as MOBILE, so it rejects every landline, and every US number, which
+  // libphonenumber classes as FIXED_LINE_OR_MOBILE.
+  looksDialable(iti) {
+    if (!iti.isValidNumber()) return false
+
+    return typeof iti.getNumberType === "function" ? iti.getNumberType() !== -1 : true
+  }
+
+  showError(input, message) {
+    input.setAttribute("aria-invalid", "true")
+    input.classList.add("border-red-500")
+
+    let error = this.errorElementFor(input)
+    if (!error) {
+      error = document.createElement("p")
+      error.dataset.phoneError = "true"
+      error.className = "mt-1 text-sm text-red-600"
+      error.setAttribute("role", "alert")
+      const container = input.closest(".iti") || input
+      container.insertAdjacentElement("afterend", error)
+    }
+    error.textContent = message
+  }
+
+  clearError(input) {
+    input.removeAttribute("aria-invalid")
+    input.classList.remove("border-red-500")
+    this.errorElementFor(input)?.remove()
+  }
+
+  errorElementFor(input) {
+    const container = input.closest(".iti") || input
+    const next = container.nextElementSibling
+    return next?.dataset?.phoneError ? next : null
+  }
+
   disconnect() {
-    const inputs = this.hasInputTarget ? this.inputTargets : this.element.querySelectorAll('input[type="tel"]')
-    inputs.forEach(input => {
+    this.inputs.forEach(input => {
+      this.clearError(input)
       if (input.iti) {
         input.iti.destroy()
         delete input.iti
       }
+      delete input.dataset.phoneInitialized
+      delete input.dataset.phoneUtilsReady
     })
   }
 }

--- a/app/jobs/process_import_batch_job.rb
+++ b/app/jobs/process_import_batch_job.rb
@@ -253,10 +253,15 @@ class ProcessImportBatchJob < ApplicationJob
     name = [ row[:emergency_first_name], row[:emergency_last_name] ].compact.join(" ")
     return if name.blank?
 
+    phone = normalize_phone(row[:emergency_phone])
+    if phone.nil? && row[:emergency_phone].present?
+      raise ArgumentError, "Emergency contact phone #{row[:emergency_phone].inspect} is not a valid phone number. Include the country code, for example +1 415 555 0132."
+    end
+
     EmergencyContact.create!(
       participant_event: participant_event,
       name: name,
-      phone: normalize_phone(row[:emergency_phone]),
+      phone: phone,
       email: row[:emergency_email].presence,
       relationship: row[:emergency_relationship].presence,
       priority: 1
@@ -404,11 +409,16 @@ class ProcessImportBatchJob < ApplicationJob
     "3xl" => "XXXL"
   }.freeze
 
+  # Returns E.164, or nil when the cell isn't a real number. See the matching
+  # note in CsvImportService: never fall back to the raw string.
   def normalize_phone(phone_str)
     return nil if phone_str.blank?
 
-    parsed = Phonelib.parse(phone_str)
-    parsed.valid? ? parsed.e164 : phone_str
+    normalized = PhoneNormalizer.normalize(phone_str)
+    if normalized.nil?
+      Rails.logger.warn("[ProcessImportBatchJob] Dropping unparseable phone number #{phone_str.inspect}")
+    end
+    normalized
   end
 
   def normalize_tshirt_size(size_str)

--- a/app/models/automated_sms_log.rb
+++ b/app/models/automated_sms_log.rb
@@ -1,9 +1,14 @@
 class AutomatedSmsLog < ApplicationRecord
+  include NormalizesPhoneNumbers
   self.implicit_order_column = "created_at"
 
   encrypts :body
 
   validates :phone_number, presence: true
+
+  # `for_phone` is an exact match against an E.164 number held elsewhere,
+  # so the stored value has to be canonical too.
+  normalizes_phone_number :phone_number
   validates :body, presence: true
   validates :sent_at, presence: true
 

--- a/app/models/concerns/normalizes_phone_numbers.rb
+++ b/app/models/concerns/normalizes_phone_numbers.rb
@@ -1,0 +1,23 @@
+# Rewrites phone attributes to E.164 before validation, so the database only
+# ever holds one canonical format. Deterministic encryption means an equality
+# lookup on `phone` never matches unless the stored format is canonical, so
+# this also keeps ticket-to-participant matching and admin search working.
+module NormalizesPhoneNumbers
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def normalizes_phone_number(*attributes, default_country: PhoneNormalizer::DEFAULT_COUNTRY)
+      before_validation do
+        attributes.each do |attribute|
+          raw = public_send(attribute)
+          next if raw.blank?
+
+          normalized = PhoneNormalizer.normalize(raw, default_country: default_country)
+          # Leave an unparseable value in place: the validator reports it back
+          # to the person who typed it instead of silently blanking the field.
+          public_send(:"#{attribute}=", normalized) if normalized
+        end
+      end
+    end
+  end
+end

--- a/app/models/emergency_contact.rb
+++ b/app/models/emergency_contact.rb
@@ -1,4 +1,5 @@
 class EmergencyContact < ApplicationRecord
+  include NormalizesPhoneNumbers
   has_paper_trail
 
   self.implicit_order_column = "created_at"
@@ -15,10 +16,10 @@ class EmergencyContact < ApplicationRecord
   has_one :guardian, through: :guardian_participant_event
 
   validates :name, presence: true
-  validates :phone, presence: true, phone: { possible: true }
+  validates :phone, presence: true, e164_phone: true
   validate :linked_to_guardian_or_participant
 
-  before_validation :normalize_phone
+  normalizes_phone_number :phone
 
   scope :by_priority, -> { order(priority: :asc) }
 
@@ -27,13 +28,6 @@ class EmergencyContact < ApplicationRecord
   end
 
   private
-
-  def normalize_phone
-    return if phone.blank?
-
-    parsed = Phonelib.parse(phone)
-    self.phone = parsed.e164 if parsed.valid?
-  end
 
   def linked_to_guardian_or_participant
     if guardian_participant_event_id.blank? && participant_event_id.blank?

--- a/app/models/guardian.rb
+++ b/app/models/guardian.rb
@@ -1,5 +1,6 @@
 class Guardian < ApplicationRecord
   include EmailDeliverability
+  include NormalizesPhoneNumbers
 
   has_paper_trail
 
@@ -16,25 +17,11 @@ class Guardian < ApplicationRecord
   validates :legal_first_name, presence: true
   validates :legal_last_name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :phone, phone: { possible: true, allow_blank: true }
+  validates :phone, e164_phone: true, allow_blank: true
 
-  before_validation :normalize_phone
+  normalizes_phone_number :phone
 
   def full_name
     "#{legal_first_name} #{legal_last_name}"
-  end
-
-  private
-
-  def normalize_phone
-    return if phone.blank?
-
-    if phone.start_with?("+")
-      parsed = Phonelib.parse(phone)
-      self.phone = parsed.e164 if parsed.valid?
-    else
-      parsed = Phonelib.parse(phone, nil)
-      self.phone = parsed.e164 if parsed.valid?
-    end
   end
 end

--- a/app/models/incident_report.rb
+++ b/app/models/incident_report.rb
@@ -1,4 +1,5 @@
 class IncidentReport < ApplicationRecord
+  include NormalizesPhoneNumbers
   has_paper_trail skip: [ :summary, :details ]
 
   self.implicit_order_column = "created_at"
@@ -43,7 +44,11 @@ class IncidentReport < ApplicationRecord
 
   enum :status, { open: "open", in_review: "in_review", resolved: "resolved" }
 
+  normalizes_phone_number :reporter_phone
+
   validates :reporter_name, :reporter_email, :reporter_phone, presence: true
+  # A safety report we can't call back on is close to useless.
+  validates :reporter_phone, e164_phone: true, allow_blank: true
   validates :reporter_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   validates :reporter_role, presence: true, inclusion: { in: ROLES.keys }
   validates :incident_type, presence: true, inclusion: { in: INCIDENT_TYPES.keys }

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -3,6 +3,7 @@ class Participant < ApplicationRecord
   include DecodableImageAttachment
   include TravelCalendarCacheInvalidatable
   include EmailDeliverability
+  include NormalizesPhoneNumbers
 
   has_paper_trail
 
@@ -44,7 +45,7 @@ class Participant < ApplicationRecord
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :date_of_birth, presence: true, on: :onboarding
   validates :headshot, presence: true, on: :onboarding
-  validates :phone, phone: { possible: true, allow_blank: true }
+  validates :phone, e164_phone: true, allow_blank: true
   validate :headshot_content_type
   validates :public_profile_slug, presence: true, if: :public_profile_enabled?
   validates :public_profile_slug,
@@ -93,7 +94,7 @@ class Participant < ApplicationRecord
     value.presence
   }
 
-  before_validation :normalize_phone
+  normalizes_phone_number :phone
   before_validation :normalize_public_profile_slug
   before_validation :generate_public_profile_slug, if: -> { public_profile_enabled? && public_profile_slug.blank? }
   after_update_commit :touch_participant_events
@@ -249,18 +250,6 @@ class Participant < ApplicationRecord
     end
 
     self.public_profile_slug = candidate
-  end
-
-  def normalize_phone
-    return if phone.blank?
-
-    if phone.start_with?("+")
-      parsed = Phonelib.parse(phone)
-      self.phone = parsed.e164 if parsed.valid?
-    else
-      parsed = Phonelib.parse(phone, nil)
-      self.phone = parsed.e164 if parsed.valid?
-    end
   end
 
   def headshot_content_type

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,6 +1,8 @@
 class Ticket < ApplicationRecord
   class MergedTicketError < StandardError; end
 
+  include NormalizesPhoneNumbers
+
   include ActionView::RecordIdentifier
 
   has_paper_trail
@@ -32,6 +34,11 @@ class Ticket < ApplicationRecord
   }
 
   validates :phone_number, presence: true
+
+  # Participant#phone and Guardian#phone are deterministically encrypted, so
+  # subject matching is an exact-string comparison — both sides have to be
+  # E.164 or an inbound message never links to the person who sent it.
+  normalizes_phone_number :phone_number
   validates :channel, presence: true
   validates :status, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include NormalizesPhoneNumbers
   include DecodableImageAttachment
 
   self.implicit_order_column = "created_at"
@@ -24,6 +25,11 @@ class User < ApplicationRecord
   # the same treatment. Neither is queried by value, hence non-deterministic.
   encrypts :oidc_claims
   encrypts :phone_number
+
+  normalizes_phone_number :phone_number
+  # Guarded on `_changed?`: sign-in refreshes claims through `user.update`,
+  # and a pre-existing bad number must never block that.
+  validates :phone_number, e164_phone: true, allow_blank: true, if: :phone_number_changed?
 
   has_one_attached :avatar
 
@@ -251,7 +257,9 @@ class User < ApplicationRecord
   def backfill_contact_from_claims!
     updates = {}
     updates[:slack_user_id] = oidc_claims["slack_id"] if slack_user_id.blank? && oidc_claims["slack_id"].present?
-    updates[:phone_number] = oidc_claims["phone_number"] if phone_number.blank? && oidc_claims["phone_number"].present?
+    if phone_number.blank? && (claimed_phone = PhoneNormalizer.normalize(oidc_claims["phone_number"]))
+      updates[:phone_number] = claimed_phone
+    end
     return if updates.empty?
 
     # `update_columns` would bypass the encrypting type and write the phone

--- a/app/services/csv_import_service.rb
+++ b/app/services/csv_import_service.rb
@@ -298,10 +298,15 @@ class CsvImportService
     name = [ row[:emergency_first_name], row[:emergency_last_name] ].compact.join(" ")
     return if name.blank?
 
+    phone = normalize_phone(row[:emergency_phone])
+    if phone.nil? && row[:emergency_phone].present?
+      raise ArgumentError, "Emergency contact phone #{row[:emergency_phone].inspect} is not a valid phone number. Include the country code, for example +1 415 555 0132."
+    end
+
     EmergencyContact.create!(
       participant_event: participant_event,
       name: name,
-      phone: normalize_phone(row[:emergency_phone]),
+      phone: phone,
       email: row[:emergency_email].presence,
       relationship: row[:emergency_relationship].presence,
       priority: 1
@@ -446,16 +451,17 @@ class CsvImportService
     @errors << { email: participant.email, error: "Imported but failed to send invitation: #{e.message}" }
   end
 
+  # Returns E.164, or nil when the cell isn't a real number. It deliberately
+  # does NOT fall back to the raw string: that fallback is how values like
+  # "15555555" and "0555550100" got imported and then handed to Twilio.
   def normalize_phone(phone_str)
     return nil if phone_str.blank?
 
-    if phone_str.start_with?("+")
-      parsed = Phonelib.parse(phone_str)
-      parsed.valid? ? parsed.e164 : phone_str
-    else
-      parsed = Phonelib.parse(phone_str, nil)
-      parsed.valid? ? parsed.e164 : phone_str
+    normalized = PhoneNormalizer.normalize(phone_str)
+    if normalized.nil?
+      Rails.logger.warn("[CsvImportService] Dropping unparseable phone number #{phone_str.inspect}")
     end
+    normalized
   end
 
   def normalize_tshirt_size(size_str)

--- a/app/services/phone_normalizer.rb
+++ b/app/services/phone_normalizer.rb
@@ -1,14 +1,76 @@
+# Single source of truth for turning a user- or import-supplied phone number
+# into E.164. Every phone number entering the app should pass through here.
+#
+# The important rule is that a number must be *valid*, not merely *possible*.
+# Phonelib's `possible?` is only a length check, so "15555555", "0555550100"
+# and "+1 0555550100" all pass it while being undialable — which is exactly
+# how those numbers ended up in the database.
 class PhoneNormalizer
-  def self.normalize(raw)
-    return nil if raw.blank?
+  # A number typed without a country code is interpreted against this country.
+  # A national-format number from anywhere else overwhelmingly fails `valid?`
+  # and is rejected, rather than silently becoming a bogus US number.
+  DEFAULT_COUNTRY = "US"
 
-    stripped = raw.sub(/\Awhatsapp:/, "")
-    parsed = if stripped.start_with?("+")
-               Phonelib.parse(stripped)
-    else
-               Phonelib.parse(stripped, nil)
+  # Strips the channel prefixes Twilio puts on inbound addresses.
+  CHANNEL_PREFIX = /\A(?:whatsapp|sms|tel|messenger):/i
+
+  class << self
+    # The E.164 string, or nil when the input is not a real dialable number.
+    # Never returns the raw input — a caller that falls back to the raw string
+    # is how unparseable junk gets persisted.
+    def normalize(raw, default_country: DEFAULT_COUNTRY)
+      parsed = parse(raw, default_country: default_country)
+      return nil unless parsed&.valid?
+
+      parsed.e164
     end
 
-    parsed.valid? ? parsed.e164 : nil
+    def valid?(raw, default_country: DEFAULT_COUNTRY)
+      normalize(raw, default_country: default_country).present?
+    end
+
+    # The number as its own country writes it, for display only.
+    def national(raw, default_country: DEFAULT_COUNTRY)
+      parsed = parse(raw, default_country: default_country)
+      return raw.to_s if parsed.nil? || !parsed.valid?
+
+      parsed.national
+    end
+
+    # Two-letter country of the number, or nil if it doesn't resolve.
+    def country(raw, default_country: DEFAULT_COUNTRY)
+      parsed = parse(raw, default_country: default_country)
+      parsed&.valid? ? parsed.country : nil
+    end
+
+    def parse(raw, default_country: DEFAULT_COUNTRY)
+      cleaned = clean(raw)
+      return nil if cleaned.blank?
+
+      # An explicit country code always wins over the default, or "+44 7911
+      # 123456" gets re-read against DEFAULT_COUNTRY and comes out wrong.
+      return Phonelib.parse(cleaned, nil) if cleaned.start_with?("+")
+
+      # No country code and nothing to assume: refuse to guess.
+      return nil if default_country.blank?
+
+      Phonelib.parse(cleaned, default_country)
+    end
+
+    private
+
+    def clean(raw)
+      str = raw.to_s.strip
+      return "" if str.blank?
+
+      str = str.sub(CHANNEL_PREFIX, "").strip
+      # "00" is the international access prefix across most of the world;
+      # Phonelib only understands the "+" form.
+      str = str.sub(/\A00(?=\d)/, "+")
+      # A lone "+" or a string with no digits at all is never a number.
+      return "" unless str.match?(/\d/)
+
+      str
+    end
   end
 end

--- a/app/validators/e164_phone_validator.rb
+++ b/app/validators/e164_phone_validator.rb
@@ -1,0 +1,28 @@
+# Requires a real, dialable phone number.
+#
+# Named to avoid colliding with the `PhoneValidator` phonelib registers for
+# `validates :phone, phone: true`. That one was previously used here as
+# `phone: { possible: true }`, which only length-checks and let undialable
+# numbers through.
+#
+# Pair with `normalizes_phone_number` so the attribute is already E.164 by the
+# time this runs; anything still failing here is genuinely unparseable.
+class E164PhoneValidator < ActiveModel::EachValidator
+  MESSAGE = "is not a valid phone number. Include the country code, " \
+            "for example +1 415 555 0132.".freeze
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    return if PhoneNormalizer.valid?(value, default_country: default_country)
+
+    record.errors.add(attribute, options[:message] || MESSAGE)
+  end
+
+  private
+
+  # `default_country: nil` makes the attribute strict E.164 — a number with no
+  # country code is rejected instead of being read as a US number.
+  def default_country
+    options.fetch(:default_country, PhoneNormalizer::DEFAULT_COUNTRY)
+  end
+end

--- a/app/views/admin/emergency_contacts/_form.html.erb
+++ b/app/views/admin/emergency_contacts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @emergency_contact, url: form_url, method: form_method, local: true, class: "space-y-4" do |f| %>
+<%= form_with model: @emergency_contact, url: form_url, method: form_method, local: true, class: "space-y-4", data: { controller: "phone-input" } do |f| %>
   <% if @emergency_contact.errors.any? %>
     <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded">
       <ul class="list-disc list-inside">

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -293,7 +293,7 @@
 
         <div class="mt-4 border-2 border-dashed border-orange-400 rounded-lg p-4">
           <h3 class="text-sm font-semibold text-orange-700 mb-3">Link Guardian (Admin)</h3>
-          <%= form_with url: link_guardian_admin_event_participant_path(current_event, @participant_event), method: :post, local: true, class: "space-y-3" do |f| %>
+          <%= form_with url: link_guardian_admin_event_participant_path(current_event, @participant_event), method: :post, local: true, class: "space-y-3", data: { controller: "phone-input" } do |f| %>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <%= f.label :guardian_first_name, "First Name", class: "block text-xs font-medium text-gray-700 mb-1" %>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -87,7 +87,7 @@
           </p>
         </div>
         <div class="flex items-center gap-2">
-          <%= form_with url: update_twilio_from_number_admin_settings_path, method: :post, class: "flex items-center gap-2" do |f| %>
+          <%= form_with url: update_twilio_from_number_admin_settings_path, method: :post, class: "flex items-center gap-2", data: { controller: "phone-input" } do |f| %>
             <%= f.telephone_field :twilio_from_number,
                   value: @twilio_from_number,
                   placeholder: "+1234567890",

--- a/app/views/dashboard/profile.html.erb
+++ b/app/views/dashboard/profile.html.erb
@@ -330,7 +330,7 @@
             How you appear to other organizers — on comments, audit logs, and other admin activity — and how Attend reaches you for incidents.
           </p>
           <div class="mt-4 overflow-hidden rounded-2xl border border-(--border-card) bg-(--bg-elev)">
-            <%= form_with model: current_user, url: dashboard_staff_profile_path, method: :patch, class: "px-6 py-5 space-y-5", data: { controller: "avatar-preview" } do |f| %>
+            <%= form_with model: current_user, url: dashboard_staff_profile_path, method: :patch, class: "px-6 py-5 space-y-5", data: { controller: "avatar-preview phone-input" } do |f| %>
               <div class="flex items-center gap-5">
                 <div class="relative shrink-0" data-avatar-preview-target="container">
                   <% if current_user.avatar_displayable? %>

--- a/app/views/incident_reports/new.html.erb
+++ b/app/views/incident_reports/new.html.erb
@@ -41,7 +41,7 @@
 
   <%= form_with model: @incident_report, url: incident_report_path, method: :post,
         html: { multipart: true, novalidate: false },
-        data: { incident_report_target: "form" } do |f| %>
+        data: { incident_report_target: "form", controller: "phone-input" } do |f| %>
 
     <% if @incident_report.errors.any? %>
       <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">

--- a/lib/tasks/audit_phone_numbers.rake
+++ b/lib/tasks/audit_phone_numbers.rake
@@ -1,0 +1,77 @@
+namespace :phone do
+  # Every model/attribute holding a number someone is actually dialled on.
+  # Resolved lazily: the constants don't exist until :environment has run.
+  def self.targets
+    [
+      [ Participant,      :phone ],
+      [ Guardian,         :phone ],
+      [ EmergencyContact, :phone ],
+      [ IncidentReport,   :reporter_phone ],
+      [ User,             :phone_number ],
+      [ Ticket,           :phone_number ]
+    ]
+  end
+
+  desc "Report stored phone numbers that aren't valid E.164 (no writes)"
+  task audit: :environment do
+    total = 0
+
+    targets.each do |model, attribute|
+      bad = []
+
+      model.find_each do |record|
+        raw = record.public_send(attribute)
+        next if raw.blank?
+        next if raw == PhoneNormalizer.normalize(raw)
+
+        bad << [ record.id, raw, PhoneNormalizer.normalize(raw) ]
+      end
+
+      total += bad.size
+      puts "\n#{model.name}##{attribute}: #{bad.size} non-canonical"
+      bad.each do |id, raw, fixed|
+        # Repairable means we can derive E.164; nil means someone has to ask
+        # the person for a working number.
+        puts "  #{id}  #{raw.inspect} -> #{fixed ? fixed : 'UNREPAIRABLE'}"
+      end
+    end
+
+    puts "\n#{total} record(s) hold a non-canonical phone number."
+    puts "Run `rake phone:repair` to rewrite the repairable ones."
+  end
+
+  desc "Rewrite stored phone numbers to E.164 where possible (dry run unless APPLY=1)"
+  task repair: :environment do
+    apply = ENV["APPLY"] == "1"
+    repaired = 0
+    unrepairable = 0
+
+    targets.each do |model, attribute|
+      model.find_each do |record|
+        raw = record.public_send(attribute)
+        next if raw.blank?
+
+        fixed = PhoneNormalizer.normalize(raw)
+        next if fixed == raw
+
+        if fixed.nil?
+          unrepairable += 1
+          puts "SKIP #{model.name}##{record.id} #{raw.inspect} — cannot be parsed, needs a human"
+          next
+        end
+
+        repaired += 1
+        puts "#{model.name}##{record.id} #{raw.inspect} -> #{fixed}"
+        next unless apply
+
+        # Skip validations: an unrelated pre-existing problem on the row
+        # must not stop us from canonicalising the phone number.
+        record.public_send(:"#{attribute}=", fixed)
+        record.save!(validate: false)
+      end
+    end
+
+    puts "\n#{apply ? 'Repaired' : 'Would repair'} #{repaired} record(s); #{unrepairable} need a human."
+    puts "Dry run — re-run with APPLY=1 to write changes." unless apply
+  end
+end

--- a/spec/jobs/process_import_batch_job_spec.rb
+++ b/spec/jobs/process_import_batch_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProcessImportBatchJob do
           email: "participant@example.com",
           legal_first_name: "Pat",
           legal_last_name: "Example",
-          phone: "+15551234567",
+          phone: "+14155550123",
           date_of_birth: "1/15/08",
           address_line_1: "123 Main St"
         }

--- a/spec/jobs/send_support_ticket_sms_notification_job_spec.rb
+++ b/spec/jobs/send_support_ticket_sms_notification_job_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe SendSupportTicketSmsNotificationJob do
   let(:twilio) { instance_double(TwilioService) }
-  let(:assignee) { User.create!(email: "assignee-sms@example.com", name: "Assignee", phone_number: "+15559990000") }
-  let(:ticket) { Ticket.create!(channel: "whatsapp", phone_number: "+15550001111", status: "open") }
+  let(:assignee) { User.create!(email: "assignee-sms@example.com", name: "Assignee", phone_number: "+14155550190") }
+  let(:ticket) { Ticket.create!(channel: "whatsapp", phone_number: "+14155550111", status: "open") }
   let(:message) do
     TicketMessage.create!(ticket: ticket, direction: "inbound", channel: "whatsapp", body: "Help please", sent_at: Time.current)
   end
@@ -12,7 +12,7 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
     allow(TwilioService).to receive(:new).and_return(twilio)
     allow(twilio).to receive(:send_sms)
     Setting.support_sms_notifications_enabled = true
-    Setting.support_sms_notification_numbers = [ "+14155551234", "+447700900123" ]
+    Setting.support_sms_notification_numbers = [ "+14155551234", "+447911123456" ]
     allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
   end
 
@@ -20,8 +20,8 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
     it "texts every configured number" do
       described_class.perform_now(message.id, "new_ticket")
 
-      expect(twilio).to have_received(:send_sms).with(to: "+14155551234", body: a_string_including("+15550001111", "Help please"), source: "Staff notifications")
-      expect(twilio).to have_received(:send_sms).with(to: "+447700900123", body: a_string_including("WhatsApp"), source: "Staff notifications")
+      expect(twilio).to have_received(:send_sms).with(to: "+14155551234", body: a_string_including("+14155550111", "Help please"), source: "Staff notifications")
+      expect(twilio).to have_received(:send_sms).with(to: "+447911123456", body: a_string_including("WhatsApp"), source: "Staff notifications")
     end
 
     it "sends nothing when the feature is disabled" do
@@ -36,7 +36,7 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
       allow(twilio).to receive(:send_sms).with(to: "+14155551234", body: anything, source: anything).and_raise(TwilioService::Error, "boom")
 
       expect { described_class.perform_now(message.id, "new_ticket") }.not_to raise_error
-      expect(twilio).to have_received(:send_sms).with(to: "+447700900123", body: anything, source: anything)
+      expect(twilio).to have_received(:send_sms).with(to: "+447911123456", body: anything, source: anything)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe SendSupportTicketSmsNotificationJob do
     it "texts the assignee's phone" do
       described_class.perform_now(message.id, "assigned_reply")
 
-      expect(twilio).to have_received(:send_sms).with(to: "+15559990000", body: a_string_including("new reply"), source: "Staff notifications")
+      expect(twilio).to have_received(:send_sms).with(to: "+14155550190", body: a_string_including("new reply"), source: "Staff notifications")
     end
 
     it "skips when the assignee has no phone" do

--- a/spec/models/phone_validation_spec.rb
+++ b/spec/models/phone_validation_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+# Stand-ins for the shapes of number that were reaching production. Every one
+# passes the previous `phone: { possible: true }` length-only check.
+INVALID_PHONE_NUMBERS = [
+  "0555550100",     # national format, country code missing entirely
+  "+1 0555550100",  # country code glued onto a national trunk prefix
+  "15555555",       # too short to be a subscriber number
+  "07911123456",    # UK national format, no +44
+  "0000000000",
+  "555",
+  "not a phone"
+].freeze
+
+VALID_PHONE_NUMBERS = {
+  "+14155550132" => "+14155550132",
+  "+1 (415) 555-0132" => "+14155550132",
+  "4155550132" => "+14155550132",
+  "+44 7911 123456" => "+447911123456",
+  "00447911123456" => "+447911123456"
+}.freeze
+
+RSpec.describe "phone number validation" do
+  shared_examples "a strictly validated phone attribute" do |attribute|
+    INVALID_PHONE_NUMBERS.each do |bad|
+      it "rejects #{bad.inspect}" do
+        record = build_record(attribute => bad)
+        expect(record).not_to be_valid, "expected #{bad.inspect} to be rejected on #{described_class}##{attribute}"
+        expect(record.errors[attribute].join).to match(/valid phone number/i)
+      end
+    end
+
+    VALID_PHONE_NUMBERS.each do |input, expected|
+      it "accepts #{input.inspect} and stores it as #{expected}" do
+        record = build_record(attribute => input)
+        expect(record).to be_valid, record.errors.full_messages.join(", ")
+        expect(record.public_send(attribute)).to eq(expected)
+      end
+    end
+  end
+
+  describe Participant do
+    def build_record(attrs) = build(:participant, **attrs)
+    it_behaves_like "a strictly validated phone attribute", :phone
+
+    it "allows a blank phone" do
+      expect(build(:participant, phone: nil)).to be_valid
+      expect(build(:participant, phone: "")).to be_valid
+    end
+  end
+
+  describe Guardian do
+    def build_record(attrs) = build(:guardian, **attrs)
+    it_behaves_like "a strictly validated phone attribute", :phone
+
+    it "allows a blank phone" do
+      expect(build(:guardian, phone: nil)).to be_valid
+    end
+  end
+
+  describe EmergencyContact do
+    let(:participant_event) { create(:participant_event) }
+    def build_record(attrs)
+      EmergencyContact.new(
+        participant_event: participant_event,
+        name: "Sam Rivers",
+        relationship: "Aunt",
+        priority: 1,
+        **attrs
+      )
+    end
+    it_behaves_like "a strictly validated phone attribute", :phone
+
+    it "still requires a phone to be present" do
+      record = build_record(phone: nil)
+      expect(record).not_to be_valid
+      expect(record.errors[:phone]).to include("can't be blank")
+    end
+  end
+
+  describe "normalization is idempotent across saves" do
+    it "leaves an already-normalized number untouched" do
+      participant = create(:participant, phone: "+1 (415) 555-0132")
+      expect(participant.phone).to eq("+14155550132")
+      participant.update!(preferred_name: "Robin")
+      expect(participant.reload.phone).to eq("+14155550132")
+    end
+  end
+end

--- a/spec/requests/admin/incident_report_comments_spec.rb
+++ b/spec/requests/admin/incident_report_comments_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin::IncidentReportComments", type: :request do
       event: event,
       reporter_name: "Reporter",
       reporter_email: "reporter-irc@example.com",
-      reporter_phone: "+15555550100",
+      reporter_phone: "+14155550150",
       reporter_role: "participant",
       incident_type: "other",
       priority: "standard",

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe "Admin::Settings", type: :request do
       sign_in global_admin
 
       post update_support_sms_numbers_admin_settings_path,
-        params: { support_sms_notification_numbers: "+14155551234\n+44 7700 900123, +14155551234" }
+        params: { support_sms_notification_numbers: "+14155551234\n+44 7911 123456, +14155551234" }
 
-      expect(Setting.support_sms_notification_number_list).to eq([ "+14155551234", "+447700900123" ])
+      expect(Setting.support_sms_notification_number_list).to eq([ "+14155551234", "+447911123456" ])
     end
 
     it "rejects invalid numbers without saving" do

--- a/spec/requests/optional_custom_documents_spec.rb
+++ b/spec/requests/optional_custom_documents_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe "Optional custom documents", type: :request do
     end
 
     it "does not create a submission for an un-added document when the portal is completed" do
-      gpe.guardian.update!(legal_first_name: "Pat", legal_last_name: "Guardian", phone: "+15555550100")
-      gpe.emergency_contacts.create!(name: "Pat Guardian", phone: "+15555550100", relationship: "Parent")
+      gpe.guardian.update!(legal_first_name: "Pat", legal_last_name: "Guardian", phone: "+14155550150")
+      gpe.emergency_contacts.create!(name: "Pat Guardian", phone: "+14155550150", relationship: "Parent")
       create(:consent, :signed, participant_event: participant_event, guardian_signed_at: Time.current)
 
       expect {

--- a/spec/requests/physical_custom_documents_spec.rb
+++ b/spec/requests/physical_custom_documents_spec.rb
@@ -441,8 +441,8 @@ RSpec.describe "Physical custom documents", type: :request do
     let(:participant_event) { create(:participant_event, event: event) }
     let(:gpe) do
       create(:guardian_participant_event, participant_event: participant_event).tap do |g|
-        g.guardian.update!(legal_first_name: "Pat", legal_last_name: "Guardian", phone: "+15555550100")
-        g.emergency_contacts.create!(name: "Pat Guardian", phone: "+15555550100", relationship: "Parent")
+        g.guardian.update!(legal_first_name: "Pat", legal_last_name: "Guardian", phone: "+14155550150")
+        g.emergency_contacts.create!(name: "Pat Guardian", phone: "+14155550150", relationship: "Parent")
       end
     end
     let(:token) { gpe.generate_invite_token! }
@@ -490,10 +490,10 @@ RSpec.describe "Physical custom documents", type: :request do
     let(:gpe) do
       create(:guardian_participant_event, participant_event: participant_event, relationship: "Parent").tap do |g|
         g.guardian.update!(
-          legal_first_name: "Pat", legal_last_name: "Guardian", phone: "+15555550100",
+          legal_first_name: "Pat", legal_last_name: "Guardian", phone: "+14155550150",
           address_line_1: "1 Main St", city: "Burlington", state: "VT", postal_code: "05401", country: "US"
         )
-        g.emergency_contacts.create!(name: "Pat Guardian", phone: "+15555550100", relationship: "Parent")
+        g.emergency_contacts.create!(name: "Pat Guardian", phone: "+14155550150", relationship: "Parent")
         g.update!(participant_info_reviewed_at: Time.current)
       end
     end

--- a/spec/requests/support/tickets_spec.rb
+++ b/spec/requests/support/tickets_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe "Support::Tickets", type: :request do
     end
   end
 
-  def make_ticket(event: nil, phone: "+15550001111")
+  def make_ticket(event: nil, phone: "+14155550111")
     Ticket.create!(channel: "whatsapp", phone_number: phone, status: "open", event: event)
   end
 
-  let!(:pending_ticket) { make_ticket(phone: "+15550001111") }
-  let!(:live_ticket) { make_ticket(event: live_event, phone: "+15550002222") }
-  let!(:other_ticket) { make_ticket(event: other_event, phone: "+15550003333") }
-  let!(:past_ticket) { make_ticket(event: past_event, phone: "+15550004444") }
+  let!(:pending_ticket) { make_ticket(phone: "+14155550111") }
+  let!(:live_ticket) { make_ticket(event: live_event, phone: "+14155550122") }
+  let!(:other_ticket) { make_ticket(event: other_event, phone: "+14155550133") }
+  let!(:past_ticket) { make_ticket(event: past_event, phone: "+14155550144") }
 
   describe "GET index" do
     it "shows every ticket to a global admin" do
@@ -118,7 +118,7 @@ RSpec.describe "Support::Tickets", type: :request do
     end
 
     it "does not mention the window on SMS tickets" do
-      sms_ticket = Ticket.create!(channel: "sms", phone_number: "+15550009999", status: "open", event: live_event, last_inbound_at: 5.days.ago)
+      sms_ticket = Ticket.create!(channel: "sms", phone_number: "+14155550199", status: "open", event: live_event, last_inbound_at: 5.days.ago)
       sign_in global_admin
       get support_ticket_path(sms_ticket)
 
@@ -129,10 +129,10 @@ RSpec.describe "Support::Tickets", type: :request do
 
   describe "GET index filters" do
     let!(:participant) do
-      Participant.create!(legal_first_name: "Ada", legal_last_name: "Lovelace", email: "ada@example.com", phone: "+15550009999")
+      Participant.create!(legal_first_name: "Ada", legal_last_name: "Lovelace", email: "ada@example.com", phone: "+14155550199")
     end
     let!(:guardian) do
-      Guardian.create!(legal_first_name: "Grace", legal_last_name: "Hopper", email: "grace@example.com", phone: "+15550008888")
+      Guardian.create!(legal_first_name: "Grace", legal_last_name: "Hopper", email: "grace@example.com", phone: "+14155550188")
     end
 
     before do
@@ -158,7 +158,7 @@ RSpec.describe "Support::Tickets", type: :request do
 
     it "filters by phone number ignoring formatting" do
       sign_in global_admin
-      get support_tickets_path, params: { phone: "(555) 000-2222" }
+      get support_tickets_path, params: { phone: "(415) 555-0122" }
 
       expect(response.body).to include(live_ticket.phone_number)
       expect(response.body).not_to include(pending_ticket.phone_number)

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe CsvImportService do
       "Final Airline Code", "Final Flight Number", "Flight Departure Date"
     ]
     values = [
-      "test@example.com", "John", "Doe", "Johnny", "U12345", "He/Him", "male", "+15551234567", "1/15/08",
+      "test@example.com", "John", "Doe", "Johnny", "U12345", "He/Him", "male", "+14155550123", "1/15/08",
       "123 Main St", "", "San Francisco", "California", "94102", "United States", "M", "Jane", "Doe",
-      "jane@example.com", "+15559876543", "Bob", "Smith", "bob@example.com", "+15555555555", "Uncle",
+      "jane@example.com", "+14155550176", "Bob", "Smith", "bob@example.com", "+14155550155", "Uncle",
       "Allergic to peanuts", "Takes daily medication", "Flight", "", "", "", "2", "SFO", "ORD", "UA", "123",
       "12/19/25", "ORD", "JFK", "UA", "456", "12/19/25", "", "", "", "", "", "JFK", "UA", "789", "12/21/25"
     ]

--- a/spec/services/mcp/response_filter_spec.rb
+++ b/spec/services/mcp/response_filter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mcp::ResponseFilter do
     end
 
     it "redacts a value with no letters to initial rather than echoing it" do
-      expect(described_class.initials("+1 555 0100")).to eq("[redacted]")
+      expect(described_class.initials("+1 415 555 0100")).to eq("[redacted]")
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Mcp::ResponseFilter do
     it "redacts contact and location detail whatever its type" do
       result = described_class.call({
         email: "leo@hackclub.com",
-        phone: "+1 555 0100",
+        phone: "+1 415 555 0100",
         date_of_birth: Date.new(2008, 3, 1),
         city: "Burlington",
         slack_user_id: "U123",

--- a/spec/services/phone_normalizer_spec.rb
+++ b/spec/services/phone_normalizer_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe PhoneNormalizer do
+  describe ".normalize" do
+    it "returns E.164 for a number that already carries its country code" do
+      expect(described_class.normalize("+44 7911 123456")).to eq("+447911123456")
+      expect(described_class.normalize("+1 (415) 555-0132")).to eq("+14155550132")
+    end
+
+    it "reads the international access prefix as a country code" do
+      expect(described_class.normalize("00447911123456")).to eq("+447911123456")
+    end
+
+    it "strips the channel prefixes Twilio puts on inbound addresses" do
+      expect(described_class.normalize("whatsapp:+14155550132")).to eq("+14155550132")
+      expect(described_class.normalize("tel:+14155550132")).to eq("+14155550132")
+    end
+
+    it "interprets a bare national number against the default country" do
+      expect(described_class.normalize("4155550132")).to eq("+14155550132")
+    end
+
+    # The shapes of number that prompted this work. Every one is "possible"
+    # by Phonelib's length check and undialable in reality.
+    describe "numbers that are possible but not valid" do
+      {
+        "a national-format number with no country code" => "0555550100",
+        "a country code glued to a national trunk prefix" => "+1 0555550100",
+        "too few digits to be a real subscriber number" => "15555555",
+        "an all-zero placeholder" => "0000000000"
+      }.each do |description, input|
+        it "rejects #{description} (#{input})" do
+          expect(Phonelib.parse(input).possible?).to be(true), "expected #{input} to be the possible-but-invalid case this guards"
+          expect(described_class.normalize(input)).to be_nil
+        end
+      end
+    end
+
+    it "rejects a national number from a country other than the default" do
+      # A UK mobile typed without +44 must not silently become a US number.
+      expect(described_class.normalize("07911123456")).to be_nil
+    end
+
+    it "never returns the raw input when it cannot parse" do
+      expect(described_class.normalize("not a phone")).to be_nil
+      expect(described_class.normalize("123")).to be_nil
+      expect(described_class.normalize("+")).to be_nil
+    end
+
+    it "returns nil for blank input" do
+      expect(described_class.normalize(nil)).to be_nil
+      expect(described_class.normalize("")).to be_nil
+      expect(described_class.normalize("   ")).to be_nil
+    end
+
+    context "with default_country: nil" do
+      it "requires an explicit country code" do
+        expect(described_class.normalize("4155550132", default_country: nil)).to be_nil
+        expect(described_class.normalize("+14155550132", default_country: nil)).to eq("+14155550132")
+      end
+    end
+
+    it "lets an explicit country code win over the default country" do
+      expect(described_class.normalize("+447911123456", default_country: "US")).to eq("+447911123456")
+    end
+
+    it "is idempotent" do
+      once = described_class.normalize("+1 (415) 555-0132")
+      expect(described_class.normalize(once)).to eq(once)
+    end
+  end
+
+  describe ".valid?" do
+    it "mirrors normalize" do
+      expect(described_class.valid?("+14155550132")).to be(true)
+      expect(described_class.valid?("15555555")).to be(false)
+      expect(described_class.valid?(nil)).to be(false)
+    end
+  end
+
+  describe ".country" do
+    it "resolves the country of a valid number" do
+      expect(described_class.country("+447911123456")).to eq("GG").or eq("GB")
+      expect(described_class.country("15555555")).to be_nil
+    end
+  end
+end

--- a/spec/toolboxes/mcp_connection_settings_spec.rb
+++ b/spec/toolboxes/mcp_connection_settings_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "MCP connection settings", type: :toolbox do
 
     it "refuses a record that isn't linked to any event" do
       settings.narrow_events!([ assemble.id ])
-      ticket = Ticket.create!(channel: "sms", phone_number: "+15550100", status: "open")
+      ticket = Ticket.create!(channel: "sms", phone_number: "+14155550101", status: "open")
 
       call_tool("tickets_show", params: { "ticket_id" => ticket.id }, as: ticket_auth)
 
@@ -109,7 +109,7 @@ RSpec.describe "MCP connection settings", type: :toolbox do
   describe "anonymization" do
     let(:participant) do
       create(:participant, legal_first_name: "Kim", legal_last_name: "Doe",
-                           email: "kim@example.com", phone: "+1 555 0100")
+                           email: "kim@example.com", phone: "+1 415 555 0100")
     end
 
     before { create(:participant_event, participant: participant, event: assemble) }


### PR DESCRIPTION
Undialable numbers were reaching the database and Twilio: national-format numbers with no country code, a country code glued onto a national trunk prefix, and numbers too short to be a subscriber line.

## Root cause

Both layers were checking *possible* rather than *valid*.

- Models used `validates :phone, phone: { possible: true }`. Phonelib's `possible?` is a **length check only**, so every one of those shapes passed. `normalize_phone` then wrote E.164 only `if parsed.valid?`, which left invalid input stored **raw**.
- Both CSV importers fell back to the raw string explicitly: `parsed.valid? ? parsed.e164 : phone_str`.
- The form submit handler rewrote the field to E.164 only when the number looked valid. With `separateDialCode: true` the input holds national digits *alone*, so an invalid number was posted with no country code at all.

Also worth knowing: `Phonelib.parse(x, nil)` does **not** disable the default country — it falls back to it. The `if phone.start_with?("+")` branches were dead code; both sides behaved identically.

## Server

`PhoneNormalizer` is now the only thing that touches Phonelib. `normalize` returns E.164 or `nil`, never the raw input. A shared `E164PhoneValidator` (`validates :x, e164_phone: true`) and a `NormalizesPhoneNumbers` concern replace the three duplicated `normalize_phone` methods, covering `Participant`, `Guardian`, `EmergencyContact`, `IncidentReport`, `User`, `Ticket` and `AutomatedSmsLog`.

`User#phone_number` validates only `if phone_number_changed?`, so a legacy value can't fail the `user.update` that refreshes claims at sign-in. `Ticket` and `AutomatedSmsLog` normalise but don't hard-validate — refusing to record an inbound support message would be worse than storing an odd address, and normalising is what keeps the deterministic-encryption subject matching working.

## Client

Three separate traps, all verified in a browser rather than from docs:

- `isValidNumber()` has been **length-only since intl-tel-input v24**, so it accepts a national number that lost its country code.
- `isValidNumberPrecise()` is not the fix — it only accepts numbers typed `MOBILE`, so it rejects every landline *and* every US number (libphonenumber types those `FIXED_LINE_OR_MOBILE`). `validationNumberTypes` is now pinned to `null` with a comment, so nobody narrows it again.
- The check that actually matches Phonelib is `isValidNumber() && getNumberType() !== -1` — libphonenumber returns `UNKNOWN (-1)` for a number matching no real range. Confirmed agreeing with the server across US/UK/AU/DE/FR/IN.

`initialCountry: "auto"` used a `geoIpLookup` against a host that is **not in the CSP `connect-src` allowlist**, so it failed on every page with a phone field and fell back to `"us"` for *every user* — a direct cause of missing country codes, since someone abroad typed their national number under a US flag. Replaced with the browser's own locale region (`Intl.Locale(...).region || .maximize().region`): no network request, no CSP change, and no reporter IP sent to a third party from the confidential incident-report form.

The five forms that had no widget at all now have one (admin emergency contacts, admin participants → link guardian, dashboard profile, incident report, Twilio settings), submission is blocked with an inline message, and the `.iti` wrapper carries the field width — it is `display: inline-block`, which was making phone fields narrower than the fields beside them.

## Existing rows

`rake phone:audit` reports every stored number that isn't canonical E.164 and whether it can be repaired; `rake phone:repair APPLY=1` rewrites the fixable ones. Numbers of the kind that prompted this come back `UNREPAIRABLE` — they genuinely can't be recovered without asking the person, which seemed more honest than guessing a country.

## Testing

1511 examples. The two remaining failures (`webhooks_spec:247`, `csv_import_service_spec:195`) were confirmed failing at unmodified `main` and are unrelated — the first only fails locally when `config/master.key` is present, the second is order-dependent.

46 existing specs needed fixture updates: `555` is not a real area code and `555-1234` is not a valid line, so numbers like `+15551234567` are correctly rejected now. Valid fictional numbers live in `+1 <real area code> 555 0100–0199`. `+447700900123` (the Ofcom drama range) is also invalid and became a real-format UK number.

End-to-end over HTTP, each bad shape returns 422 with *"is not a valid phone number. Include the country code, for example +1 415 555 0132."*, and a valid number is accepted. Checked in light and dark themes at mobile and desktop widths.
