### PR TITLE
Clear "none"/"N/A" answers from medical free-text fields

### DIFF
--- a/app/models/accessibility.rb
+++ b/app/models/accessibility.rb
@@ -1,9 +1,15 @@
 class Accessibility < ApplicationRecord
+  include ClearsNegativeResponses
+
   has_paper_trail
 
   self.implicit_order_column = "created_at"
 
   encrypts :mobility_needs, :sensory_needs, :communication_needs, :religious_practices, :other_needs
+
+  clears_negative_responses :mobility_needs, :sensory_needs, :communication_needs,
+                            :religious_practices, :other_needs, :neurodivergent_notes,
+                            :distance_limitations, :unavailable_times
 
   belongs_to :participant_event
   has_one :participant, through: :participant_event

--- a/app/models/concerns/clears_negative_responses.rb
+++ b/app/models/concerns/clears_negative_responses.rb
@@ -1,0 +1,37 @@
+# Participants routinely answer an optional free-text medical question with
+# "None" or "N/A" rather than leaving it empty, and that answer then reads as
+# real content everywhere downstream — a field showing "None" looks filled-in
+# next to one that is genuinely blank, and staff have to read every box to tell
+# the difference. Collapse those answers to NULL as they are written so blank
+# means one thing across the admin views, exports, API and wallet passes.
+#
+# Only whole-value matches are cleared. "No known allergies" and "none that
+# need refrigeration" are real answers and must survive untouched, so this
+# never does substring matching.
+#
+# `normalizes` runs on assignment and on write, not on load, so values already
+# in the database keep whatever text they hold until the record is next saved.
+# Readers that interpret legacy text — see Medical::NEGATIVE_RESPONSES, whose
+# list is deliberately broader than this one — still need to.
+module ClearsNegativeResponses
+  extend ActiveSupport::Concern
+
+  # Deliberately narrow. Ambiguous answers ("nil", "-", "0") are left for a
+  # human to read rather than silently dropped from a medical record.
+  BLANK_EQUIVALENTS = %w[no none n/a na].freeze
+
+  # A trailing full stop is tolerated ("None.") because it is punctuation, not
+  # content. Anything else keeps the participant's own text, stripped.
+  NORMALIZER = lambda do |value|
+    text = value.to_s.strip
+    return nil if text.empty?
+
+    BLANK_EQUIVALENTS.include?(text.downcase.delete_suffix(".")) ? nil : text
+  end
+
+  class_methods do
+    def clears_negative_responses(*names)
+      normalizes(*names, with: NORMALIZER)
+    end
+  end
+end

--- a/app/models/dietary.rb
+++ b/app/models/dietary.rb
@@ -1,9 +1,13 @@
 class Dietary < ApplicationRecord
+  include ClearsNegativeResponses
+
   has_paper_trail
 
   self.implicit_order_column = "created_at"
 
   encrypts :intolerances, :life_threatening_allergies, :notes
+
+  clears_negative_responses :intolerances, :life_threatening_allergies, :notes
 
   belongs_to :participant_event
   has_one :participant, through: :participant_event

--- a/app/models/medical.rb
+++ b/app/models/medical.rb
@@ -1,9 +1,14 @@
 class Medical < ApplicationRecord
+  include ClearsNegativeResponses
+
   has_paper_trail
 
   self.implicit_order_column = "created_at"
 
   encrypts :allergies, :medical_conditions, :medications, :emergency_action_plan, :additional_notes
+
+  clears_negative_responses :allergies, :medical_conditions, :medications,
+                            :emergency_action_plan, :additional_notes
 
   belongs_to :participant_event
   belongs_to :last_updated_by, class_name: "User", foreign_key: "last_updated_by_user_id", optional: true

