### PR TITLE
Send the full phone number when saving in the background

### DIFF
--- a/app/javascript/controllers/autosave_controller.js
+++ b/app/javascript/controllers/autosave_controller.js
@@ -87,6 +87,18 @@ export default class extends Controller {
       if (input.name) formData.delete(input.name)
     })
 
+    // intl-tel-input keeps the country code out of the field itself, so the raw
+    // value here is bare national digits. Autosave writes straight to the record,
+    // so sending those means a non-US number is parsed against the default
+    // country, fails validation and is silently dropped — while the status line
+    // still says "Saved". Send the same E.164 number a real submit would.
+    form.querySelectorAll('input[type="tel"]').forEach((input) => {
+      if (!input.name || !input.iti) return
+
+      const e164 = input.iti.getNumber()
+      if (e164) formData.set(input.name, e164)
+    })
+
     this.inFlight = true
     this.updateStatus("Saving...")
 

--- a/app/javascript/controllers/incident_report_controller.js
+++ b/app/javascript/controllers/incident_report_controller.js
@@ -49,7 +49,15 @@ export default class extends Controller {
     const draft = {}
     this.persistTargets.forEach((el) => {
       if (!el.name) return
-      draft[el.name] = el.type === "checkbox" ? el.checked : el.value
+      if (el.type === "checkbox") {
+        draft[el.name] = el.checked
+      } else if (el.type === "tel" && el.iti) {
+        // Save the full +country number, not the national digits on screen, so
+        // the chosen country survives the login round-trip.
+        draft[el.name] = el.iti.getNumber() || el.value
+      } else {
+        draft[el.name] = el.value
+      }
     })
     try {
       localStorage.setItem(this.constructor.STORAGE_KEY, JSON.stringify(draft))


### PR DESCRIPTION
The phone fields use intl-tel-input with `separateDialCode`, so the country code lives in the dropdown and the input itself holds bare national digits. The submit handler already accounts for this and rewrites to E.164 on submit — but the two paths that stash a number *before* submit did not.

### Onboarding autosave

`autosave_controller` serialised the form with `new FormData(form)`, so every debounced PATCH sent national digits with no country code. `autosave_step_data` calls `update`, which runs validations, so anything that doesn't parse against the default country failed and was dropped — while the status line still said "Saved". The number only stuck if the person reached the end and submitted.

Affects the three onboarding steps that pair `phone-input` with `autosave`: profile, guardian, emergency.

### Incident report draft

The incident form persists a draft to localStorage so it survives the Hack Club login round-trip. It saved the displayed value, so returning from OAuth restored the digits under whichever country the picker happened to default to.

### Verification

Drove the real controllers in the browser and intercepted the autosave request. With a number typed nationally against a non-default country, `FormData` alone sends `30 901820`; autosave now sends the E.164 equivalent. Confirmed the old value fails model validation (`phone: ["is invalid"]`) and the new one passes, which is the silent-drop this fixes.

### Notes

Both paths fall back to the raw value when intl-tel-input hasn't initialised yet, so behaviour is unchanged before the widget loads.

Deliberately scoped to these two files. #96 covers the validation threshold, the shared `phone-input` controller and the `.iti` width, and doesn't touch either file here — so this should merge cleanly alongside it in either order. The incident-form half is a no-op until #96 attaches the controller to that form.