### PR TITLE
Stop a guardian's email from matching the participant's

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -65,7 +65,11 @@ module Admin
           row_number: index + 2,
           email: email,
           name: [ row[:legal_first_name], row[:legal_last_name] ].compact.join(" "),
-          parent_email: row[:parent_email]
+          parent_email: row[:parent_email],
+          # The import drops a parent column that repeats the participant's own
+          # address; say so here rather than after the fact.
+          parent_email_conflict: row[:parent_email].present? &&
+            row[:parent_email].to_s.strip.downcase == email
         }
 
         if existing_pe

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -162,7 +162,16 @@ module Admin
     def link_guardian
       authorize @participant_event, :update?
 
-      guardian = Guardian.find_or_initialize_by(email: params[:guardian_email].strip.downcase)
+      guardian_email = params[:guardian_email].to_s.strip.downcase
+      participant_email = @participant_event.participant.email.to_s.strip.downcase
+
+      if guardian_email.present? && guardian_email == participant_email
+        redirect_to admin_event_participant_path(current_event, @participant_event),
+          alert: "Guardian email cannot be the same as the participant's email address."
+        return
+      end
+
+      guardian = Guardian.find_or_initialize_by(email: guardian_email)
       guardian.assign_attributes(
         legal_first_name: params[:guardian_first_name],
         legal_last_name: params[:guardian_last_name],
@@ -178,7 +187,10 @@ module Admin
         if gpe.persisted?
           redirect_to admin_event_participant_path(current_event, @participant_event), notice: "Guardian linked successfully."
         else
-          redirect_to admin_event_participant_path(current_event, @participant_event), alert: "Guardian already linked to this participant."
+          # Anything the link itself rejected (a duplicate, or a guardian whose
+          # address collides with the participant's) is worth saying out loud.
+          reason = gpe.errors.full_messages.presence&.join(", ") || "Guardian already linked to this participant."
+          redirect_to admin_event_participant_path(current_event, @participant_event), alert: reason
         end
       else
         redirect_to admin_event_participant_path(current_event, @participant_event), alert: "Could not save guardian: #{guardian.errors.full_messages.join(', ')}"

--- a/app/controllers/guardian_portal_controller.rb
+++ b/app/controllers/guardian_portal_controller.rb
@@ -59,6 +59,10 @@ class GuardianPortalController < ApplicationController
         redirect_to guardian_portal_path(token: @token), notice: "Progress saved."
       end
     else
+      # The step partials render bare forms, so a rejected save (a guardian
+      # email or phone that matches the participant's, say) would otherwise
+      # bounce back looking identical to a successful one.
+      flash.now[:alert] = step_error_message
       load_wizard_position
       load_step_data
       render :step, status: :unprocessable_entity
@@ -511,6 +515,13 @@ class GuardianPortalController < ApplicationController
       @consents = @participant_event.consents.where(consent_type: consent_types)
       @required_consent_types = consent_types
     end
+  end
+
+  def step_error_message
+    messages = [ @guardian, @participant ].compact.flat_map { |record| record.errors.full_messages }
+    return "We couldn't save your changes. Please check the highlighted fields and try again." if messages.empty?
+
+    messages.uniq.to_sentence
   end
 
   def save_step_data

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -456,7 +456,12 @@ class OnboardingController < ApplicationController
         flash.now[:alert] = "Please select a t-shirt size"
         return false
       end
-      @participant.save
+      # The profile form has no error summary, so say what was actually wrong
+      # (e.g. an email that belongs to this participant's guardian).
+      return true if @participant.save
+
+      flash.now[:alert] = @participant.errors.full_messages.to_sentence
+      false
     when "travel"
       save_travel_data
     when "accommodation"
@@ -548,6 +553,10 @@ class OnboardingController < ApplicationController
       guardian_phone_parsed = Phonelib.parse(guardian_attrs[:phone])
       return if guardian_phone_parsed.valid? && guardian_phone_parsed.e164 == @participant_event.participant.phone
     end
+
+    # Same for the email: half-typed addresses pass through here on every
+    # keystroke, so this stays silent and lets the submit path do the telling.
+    return if guardian_email_matches_participant?(guardian_attrs[:email])
 
     relationship = params[:guardian_relationship]
     relationship = params[:guardian_relationship_other] if relationship == "Other"
@@ -770,6 +779,12 @@ class OnboardingController < ApplicationController
       end
     end
 
+    # Ensure guardian email is not the same as the participant's email
+    if guardian_email_matches_participant?(guardian_attrs[:email])
+      flash.now[:alert] = "Guardian email address cannot be the same as the participant's email address."
+      return false
+    end
+
     existing_gpe = @participant_event.guardian_participant_events.first
 
     if existing_gpe
@@ -794,6 +809,15 @@ class OnboardingController < ApplicationController
         false
       end
     end
+  end
+
+  def guardian_email_matches_participant?(email)
+    return false if email.blank?
+
+    participant_email = @participant_event.participant.email
+    return false if participant_email.blank?
+
+    email.strip.downcase == participant_email.strip.downcase
   end
 
   def profile_params

--- a/app/jobs/process_import_batch_job.rb
+++ b/app/jobs/process_import_batch_job.rb
@@ -70,7 +70,7 @@ class ProcessImportBatchJob < ApplicationJob
       create_accommodation(participant_event, row)
       create_dietary(participant_event, row)
       create_medical(participant_event, row)
-      create_guardian_and_emergency_contact(participant_event, row)
+      create_guardian_and_emergency_contact(participant_event, row, row_number)
       create_travel(participant_event, row)
     end
 
@@ -210,15 +210,27 @@ class ProcessImportBatchJob < ApplicationJob
     )
   end
 