--- a/spec/models/concerns/clears_negative_responses_spec.rb
+++ b/spec/models/concerns/clears_negative_responses_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe ClearsNegativeResponses do
+  let(:participant_event) { create(:participant_event) }
+  let(:medical) { Medical.new(participant_event: participant_event) }
+
+  describe "answers that mean nothing" do
+    [ "NO", "No", "none", "None", "N/A", "n/a", "NA", "na", "  None  ", "None." ].each do |answer|
+      it "clears #{answer.inspect}" do
+        medical.allergies = answer
+
+        expect(medical.allergies).to be_nil
+      end
+    end
+  end
+
+  describe "answers that mean something" do
+    [ "No known allergies", "none that need refrigeration", "Peanuts", "Nasal spray" ].each do |answer|
+      it "keeps #{answer.inspect}" do
+        medical.allergies = answer
+
+        expect(medical.allergies).to eq(answer)
+      end
+    end
+
+    it "keeps ambiguous single characters rather than guessing" do
+      medical.allergies = "-"
+
+      expect(medical.allergies).to eq("-")
+    end
+
+    it "strips surrounding whitespace from a real answer" do
+      medical.allergies = "  Penicillin  "
+
+      expect(medical.allergies).to eq("Penicillin")
+    end
+  end
+
+  it "clears every free-text field on the medical form" do
+    medical.update!(
+      allergies: "none", medical_conditions: "N/A", medications: "No",
+      emergency_action_plan: "na", additional_notes: "None."
+    )
+    dietary = Dietary.create!(
+      participant_event: participant_event,
+      intolerances: "none", life_threatening_allergies: "N/A", notes: "NA"
+    )
+    accessibility = Accessibility.create!(
+      participant_event: participant_event,
+      mobility_needs: "none", sensory_needs: "N/A", communication_needs: "No",
+      religious_practices: "na", other_needs: "None.", neurodivergent_notes: "none",
+      distance_limitations: "N/A", unavailable_times: "NA"
+    )
+
+    expect(medical.reload.attributes.values_at(
+      "allergies", "medical_conditions", "medications", "emergency_action_plan", "additional_notes"
+    )).to all(be_nil)
+    expect(dietary.reload.attributes.values_at(
+      "intolerances", "life_threatening_allergies", "notes"
+    )).to all(be_nil)
+    expect(accessibility.reload.attributes.values_at(
+      "mobility_needs", "sensory_needs", "communication_needs", "religious_practices",
+      "other_needs", "neurodivergent_notes", "distance_limitations", "unavailable_times"
+    )).to all(be_nil)
+  end
+
+  it "leaves text already in the database alone until the record is saved again" do
+    medical.save!
+    # Skip past the normalizer to the encryption type underneath, so the row
+    # holds what a row written before this concern existed would hold.
+    legacy = Medical.type_for_attribute(:allergies).cast_type.serialize("none")
+    Medical.where(id: medical.id).update_all(Medical.sanitize_sql([ "allergies = ?", legacy ]))
+
+    expect(medical.reload.allergies).to eq("none")
+    expect(medical.has_allergies?).to be(false)
+  end
+end


### PR DESCRIPTION
Participants routinely answer an optional free-text medical question with "None" or "N/A" rather than leaving it empty. That answer then reads as real content in the admin views, exports, API and wallet passes — a field showing "None" looks filled-in next to one that is genuinely blank, so staff have to read every box to tell the difference.

This normalizes those answers to `NULL` as they are written.

## How

New `ClearsNegativeResponses` concern wrapping Rails `normalizes`, wired into the three models behind the medical forms:

| model | fields |
| --- | --- |
| `Medical` | `allergies`, `medical_conditions`, `medications`, `emergency_action_plan`, `additional_notes` |
| `Dietary` | `intolerances`, `life_threatening_allergies`, `notes` |
| `Accessibility` | `mobility_needs`, `sensory_needs`, `communication_needs`, `religious_practices`, `other_needs`, `neurodivergent_notes`, `distance_limitations`, `unavailable_times` |

Because it lives on the model, all three form paths are covered at once — the onboarding health step, the guardian portal health step, and admin → medical — plus the API and the CSV import job.

## Deliberate choices

- **Whole-value matches only.** `"No known allergies"` and `"none that need refrigeration"` survive intact; a field only clears when it is *entirely* no/none/n/a/na. A trailing full stop is tolerated (`"None."`) since that is punctuation, not content.
- **Narrower than `Medical::NEGATIVE_RESPONSES`.** That list (used by `has_allergies?`) also covers `nil`, `null`, `nothing`, `nope`, `-`, `0`. Those are left alone here — dropping `"0"` or `"-"` from a medical record on a guess is worse than leaving it for a human to read. The cleared set is a subset of it, so `has_allergies?` keeps behaving correctly either way.
- **Server-side, not as-you-type.** The onboarding form autosaves on every keystroke, so a client-side clear would wipe the box out from under someone part-way through typing "No known allergies…". The field clears on next page load instead.
- **Existing rows are unaffected.** `normalizes` runs on assignment and write, not on load, so stored text stays until the record is next saved. A one-off backfill for historic rows is easy to add separately if wanted — it is a write against medical data, so it is not bundled in here.

## Testing

18 new examples in `spec/models/concerns/clears_negative_responses_spec.rb` cover the clearing set, the near-miss phrases that must survive, every field on all three models, and the legacy-row behaviour.

Full suite run locally: 1498 examples, 1 failure — `spec/requests/api/v1/webhooks_spec.rb:247` (docuseal webhook secret), which fails identically on a reverted tree and pre-dates this branch. Rubocop clean.
