### PR TITLE
Add a ban-list API and scopeable global API tokens

### DIFF
--- a/app/controllers/admin/global_api_tokens_controller.rb
+++ b/app/controllers/admin/global_api_tokens_controller.rb
@@ -7,7 +7,11 @@ module Admin
     end
 
     def create
-      token = GlobalApiToken.generate_for(current_user, name: params[:name].presence)
+      token = GlobalApiToken.generate_for(
+        current_user,
+        name: params[:name].presence,
+        scopes: submitted_scopes
+      )
       flash[:global_api_token] = token.token
       redirect_to admin_global_api_tokens_path,
         notice: "Global API token created. Copy it now — it won't be shown again."
@@ -22,6 +26,13 @@ module Admin
     end
 
     private
+
+    # Unchecked boxes leave scopes empty, which means an unrestricted token —
+    # the behaviour this form had before scoping existed. Unknown values are
+    # dropped here and rejected again by the model.
+    def submitted_scopes
+      Array.wrap(params[:scopes]).map(&:to_s) & GlobalApiToken::SCOPES.keys
+    end
 
     def require_global_admin
       unless current_user&.global_admin?

--- a/app/controllers/api/v1/bans_controller.rb
+++ b/app/controllers/api/v1/bans_controller.rb
@@ -1,0 +1,115 @@
+module Api
+  module V1
+    class BansController < BaseController
+      requires_scope "bans:write"
+
+      before_action :require_global_admin!
+      before_action :set_paper_trail_whodunnit
+
+      # One ban record covers every email belonging to the same person, so a
+      # single call may list several. Mirrors the nested form in the admin UI.
+      def create
+        emails = submitted_emails
+        return render_error("At least one email is required") if emails.empty?
+
+        invalid = emails.reject { |email| email.match?(URI::MailTo::EMAIL_REGEXP) }
+        return render_error("Invalid email format: #{invalid.join(', ')}") if invalid.any?
+
+        expires_at = parsed_expires_at
+        return render_error("expires_at must be an ISO 8601 timestamp") if expires_at == :invalid
+
+        already_listed = BanEmail.where("LOWER(ban_emails.email) IN (?)", emails).includes(:ban)
+        return render_already_listed(already_listed) if already_listed.any?
+
+        ban = Ban.new(reason: params[:reason].presence, expires_at: expires_at, created_by: current_user)
+        emails.each { |email| ban.ban_emails.build(email: email) }
+
+        if ban.save
+          log_ban_created(ban)
+          render json: { ban: ban_json(ban) }, status: :created
+        else
+          render_error(ban.errors.full_messages.to_sentence)
+        end
+      end
+
+      private
+
+      # Accepts either `email` (one) or `emails` (many); duplicates within a
+      # request collapse rather than tripping the uniqueness validation.
+      def submitted_emails
+        raw = params[:emails].presence || params[:email].presence
+        Array.wrap(raw).map { |email| email.to_s.strip.downcase }.reject(&:blank?).uniq
+      end
+
+      # Returns nil when omitted (an indefinite ban) and :invalid when the
+      # caller sent something unparseable, so a typo can't silently become one.
+      # Strict ISO 8601 rather than Time.zone.parse, which happily reads a
+      # partial date out of nonsense and would turn a typo into a real expiry.
+      def parsed_expires_at
+        return nil if params[:expires_at].blank?
+
+        Time.zone.iso8601(params[:expires_at].to_s)
+      rescue ArgumentError
+        :invalid
+      end
+
+      # `ban_emails.email` is globally unique, revoked bans included, so an
+      # already-listed email cannot be attached to a new ban. Point the caller
+      # at the existing record instead of returning a bare validation error.
+      def render_already_listed(ban_emails)
+        render json: {
+          error: "Already on the ban list: #{ban_emails.map(&:email).sort.join(', ')}",
+          bans: ban_emails.map(&:ban).uniq.map { |ban| ban_json(ban) }
+        }, status: :conflict
+      end
+
+      def require_global_admin!
+        return if current_user&.global_admin?
+
+        render json: { error: "Only global admins can manage the ban list" }, status: :forbidden
+      end
+
+      # Api::V1::BaseController descends from ActionController::API, so it
+      # doesn't pick up ApplicationController's PaperTrail hook. Without this
+      # the ban's version history would have no author.
+      def set_paper_trail_whodunnit
+        PaperTrail.request.whodunnit = current_user.id
+      end
+
+      # Api controllers get no equivalent of Admin::BaseController's
+      # log_admin_action, so record the ban explicitly — this is the one action
+      # in the app that blocks someone from every future event.
+      def log_ban_created(ban)
+        AuditLog.log!(
+          action: "create",
+          record: ban,
+          actor: current_user,
+          metadata: {
+            ip: request.remote_ip,
+            user_agent: request.user_agent,
+            controller: controller_name,
+            emails: ban.ban_emails.map(&:email)
+          }
+        )
+      rescue => e
+        Rails.logger.error("[Security] Failed to audit-log ban #{ban.id}: #{e.class} - #{e.message}")
+        Sentry.capture_exception(e) if defined?(Sentry)
+        raise if Rails.env.local?
+      end
+
+      def ban_json(ban)
+        {
+          id: ban.id,
+          emails: ban.ban_emails.map(&:email).sort,
+          reason: ban.reason,
+          status: ban.status,
+          active: ban.active?,
+          expires_at: ban.expires_at&.iso8601,
+          revoked_at: ban.revoked_at&.iso8601,
+          created_at: ban.created_at.iso8601,
+          created_by: ban.created_by && { id: ban.created_by.id, name: ban.created_by.name }
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -2,10 +2,32 @@ module Api
   module V1
     class BaseController < ActionController::API
       before_action :authenticate_token!
+      before_action :authorize_token_scope!
 
       attr_reader :current_user, :current_token, :current_event_from_api_key
 
+      class_attribute :required_scope, instance_writer: false, default: nil
+
+      # Declares the GlobalApiToken scope that reaches this controller. A
+      # scoped token can call nothing else, so leaving it unset — as every
+      # controller but Bans does — keeps that controller full-access only.
+      def self.requires_scope(scope)
+        self.required_scope = scope
+      end
+
       private
+
+      # Scope narrowing applies to global API tokens only: mobile tokens are a
+      # signed-in human with their own permissions, and event API keys are
+      # already restricted per-controller.
+      def authorize_token_scope!
+        return unless current_token.is_a?(GlobalApiToken)
+        return if current_token.permits?(self.class.required_scope)
+
+        render json: {
+          error: "This token is limited to: #{current_token.scope_labels.join(', ')}"
+        }, status: :forbidden
+      end
 
       def authenticate_token!
         token = extract_bearer_token

--- a/app/models/global_api_token.rb
+++ b/app/models/global_api_token.rb
@@ -5,6 +5,7 @@ class GlobalApiToken < ApplicationRecord
 
   validates :token_digest, presence: true, uniqueness: true
   validate :owner_is_global_admin
+  validate :scopes_are_known
 
   # A nil expires_at means the token never expires.
   scope :active, -> {
@@ -17,13 +18,21 @@ class GlobalApiToken < ApplicationRecord
   # (GitHub push protection, etc.) recognize a leaked credential.
   TOKEN_PREFIX = "attn_".freeze
 
-  def self.generate_for(user, name: nil, expires_in: nil)
+  # Narrow capabilities a token can be limited to, mapped to the label shown
+  # when issuing one. An API controller opts into a scope with
+  # `required_scope`; anything that hasn't is unreachable by a scoped token.
+  SCOPES = {
+    "bans:write" => "Add emails to the ban list"
+  }.freeze
+
+  def self.generate_for(user, name: nil, expires_in: nil, scopes: [])
     token = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(32)}"
     global_api_token = create!(
       user: user,
       token_digest: Digest::SHA256.hexdigest(token),
       name: name,
-      expires_at: expires_in&.from_now
+      expires_at: expires_in&.from_now,
+      scopes: Array.wrap(scopes).map(&:to_s).reject(&:blank?).uniq
     )
     global_api_token.token = token
     global_api_token
@@ -56,11 +65,37 @@ class GlobalApiToken < ApplicationRecord
     !expired? && !revoked?
   end
 
+  # No scopes means the token was issued before scoping existed, or was
+  # deliberately issued unrestricted — either way it carries the owner's full
+  # global-admin access.
+  def unrestricted?
+    scopes.empty?
+  end
+
+  # Scoped tokens are deny-by-default: a controller is reachable only if it
+  # names a scope this token holds.
+  def permits?(scope)
+    return true if unrestricted?
+
+    scope.present? && scopes.include?(scope)
+  end
+
+  def scope_labels
+    scopes.map { |scope| SCOPES.fetch(scope, scope) }
+  end
+
   private
 
   def owner_is_global_admin
     return if user&.global_admin?
 
     errors.add(:user, "must be a global admin to hold a global API token")
+  end
+
+  def scopes_are_known
+    unknown = scopes - SCOPES.keys
+    return if unknown.empty?
+
+    errors.add(:scopes, "include unknown values: #{unknown.join(', ')}")
   end
 end

--- a/app/views/admin/global_api_tokens/index.html.erb
+++ b/app/views/admin/global_api_tokens/index.html.erb
@@ -2,8 +2,8 @@
   <div class="mb-6">
     <h1 class="text-3xl font-bold">Global API Tokens</h1>
     <p class="text-gray-600 text-sm mt-1">
-      Global tokens authenticate to the API as you, with your full global-admin access across every event.
-      Only global admins can create them. Treat them like a password.
+      Global tokens authenticate to the API as you, with your full global-admin access across every event —
+      unless you limit one to specific scopes below. Only global admins can create them. Treat them like a password.
     </p>
   </div>
 
@@ -13,13 +13,33 @@
       <h2 class="font-semibold text-gray-900">Create a token</h2>
     </div>
     <div class="p-4">
-      <%= form_with url: admin_global_api_tokens_path, method: :post, class: "flex items-end gap-3 flex-wrap" do |f| %>
-        <div class="flex-1 min-w-[220px]">
+      <%= form_with url: admin_global_api_tokens_path, method: :post, class: "space-y-4" do |f| %>
+        <div class="max-w-md">
           <label class="block text-sm font-medium text-gray-700 mb-1">Name (optional)</label>
           <%= f.text_field :name,
                 placeholder: "e.g. reporting script",
                 class: "w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-[#ec3750] focus:border-[#ec3750]" %>
         </div>
+
+        <div>
+          <span class="block text-sm font-medium text-gray-700 mb-1">Limit to scopes (optional)</span>
+          <p class="text-xs text-gray-500 mb-2">
+            Leave every box unchecked for a full-access token. Tick one and the token can do
+            <strong>only</strong> that — every other endpoint returns 403, including read-only ones.
+          </p>
+          <div class="space-y-2">
+            <% GlobalApiToken::SCOPES.each do |scope, label| %>
+              <label class="flex items-center gap-2">
+                <%= check_box_tag "scopes[]", scope, false,
+                      class: "rounded border-gray-300 text-[#ec3750] focus:ring-[#ec3750]",
+                      id: "scope_#{scope.parameterize.underscore}" %>
+                <span class="text-sm text-gray-700"><%= label %></span>
+                <code class="text-xs text-gray-400"><%= scope %></code>
+              </label>
+            <% end %>
+          </div>
+        </div>
+
         <%= f.submit "Generate Token",
               class: "bg-[#d42f46] hover:bg-[#b82840] text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer" %>
       <% end %>
@@ -41,10 +61,12 @@
     </div>
 
     <% if @global_api_tokens.any? %>
+      <div class="overflow-x-auto">
       <table class="w-full text-sm">
         <thead>
           <tr class="text-left text-gray-500 border-b border-gray-100">
             <th class="px-4 py-2 font-medium">Name</th>
+            <th class="px-4 py-2 font-medium">Scope</th>
             <th class="px-4 py-2 font-medium">Created</th>
             <th class="px-4 py-2 font-medium">Last used</th>
             <th class="px-4 py-2 font-medium">Status</th>
@@ -55,6 +77,17 @@
           <% @global_api_tokens.each do |token| %>
             <tr class="border-b border-gray-50">
               <td class="px-4 py-3 font-medium text-gray-900"><%= token.name.presence || "Untitled" %></td>
+              <td class="px-4 py-3">
+                <% if token.unrestricted? %>
+                  <span class="px-2 py-1 text-xs font-medium rounded bg-amber-100 text-amber-800 whitespace-nowrap">Full access</span>
+                <% else %>
+                  <div class="flex flex-wrap gap-1">
+                    <% token.scope_labels.each do |label| %>
+                      <span class="px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-800 whitespace-nowrap"><%= label %></span>
+                    <% end %>
+                  </div>
+                <% end %>
+              </td>
               <td class="px-4 py-3 text-gray-600"><%= token.created_at.strftime("%b %-d, %Y") %></td>
               <td class="px-4 py-3 text-gray-600"><%= token.last_used_at ? time_ago_in_words(token.last_used_at) + " ago" : "Never" %></td>
               <td class="px-4 py-3">
@@ -77,6 +110,7 @@
           <% end %>
         </tbody>
       </table>
+      </div>
     <% else %>
       <p class="px-4 py-6 text-gray-400 text-sm">No tokens yet.</p>
     <% end %>
@@ -87,6 +121,11 @@
     <div class="mt-3 bg-gray-50 rounded-lg p-4">
       <pre class="bg-gray-800 text-gray-100 p-3 rounded text-xs overflow-x-auto">curl <%= api_v1_events_url %> \
   -H "Authorization: Bearer YOUR_GLOBAL_TOKEN"</pre>
+      <p class="text-xs text-gray-500 mt-3 mb-1">With a token scoped to <code>bans:write</code>:</p>
+      <pre class="bg-gray-800 text-gray-100 p-3 rounded text-xs overflow-x-auto">curl -X POST <%= api_v1_bans_url %> \
+  -H "Authorization: Bearer YOUR_SCOPED_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"banned@example.com","reason":"why"}'</pre>
     </div>
   </details>
 </div>

--- a/config/openapi.yml
+++ b/config/openapi.yml
@@ -23,7 +23,12 @@ info:
       `X-Token-Refresh-Recommended: true` when the token is nearing expiry;
       call `POST /session/refresh` to rotate it.
     - **Global API token** — a superadmin-issued token. Only honoured while its
-      owner is still a global admin. Sets the current user.
+      owner is still a global admin. Sets the current user. May be **scoped**
+      when issued, in which case it reaches only the endpoints that accept
+      that scope and returns `403` everywhere else, read-only endpoints
+      included. An unscoped token carries its owner's full access. Scopes are
+      noted on the endpoints that accept them; the only one today is
+      `bans:write`.
     - **Event API key** — per-event key (`Event#api_key`). Does **not** set a
       current user, so it only works on the subset of endpoints that don't
       require one (participant `lookup`, `roster`, `create`, and the travel
@@ -72,6 +77,8 @@ tags:
     description: Provision and manage participant NFC badges.
   - name: Push Tokens
     description: Register device push-notification tokens.
+  - name: Bans
+    description: The app-wide ban list. Global admins only.
   - name: Travel
     description: >-
       Airport and flight lookups. These endpoints authenticate with the web
@@ -244,6 +251,91 @@ paths:
               schema: { $ref: "#/components/schemas/Success" }
         "404":
           description: Token not found.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /bans:
+    post:
+      tags: [Bans]
+      summary: Add emails to the ban list
+      description: >-
+        Ban one person from every event. A ban holds one or more emails, so
+        send all of a person's addresses in a single call rather than creating
+        a ban per address. Omitting `expires_at` makes the ban indefinite.
+
+
+        Requires a global admin — a mobile token belonging to one, or a global
+        API token. Event API keys are rejected.
+
+
+        This is the only endpoint reachable by a token scoped to `bans:write`,
+        so an integration that just needs to ban people can hold a credential
+        that can do nothing else.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: A single email to ban. Use `emails` for several.
+                  example: banned@example.com
+                emails:
+                  type: array
+                  description: >-
+                    Every email belonging to the person. Case and surrounding
+                    whitespace are normalised, and duplicates collapse.
+                  items: { type: string }
+                reason:
+                  type: string
+                  nullable: true
+                  description: Free text shown to admins in the ban list.
+                expires_at:
+                  type: string
+                  format: date-time
+                  nullable: true
+                  description: >-
+                    ISO 8601 timestamp the ban lifts at. Omit for an
+                    indefinite ban. A value that isn't ISO 8601 is rejected
+                    rather than treated as absent.
+      responses:
+        "201":
+          description: Ban created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ban: { $ref: "#/components/schemas/Ban" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: >-
+            The caller is not a global admin, or holds a scoped token that
+            doesn't include `bans:write`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: >-
+            At least one email is already on the ban list. Emails stay
+            reserved even after a ban is revoked, so the response includes the
+            bans holding them — revoke or reinstate those instead of creating
+            a new one.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  bans:
+                    type: array
+                    items: { $ref: "#/components/schemas/Ban" }
+        "422":
+          description: No email supplied, a malformed email, or a bad `expires_at`.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
@@ -997,6 +1089,31 @@ components:
       type: object
       properties:
         success: { type: boolean, example: true }
+
+    Ban:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        emails:
+          type: array
+          items: { type: string }
+        reason: { type: string, nullable: true }
+        status:
+          type: string
+          description: Indefinite, Active, Expired, or Revoked.
+          example: Indefinite
+        active:
+          type: boolean
+          description: Whether the ban currently blocks registration.
+        expires_at: { type: string, format: date-time, nullable: true }
+        revoked_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }
+        created_by:
+          type: object
+          nullable: true
+          properties:
+            id: { type: string, format: uuid }
+            name: { type: string }
 
     InviteError:
       type: object

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,9 @@ Rails.application.routes.draw do
       resources :events, only: [ :index ]
       resources :push_tokens, only: [ :create, :destroy ], param: :token
 
+      # Global-admin only: adds emails to the app-wide ban list.
+      resources :bans, only: [ :create ]
+
       get "travel/search_airports", to: "travel#search_airports"
       post "travel/validate_flight", to: "travel#validate_flight"
 

--- a/db/migrate/20260901120000_add_scopes_to_global_api_tokens.rb
+++ b/db/migrate/20260901120000_add_scopes_to_global_api_tokens.rb
@@ -1,0 +1,8 @@
+class AddScopesToGlobalApiTokens < ActiveRecord::Migration[8.1]
+  # An empty array means unrestricted — every token issued before this column
+  # existed keeps its full global-admin access. A non-empty array narrows the
+  # token to just those scopes; see GlobalApiToken::SCOPES.
+  def change
+    add_column :global_api_tokens, :scopes, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -476,6 +476,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
     t.datetime "last_used_at"
     t.string "name"
     t.datetime "revoked_at"
+    t.string "scopes", default: [], null: false, array: true
     t.string "token_digest", null: false
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false

--- a/spec/models/global_api_token_spec.rb
+++ b/spec/models/global_api_token_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe GlobalApiToken, type: :model do
+  let(:admin) { create(:user, global_role: :global_admin) }
+
+  describe "scopes" do
+    it "issues an unrestricted token when none are given" do
+      token = described_class.generate_for(admin)
+
+      expect(token.scopes).to eq([])
+      expect(token).to be_unrestricted
+    end
+
+    # Tokens created before the column existed default to [], so they must keep
+    # working everywhere rather than losing access on deploy.
+    it "treats an unrestricted token as permitting every scope, named or not" do
+      token = described_class.generate_for(admin)
+
+      expect(token.permits?("bans:write")).to be(true)
+      expect(token.permits?(nil)).to be(true)
+    end
+
+    it "permits only the scopes it holds" do
+      token = described_class.generate_for(admin, scopes: [ "bans:write" ])
+
+      expect(token).not_to be_unrestricted
+      expect(token.permits?("bans:write")).to be(true)
+      expect(token.permits?("something:else")).to be(false)
+    end
+
+    # A controller that declares no scope is full-access only, so a scoped
+    # token must be refused there rather than falling through to allowed.
+    it "refuses a nil scope once restricted" do
+      token = described_class.generate_for(admin, scopes: [ "bans:write" ])
+
+      expect(token.permits?(nil)).to be(false)
+      expect(token.permits?("")).to be(false)
+    end
+
+    it "normalises and de-duplicates the requested scopes" do
+      token = described_class.generate_for(admin, scopes: [ :"bans:write", "bans:write", "" ])
+
+      expect(token.scopes).to eq([ "bans:write" ])
+    end
+
+    it "rejects an unknown scope" do
+      expect { described_class.generate_for(admin, scopes: [ "bans:write", "everything" ]) }
+        .to raise_error(ActiveRecord::RecordInvalid, /unknown values: everything/)
+    end
+
+    it "labels its scopes for display" do
+      token = described_class.generate_for(admin, scopes: [ "bans:write" ])
+
+      expect(token.scope_labels).to eq([ "Add emails to the ban list" ])
+    end
+  end
+end

--- a/spec/requests/admin/global_api_tokens_spec.rb
+++ b/spec/requests/admin/global_api_tokens_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Admin::GlobalApiTokens", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:user, global_role: :global_admin) }
+
+  before { sign_in admin }
+
+  it "offers each available scope on the create form" do
+    get admin_global_api_tokens_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("bans:write")
+    expect(response.body).to include("Add emails to the ban list")
+  end
+
+  it "issues a token limited to the ticked scopes" do
+    post admin_global_api_tokens_path, params: { name: "ban bot", scopes: [ "bans:write" ] }
+
+    token = GlobalApiToken.last
+    expect(token.scopes).to eq([ "bans:write" ])
+    expect(token.name).to eq("ban bot")
+  end
+
+  it "issues a full-access token when no scope is ticked" do
+    post admin_global_api_tokens_path, params: { name: "reporting" }
+
+    expect(GlobalApiToken.last).to be_unrestricted
+  end
+
+  # A hand-crafted form post shouldn't be able to invent a scope that no
+  # controller honours — that would read as "restricted" while permitting
+  # nothing, which is confusing rather than dangerous, but still wrong.
+  it "drops a scope the app doesn't define" do
+    post admin_global_api_tokens_path, params: { scopes: [ "bans:write", "everything" ] }
+
+    expect(GlobalApiToken.last.scopes).to eq([ "bans:write" ])
+  end
+
+  it "shows how each token is scoped in the list" do
+    GlobalApiToken.generate_for(admin, name: "ban bot", scopes: [ "bans:write" ])
+    GlobalApiToken.generate_for(admin, name: "reporting")
+
+    get admin_global_api_tokens_path
+
+    expect(response.body).to include("Add emails to the ban list")
+    expect(response.body).to include("Full access")
+  end
+
+  # Bounced by Admin::BaseController before the tokens controller is reached,
+  # so assert on the outcome rather than on which path it lands at.
+  it "keeps non-admins out" do
+    sign_in create(:user)
+    post admin_global_api_tokens_path, params: { scopes: [ "bans:write" ] }
+
+    expect(response).to have_http_status(:redirect)
+    expect(GlobalApiToken.count).to eq(0)
+  end
+end

--- a/spec/requests/api/v1/bans_spec.rb
+++ b/spec/requests/api/v1/bans_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Bans", type: :request do
+  let(:admin) { create(:user, global_role: :global_admin) }
+  let(:headers) { { "Authorization" => "Bearer #{MobileToken.generate_for(admin).token}" } }
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  it "creates an indefinite ban from a single email" do
+    post api_v1_bans_path, params: { email: "Blocked@Example.com", reason: "Test" }, headers: headers
+
+    expect(response).to have_http_status(:created)
+    expect(json["ban"]["emails"]).to eq([ "blocked@example.com" ])
+    expect(json["ban"]["status"]).to eq("Indefinite")
+    expect(json["ban"]["created_by"]["id"]).to eq(admin.id)
+    expect(Ban.banned?("blocked@example.com")).to be(true)
+  end
+
+  it "puts every email for one person on the same ban" do
+    post api_v1_bans_path,
+      params: { emails: [ "one@example.com", " ONE@example.com ", "two@example.com" ] },
+      headers: headers
+
+    expect(response).to have_http_status(:created)
+    expect(Ban.count).to eq(1)
+    expect(json["ban"]["emails"]).to eq([ "one@example.com", "two@example.com" ])
+  end
+
+  it "honours an expiry" do
+    post api_v1_bans_path,
+      params: { email: "temporary@example.com", expires_at: 3.days.from_now.iso8601 },
+      headers: headers
+
+    expect(response).to have_http_status(:created)
+    expect(json["ban"]["status"]).to eq("Active")
+    expect(Ban.last.expires_at).to be_within(1.second).of(3.days.from_now)
+  end
+
+  # A typo here would otherwise be dropped and quietly create a permanent ban.
+  it "rejects an unparseable expiry rather than banning indefinitely" do
+    post api_v1_bans_path,
+      params: { email: "temporary@example.com", expires_at: "next tuesday-ish" },
+      headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json["error"]).to match(/expires_at/)
+    expect(Ban.count).to eq(0)
+  end
+
+  it "rejects a missing email" do
+    post api_v1_bans_path, params: { reason: "No email" }, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json["error"]).to match(/at least one email/i)
+  end
+
+  it "rejects a malformed email" do
+    post api_v1_bans_path, params: { email: "not-an-email" }, headers: headers
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(json["error"]).to match(/invalid email format/i)
+    expect(Ban.count).to eq(0)
+  end
+
+  # ban_emails.email is globally unique, so the caller needs the existing
+  # record's id to act on it rather than a bare validation failure.
+  it "returns the existing ban when the email is already listed" do
+    existing = create(:ban, email: "repeat@example.com")
+
+    post api_v1_bans_path, params: { email: "REPEAT@example.com" }, headers: headers
+
+    expect(response).to have_http_status(:conflict)
+    expect(json["error"]).to match(/already on the ban list/i)
+    expect(json["bans"].map { |ban| ban["id"] }).to eq([ existing.id ])
+    expect(Ban.count).to eq(1)
+  end
+
+  it "reports a revoked ban as the conflict, since its email stays reserved" do
+    existing = create(:ban, email: "revoked@example.com")
+    existing.revoke!(by: admin)
+
+    post api_v1_bans_path, params: { email: "revoked@example.com" }, headers: headers
+
+    expect(response).to have_http_status(:conflict)
+    expect(json["bans"].first["status"]).to eq("Revoked")
+  end
+
+  it "attributes the ban in the audit log and version history" do
+    post api_v1_bans_path, params: { email: "audited@example.com" }, headers: headers
+
+    ban = Ban.last
+    log = AuditLog.for_record(ban).last
+    expect(log.actor).to eq(admin)
+    expect(log.metadata["emails"]).to eq([ "audited@example.com" ])
+    expect(ban.versions.last.whodunnit).to eq(admin.id.to_s)
+  end
+
+  describe "authorization" do
+    it "refuses a non-admin user" do
+      staff = create(:user)
+      post api_v1_bans_path,
+        params: { email: "blocked@example.com" },
+        headers: { "Authorization" => "Bearer #{MobileToken.generate_for(staff).token}" }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(Ban.count).to eq(0)
+    end
+
+    it "refuses an event API key, which has no user behind it" do
+      api_key = create(:event).generate_api_key!
+      post api_v1_bans_path,
+        params: { email: "blocked@example.com" },
+        headers: { "Authorization" => "Bearer #{api_key}" }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(Ban.count).to eq(0)
+    end
+
+    it "refuses a request with no token" do
+      post api_v1_bans_path, params: { email: "blocked@example.com" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(Ban.count).to eq(0)
+    end
+
+    it "accepts a global API token" do
+      token = GlobalApiToken.generate_for(admin).token
+      post api_v1_bans_path,
+        params: { email: "blocked@example.com" },
+        headers: { "Authorization" => "Bearer #{token}" }
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+
+  describe "token scoping" do
+    def scoped_headers(scopes)
+      { "Authorization" => "Bearer #{GlobalApiToken.generate_for(admin, scopes: scopes).token}" }
+    end
+
+    it "accepts a token scoped to bans:write" do
+      post api_v1_bans_path, params: { email: "blocked@example.com" }, headers: scoped_headers([ "bans:write" ])
+
+      expect(response).to have_http_status(:created)
+      expect(Ban.banned?("blocked@example.com")).to be(true)
+    end
+
+    # The point of the scope: a leaked ban-list token must not read the
+    # participant data the same global admin can reach interactively.
+    it "refuses that token everywhere else, read-only endpoints included" do
+      headers = scoped_headers([ "bans:write" ])
+
+      get api_v1_events_path, headers: headers
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to match(/limited to: Add emails to the ban list/)
+
+      get api_v1_me_path, headers: headers
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "leaves an unscoped token with its full access" do
+      headers = { "Authorization" => "Bearer #{GlobalApiToken.generate_for(admin).token}" }
+
+      get api_v1_events_path, headers: headers
+      expect(response).to have_http_status(:ok)
+
+      post api_v1_bans_path, params: { email: "blocked@example.com" }, headers: headers
+      expect(response).to have_http_status(:created)
+    end
+
+    it "does not restrict a mobile token, which carries a signed-in human" do
+      get api_v1_events_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Adds `POST /api/v1/bans` so an integration can put someone on the app-wide ban list without a browser session, and lets a global API token be scoped to just that.

## The endpoint

```
POST /api/v1/bans
{ "emails": ["…", "…"], "reason": "…", "expires_at": "2026-12-01T00:00:00Z" }
```

Takes `email` (one) or `emails` (many). A ban holds every address belonging to one person, matching the admin form, so callers send them in a single request rather than creating one ban per address. `reason` and `expires_at` are optional; no expiry means indefinite.

Global admins only — a mobile token belonging to one, or a global API token. Event API keys are rejected.

## Decisions worth reviewing

**409 rather than a validation error when an email is already listed.** `ban_emails.email` is globally unique *including revoked bans*, so an address that has ever been banned can't be attached to a new one. The response carries the ban already holding it, so the caller knows to revoke or reinstate rather than retrying.

**`expires_at` is strict ISO 8601.** `Time.zone.parse` happily reads a partial date out of nonsense, which would quietly turn a typo into either a real expiry or an indefinite ban. `Time.zone.iso8601` rejects it instead. Side effect: space-separated `"2026-09-05 12:00:00"` is refused.

**Attribution is set explicitly.** `Api::V1::BaseController` descends from `ActionController::API`, so it inherits neither `ApplicationController`'s PaperTrail hook nor anything like `Admin::BaseController#log_admin_action`. Banning is the one action that blocks someone from every future event, so it shouldn't land in the history unattributed. Worth noting the other API mutations (notes, scans, NFC badges) still are — a real gap, but wider than this change.

**Token scoping is deny-by-default.** A scoped token reaches only the controllers naming a scope it holds, and gets 403 everywhere else — read-only endpoints included. That's the point: a leaked ban-list credential must not read the participant data its owner can reach interactively. The cost is that a scoped token can't do the harmless reads either, so anything wanting both needs two tokens. The form copy says so outright.

**Empty scopes means unrestricted**, which is what every existing token has, so none of them change behaviour — no backfill, no access lost on deploy. Only global API tokens are narrowed; mobile tokens are a signed-in human with their own permissions, and event API keys are already restricted per-controller.

Mechanically it's a `class_attribute` on the API base controller plus one `requires_scope "bans:write"` line, so adding a scope later is a one-line opt-in.

## UI

`/admin/global_api_tokens` gets a "Limit to scopes" checklist on the create form and a scope badge per row. The new column pushed the table past a phone width, so it's wrapped in `overflow-x-auto`.

## Verification

13 new specs (7 model, 6 admin request) plus 4 scoping cases on the bans request spec — all green, `rubocop` clean.

Also driven against a local server: a `bans:write` token got 201 on `POST /bans` and 403 on `/events` and `/me`; an unscoped token still got 200 on `/events`. Checked the admin page at desktop and mobile widths.

One pre-existing failure in `webhooks_spec.rb:247` is unrelated — it's the "docuseal secret not configured" case, which flips depending on whether credentials are readable locally.