-  def create_guardian_and_emergency_contact(participant_event, row)
+  def create_guardian_and_emergency_contact(participant_event, row, row_number)
     if row[:parent_email].present?
-      guardian = find_or_create_guardian(row)
-      create_guardian_participant_event(participant_event, guardian)
+      # A sheet where the parent column was filled in with the participant's own
+      # address would otherwise mail the minor their own guardian invite. Import
+      # the participant anyway and flag the row so an admin can chase the real
+      # parent address.
+      if parent_email_matches_participant?(row)
+        add_error(row_number, row[:email], "Parent email is the same as the participant's email - guardian not created")
+      else
+        guardian = find_or_create_guardian(row)
+        create_guardian_participant_event(participant_event, guardian)
+      end
     end
 
     if row[:emergency_first_name].present? && row[:emergency_phone].present?
       create_emergency_contact(participant_event, row)
     end
+  end
+
+  def parent_email_matches_participant?(row)
+    row[:parent_email].to_s.strip.downcase == row[:email].to_s.strip.downcase
   end
 
   def find_or_create_guardian(row)

--- a/app/models/guardian.rb
+++ b/app/models/guardian.rb
@@ -17,6 +17,11 @@ class Guardian < ApplicationRecord
   validates :legal_last_name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :phone, phone: { possible: true, allow_blank: true }
+  # A guardian who shares the participant's address gets the participant's
+  # invite links, waiver copies and portal codes -- and a minor can sign their
+  # own consent by reading their "guardian's" mail. Only checked when the email
+  # actually changes, so pre-existing rows can still be edited otherwise.
+  validate :email_differs_from_participants, if: :will_save_change_to_email?
 
   before_validation :normalize_phone
 
@@ -25,6 +30,15 @@ class Guardian < ApplicationRecord
   end
 
   private
+
+  def email_differs_from_participants
+    return if email.blank? || new_record?
+
+    conflict = participants.where("LOWER(participants.email) = ?", email.strip.downcase).exists?
+    return unless conflict
+
+    errors.add(:email, "cannot be the same as the participant's email address")
+  end
 
   def normalize_phone
     return if phone.blank?

--- a/app/models/guardian_participant_event.rb
+++ b/app/models/guardian_participant_event.rb
@@ -18,6 +18,11 @@ class GuardianParticipantEvent < ApplicationRecord
 
   validates :guardian_id, presence: true
   validates :participant_event_id, presence: true, uniqueness: { scope: :guardian_id }
+  # Guardian#email_differs_from_participants can't see this pairing until the
+  # link exists, so a freshly created guardian is checked here instead. Create
+  # only: existing links are updated constantly (invite tokens, status) and
+  # must not be held hostage by historical data.
+  validate :guardian_email_differs_from_participant, on: :create
 
   before_create :set_invited_via_email
   after_update_commit :complete_participant_event_if_eligible
@@ -111,6 +116,14 @@ class GuardianParticipantEvent < ApplicationRecord
   end
 
   private
+
+  def guardian_email_differs_from_participant
+    guardian_email = guardian&.email.to_s.strip.downcase
+    participant_email = participant_event&.participant&.email.to_s.strip.downcase
+    return if guardian_email.blank? || guardian_email != participant_email
+
+    errors.add(:base, "Guardian email cannot be the same as the participant's email address")
+  end
 
   def set_invited_via_email
     self.invited_via_email = guardian.email

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -18,6 +18,8 @@ class Participant < ApplicationRecord
   belongs_to :user, optional: true
   has_many :participant_events, dependent: :destroy
   has_many :events, through: :participant_events
+  has_many :guardian_participant_events, through: :participant_events
+  has_many :guardians, through: :guardian_participant_events
   has_many :sibling_memberships, dependent: :destroy
   has_many :sibling_groups, through: :sibling_memberships
 
@@ -46,6 +48,10 @@ class Participant < ApplicationRecord
   validates :headshot, presence: true, on: :onboarding
   validates :phone, phone: { possible: true, allow_blank: true }
   validate :headshot_content_type
+  # The mirror of Guardian#email_differs_from_participants: the guardian portal
+  # and the admin edit form can both rewrite a participant's email, and landing
+  # it on their own guardian's address collapses the two people into one inbox.
+  validate :email_differs_from_guardians, if: :will_save_change_to_email?
   validates :public_profile_slug, presence: true, if: :public_profile_enabled?
   validates :public_profile_slug,
     uniqueness: true,
@@ -224,6 +230,15 @@ class Participant < ApplicationRecord
 
   def touch_participant_events
     participant_events.touch_all
+  end
+
+  def email_differs_from_guardians
+    return if email.blank? || new_record?
+
+    conflict = guardians.where("LOWER(guardians.email) = ?", email.strip.downcase).exists?
+    return unless conflict
+
+    errors.add(:email, "cannot be the same as a parent or guardian's email address")
   end
 
   def normalize_public_profile_slug

--- a/app/services/csv_import_service.rb
+++ b/app/services/csv_import_service.rb
@@ -157,7 +157,7 @@ class CsvImportService
       create_accommodation(participant_event, row)
       create_dietary(participant_event, row)
       create_medical(participant_event, row)
-      create_guardian_and_emergency_contact(participant_event, row)
+      create_guardian_and_emergency_contact(participant_event, row, row_number)
       create_travel(participant_event, row)
       apply_groups(participant_event, row)
 
@@ -255,15 +255,30 @@ class CsvImportService
     )
   end
 
-  def create_guardian_and_emergency_contact(participant_event, row)
+  def create_guardian_and_emergency_contact(participant_event, row, row_number)
     if row[:parent_email].present?
-      guardian = find_or_create_guardian(row)
-      create_guardian_participant_event(participant_event, guardian)
+      # Mirrors ProcessImportBatchJob: a parent column holding the participant's
+      # own address means there is no second person to invite, so import the
+      # participant and report the row instead of linking them to themselves.
+      if parent_email_matches_participant?(row)
+        @errors << {
+          row: row_number,
+          email: row[:email],
+          error: "Parent email is the same as the participant's email - guardian not created"
+        }
+      else
+        guardian = find_or_create_guardian(row)
+        create_guardian_participant_event(participant_event, guardian)
+      end
     end
 
     if row[:emergency_first_name].present? && row[:emergency_phone].present?
       create_emergency_contact(participant_event, row)
     end
+  end
+
+  def parent_email_matches_participant?(row)
+    row[:parent_email].to_s.strip.downcase == row[:email].to_s.strip.downcase
   end
 
   def find_or_create_guardian(row)

--- a/app/views/admin/imports/preview.html.erb
+++ b/app/views/admin/imports/preview.html.erb
@@ -43,7 +43,12 @@
                 <td class="px-4 py-3 text-sm text-gray-500"><%= row[:row_number] %></td>
                 <td class="px-4 py-3 text-sm font-medium text-gray-900"><%= row[:name].presence || "—" %></td>
                 <td class="px-4 py-3 text-sm text-gray-600"><%= row[:email] %></td>
-                <td class="px-4 py-3 text-sm text-gray-600"><%= row[:parent_email].presence || "—" %></td>
+                <td class="px-4 py-3 text-sm <%= row[:parent_email_conflict] ? "text-yellow-700" : "text-gray-600" %>">
+                  <%= row[:parent_email].presence || "—" %>
+                  <% if row[:parent_email_conflict] %>
+                    <span class="block text-xs">Same as participant email — no guardian will be created</span>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
             <% if @valid_rows.count > 100 %>

--- a/spec/jobs/process_import_batch_job_spec.rb
+++ b/spec/jobs/process_import_batch_job_spec.rb
@@ -26,4 +26,31 @@ RSpec.describe ProcessImportBatchJob do
     expect(import_batch.reload).to be_completed
     expect(import_batch.rows_data).to eq([])
   end
+
+  it "imports a row whose parent email repeats the participant's, without a guardian" do
+    import_batch = ImportBatch.create!(
+      event: event,
+      status: :pending,
+      total_count: 1,
+      send_invitations: false,
+      rows_data: [
+        {
+          email: "solo@example.com",
+          legal_first_name: "Pat",
+          legal_last_name: "Example",
+          date_of_birth: "1/15/08",
+          parent_first_name: "Pat",
+          parent_last_name: "Example",
+          parent_email: "SOLO@example.com"
+        }
+      ]
+    )
+
+    expect { described_class.perform_now(import_batch.id) }.not_to change(Guardian, :count)
+
+    import_batch.reload
+    expect(import_batch.imported_count).to eq(1)
+    expect(import_batch.errors_data.map { |e| e["error"] })
+      .to include(a_string_matching(/Parent email is the same as the participant's email/))
+  end
 end

--- a/spec/models/guardian_participant_event_spec.rb
+++ b/spec/models/guardian_participant_event_spec.rb
@@ -119,4 +119,24 @@ RSpec.describe GuardianParticipantEvent do
       expect(described_class.find_by_invite_token!(token)).to eq(gpe)
     end
   end
+
+  describe "guardian email vs participant email" do
+    it "refuses to link a guardian who shares the participant's email" do
+      participant_event = create(:participant_event)
+      guardian = create(:guardian, email: participant_event.participant.email.upcase)
+
+      gpe = described_class.new(guardian: guardian, participant_event: participant_event)
+
+      expect(gpe).not_to be_valid
+      expect(gpe.errors[:base])
+        .to include("Guardian email cannot be the same as the participant's email address")
+    end
+
+    it "still allows updates to a link that already collides" do
+      gpe = create(:guardian_participant_event)
+      gpe.guardian.update_column(:email, gpe.participant_event.participant.email)
+
+      expect(gpe.reload.update(status: :in_progress)).to be(true)
+    end
+  end
 end

--- a/spec/models/guardian_spec.rb
+++ b/spec/models/guardian_spec.rb
@@ -30,4 +30,33 @@ RSpec.describe Guardian do
     expect(guardian.address_line_1).to eq("123 Main St")
     expect(guardian.city).to eq("San Francisco")
   end
+
+  describe "email vs the participant's email" do
+    it "rejects an email change onto a linked participant's address" do
+      gpe = create(:guardian_participant_event)
+      participant = gpe.participant_event.participant
+
+      gpe.guardian.email = participant.email.upcase
+
+      expect(gpe.guardian).not_to be_valid
+      expect(gpe.guardian.errors[:email])
+        .to include("cannot be the same as the participant's email address")
+    end
+
+    it "allows unrelated edits on a guardian whose email already collides" do
+      gpe = create(:guardian_participant_event)
+      participant = gpe.participant_event.participant
+      guardian = gpe.guardian
+      guardian.update_column(:email, participant.email)
+
+      expect(guardian.reload.update(legal_first_name: "Robin")).to be(true)
+    end
+
+    it "leaves guardians of other participants alone" do
+      guardian = create(:guardian)
+      create(:participant, email: "someone-else@example.com")
+
+      expect(guardian.update(email: "someone-else@example.com")).to be(true)
+    end
+  end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -215,4 +215,25 @@ RSpec.describe Participant, type: :model do
       expect(participant.public_profile_participant_events).to be_empty
     end
   end
+
+  describe "email vs a guardian's email" do
+    it "rejects an email change onto a linked guardian's address" do
+      gpe = create(:guardian_participant_event)
+      participant = gpe.participant_event.participant
+
+      participant.email = gpe.guardian.email.upcase
+
+      expect(participant).not_to be_valid
+      expect(participant.errors[:email])
+        .to include("cannot be the same as a parent or guardian's email address")
+    end
+
+    it "allows unrelated edits on a participant whose email already collides" do
+      gpe = create(:guardian_participant_event)
+      participant = gpe.participant_event.participant
+      participant.update_column(:email, gpe.guardian.email)
+
+      expect(participant.reload.update(preferred_name: "Sam")).to be(true)
+    end
+  end
 end

--- a/spec/requests/guardian_email_conflict_spec.rb
+++ b/spec/requests/guardian_email_conflict_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+
+# A guardian sharing the participant's email address is a single inbox wearing
+# two hats: the minor receives their own guardian invite, can open the portal,
+# and can consent on their own behalf. Every surface that can write either
+# address has to refuse the collision.
+RSpec.describe "Guardian and participant email collisions", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:event) { create(:event, travel_enabled: false, accommodation_enabled: false) }
+
+  describe "participant onboarding" do
+    let(:user) { create(:user) }
+    let(:participant) do
+      create(:participant, user: user, email: user.email, date_of_birth: 15.years.ago.to_date)
+    end
+    let(:participant_event) do
+      create(:participant_event, participant: participant, event: event,
+        status: :in_progress, onboarding_step: 99)
+    end
+
+    before do
+      participant_event
+      sign_in user
+    end
+
+    def submit_guardian(email:, autosave: false)
+      params = {
+        guardian_first_name: "Alex",
+        guardian_last_name: "Guardian",
+        guardian_email: email,
+        guardian_phone: "+12025559876",
+        guardian_relationship: "Parent"
+      }
+      params[:autosave] = "true" if autosave
+
+      patch onboarding_step_path(step: "guardian", event_id: event.id), params: params
+    end
+
+    it "refuses a guardian email that matches the participant's" do
+      expect { submit_guardian(email: participant.email.upcase) }
+        .not_to change(Guardian, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(flash[:alert])
+        .to eq("Guardian email address cannot be the same as the participant's email address.")
+    end
+
+    it "does not quietly create the guardian on autosave either" do
+      expect { submit_guardian(email: participant.email, autosave: true) }
+        .not_to change(Guardian, :count)
+    end
+
+    it "refuses to move the participant's own email onto their guardian's" do
+      gpe = create(:guardian_participant_event, participant_event: participant_event)
+
+      patch onboarding_step_path(step: "profile", event_id: event.id),
+        params: { participant: {
+          legal_first_name: participant.legal_first_name,
+          legal_last_name: participant.legal_last_name,
+          email: gpe.guardian.email,
+          tshirt_size: "M"
+        } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(flash[:alert]).to include("cannot be the same as a parent or guardian's email address")
+      expect(participant.reload.email).not_to eq(gpe.guardian.email)
+    end
+
+    it "accepts a different guardian email" do
+      expect { submit_guardian(email: "parent@example.com") }
+        .to change(Guardian, :count).by(1)
+
+      expect(participant_event.guardian_participant_events.count).to eq(1)
+    end
+  end
+
+  describe "admin linking a guardian" do
+    let(:admin) do
+      User.create!(email: "admin-guardian-email@example.com", name: "Admin", global_role: "global_admin")
+    end
+    let(:participant_event) { create(:participant_event, event: event) }
+
+    before { sign_in admin }
+
+    it "rejects a guardian whose email is the participant's" do
+      expect {
+        post link_guardian_admin_event_participant_path(event.slug, participant_event),
+          params: {
+            guardian_email: participant_event.participant.email.upcase,
+            guardian_first_name: "Alex",
+            guardian_last_name: "Guardian",
+            guardian_relationship: "Parent"
+          }
+      }.not_to change(GuardianParticipantEvent, :count)
+
+      expect(flash[:alert])
+        .to eq("Guardian email cannot be the same as the participant's email address.")
+    end
+
+    it "rejects it on the guardian edit form too" do
+      gpe = create(:guardian_participant_event, participant_event: participant_event)
+
+      patch admin_event_participant_guardian_path(event.slug, participant_event, gpe),
+        params: { guardian: {
+          legal_first_name: gpe.guardian.legal_first_name,
+          legal_last_name: gpe.guardian.legal_last_name,
+          email: participant_event.participant.email
+        } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(gpe.guardian.reload.email).not_to eq(participant_event.participant.email)
+    end
+  end
+
+  describe "the guardian portal" do
+    let(:participant_event) { create(:participant_event, event: event) }
+    let(:gpe) { create(:guardian_participant_event, participant_event: participant_event) }
+    let(:token) { gpe.generate_invite_token! }
+
+    it "refuses a guardian email change onto the participant's address" do
+      patch guardian_portal_update_step_path(token: token, step: "details"),
+        params: {
+          guardian: {
+            legal_first_name: "Alex",
+            legal_last_name: "Guardian",
+            email: participant_event.participant.email,
+            phone: "+12025559876"
+          },
+          relationship: "Parent"
+        }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(flash[:alert]).to include("cannot be the same as the participant's email address")
+      expect(gpe.guardian.reload.email).not_to eq(participant_event.participant.email)
+    end
+
+    it "refuses to move the participant's email onto the guardian's address" do
+      participant = participant_event.participant
+
+      patch guardian_portal_update_step_path(token: token, step: "participant_info"),
+        params: { participant: { email: gpe.guardian.email } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(flash[:alert]).to include("cannot be the same as a parent or guardian's email address")
+      expect(participant.reload.email).not_to eq(gpe.guardian.email)
+    end
+  end
+end

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -312,4 +312,27 @@ RSpec.describe CsvImportService do
       expect(Participant.find_by(email: "xxl@example.com").tshirt_size).to eq("XXL")
     end
   end
+
+  describe "a parent email that repeats the participant's" do
+    let(:self_parent_csv) do
+      <<~CSV
+        Email,First Name,Last Name,Parent First Name,Parent Last Name,Parent Email
+        solo@example.com,Pat,Example,Pat,Example,SOLO@example.com
+      CSV
+    end
+
+    it "imports the participant but creates no guardian" do
+      expect { service.import(self_parent_csv) }.to change(Participant, :count).by(1)
+
+      expect(Guardian.count).to eq(0)
+      expect(GuardianParticipantEvent.count).to eq(0)
+    end
+
+    it "reports the row so the real parent address can be chased" do
+      result = service.import(self_parent_csv)
+
+      expect(result.errors.map { |e| e[:error] })
+        .to include(a_string_matching(/Parent email is the same as the participant's email/))
+    end
+  end
 end


### PR DESCRIPTION
A guardian sharing the participant's email address is one inbox wearing two hats: the minor receives their own guardian invite, can open the guardian portal, and can consent on their own behalf. The phone equivalent was already checked in three controllers — email was checked nowhere.

## Enforcement

Three validations, so no writing path can miss it:

- `Guardian` — email can't equal any linked participant's
- `Participant` — the mirror (the guardian portal lets a guardian edit the participant's email, so this is reachable from both sides)
- `GuardianParticipantEvent` — checked when the link is created, which is the first moment a brand-new guardian can be compared against anyone

All three are gated on the email actually changing (create-only for the link). Roughly 14% of existing guardian links already collide, so a retroactive rule would have locked several hundred people out of portals they're midway through. Those rows stay editable, their portals keep working, and fixing one still passes. There are specs pinning that.

## Per-surface handling

The validations are the backstop, not the UX:

- onboarding guardian step — autosave skips silently (half-typed addresses arrive on every keystroke), submit explains
- onboarding profile step — flashes the real message; that form has no error summary
- admin link-guardian and the guardian edit form
- guardian portal `details` and `participant_info`
- both importers — the participant still imports, the guardian is skipped, the row is reported
- the import preview flags conflicting rows before you hit go

MCP, API and rake paths ride on the model validations.

Guardian portal step views render no error summary at all, so `update_step` now puts model errors in the flash. That also fixes the existing guardian-phone check, which was failing silently there.

## Not covered

`User#sync_email_to_participant` and `backfill:participant_emails` both `save!(validate: false)`, so an upstream auth email change can still land a participant on their guardian's address. Adding a validation there would block sign-in, so it's deliberate.

Existing collisions are left alone by design.

## Testing

Model specs for each validation (including that colliding rows stay editable), a request spec covering onboarding, admin, and both portal directions, and import specs for the skip-and-report path. Full suite green; rubocop clean.