### PR TITLE
Add a Series API with one key per event series

### DIFF
--- a/app/controllers/admin/series_api_tokens_controller.rb
+++ b/app/controllers/admin/series_api_tokens_controller.rb
@@ -1,0 +1,59 @@
+module Admin
+  # Issues, rotates and revokes the API keys that back the Series API.
+  #
+  # Owner-only, like series membership: a series key acts as an event admin on
+  # every event in the series and is the only credential that can create new
+  # ones (see Api::V1::Series::EventsController).
+  class SeriesApiTokensController < BaseController
+    skip_before_action :set_current_event_from_session
+
+    before_action :set_series
+    before_action :require_series_owner_access
+
+    def index
+      @series_api_tokens = @series.series_api_tokens.active.includes(:user).order(created_at: :desc)
+    end
+
+    def create
+      name = params[:name].to_s.strip
+      if name.blank?
+        redirect_to admin_series_api_tokens_path(@series), alert: "Please enter a name for the API key."
+        return
+      end
+
+      token = SeriesApiToken.generate_for(@series, user: current_user, name: name)
+      flash[:series_api_token] = token.token
+      flash[:series_api_token_id] = token.id
+      redirect_to admin_series_api_tokens_path(@series),
+        notice: "API key \"#{token.name}\" created. Copy it now — it won't be shown again."
+    end
+
+    def rotate
+      token = @series.series_api_tokens.active.find(params[:id])
+      token.rotate!
+      flash[:series_api_token] = token.token
+      flash[:series_api_token_id] = token.id
+      redirect_to admin_series_api_tokens_path(@series),
+        notice: "API key \"#{token.name}\" rotated. Copy the new value now — it won't be shown again."
+    end
+
+    def destroy
+      token = @series.series_api_tokens.active.find(params[:id])
+      token.revoke!
+      redirect_to admin_series_api_tokens_path(@series),
+        notice: "API key \"#{token.name}\" revoked."
+    end
+
+    private
+
+    def set_series
+      @series = EventSeries.find_by!(slug: params[:series_slug])
+    end
+
+    def require_series_owner_access
+      return if policy(@series).manage_api_tokens?
+
+      redirect_to admin_series_path(@series), alert: "Only series owners can manage API keys."
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -3,7 +3,8 @@ module Api
     class BaseController < ActionController::API
       before_action :authenticate_token!
 
-      attr_reader :current_user, :current_token, :current_event_from_api_key
+      attr_reader :current_user, :current_token, :current_event_from_api_key,
+                  :current_series_from_api_key, :current_series_api_token
 
       private
 
@@ -41,6 +42,16 @@ module Api
           return
         end
 
+        series_token = SeriesApiToken.find_by_token(token)
+        if series_token
+          # Deliberately not @current_token: that reader is the mobile-token
+          # contract (revoke!/refresh!), and an API key is not refreshable.
+          @current_series_api_token = series_token
+          @current_series_from_api_key = series_token.event_series
+          series_token.touch_last_used!
+          return
+        end
+
         @current_event_from_api_key = Event.find_by_api_key(token)
         if @current_event_from_api_key
           return
@@ -56,7 +67,42 @@ module Api
         header.split(" ").last
       end
 
+      # True when the caller authenticated with an API key rather than a
+      # person. There is no current_user on these requests, so endpoints that
+      # need one have to keep them out explicitly.
+      def api_key_request?
+        current_event_from_api_key.present? || current_series_from_api_key.present?
+      end
+
+      # An event API key may only act on the one event it was issued for; a
+      # series API key may act on every event inside its series. That breadth
+      # is the whole point of a series key — one credential for a series that
+      # runs many events.
+      def api_key_scoped_to_event?(event)
+        return true if current_event_from_api_key && current_event_from_api_key.id == event.id
+        return true if current_series_from_api_key && event.event_series_id == current_series_from_api_key.id
+
+        false
+      end
+
+      # Renders 403 and returns false when the current API key can't act on
+      # `event`, so callers can `return unless require_api_key_event_scope!(...)`.
+      def require_api_key_event_scope!(event)
+        return true if api_key_scoped_to_event?(event)
+
+        render json: { error: "API key is not valid for this event" }, status: :forbidden
+        false
+      end
+
       def require_event_access!(event)
+        # API keys authenticate without a user. Endpoints that accept a key
+        # branch on api_key_request? before reaching here; the rest need a
+        # person, and would otherwise raise on nil instead of answering.
+        if current_user.nil?
+          render json: { error: "API key is not authorized for this action" }, status: :forbidden
+          return
+        end
+
         unless current_user.can_access_event?(event)
           render json: { error: "Forbidden" }, status: :forbidden
         end

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -35,8 +35,10 @@ module Api
 
       private
 
+      # Notes are attributed to their author, so every note endpoint needs a
+      # person behind the request. No API key — event or series — qualifies.
       def reject_api_key_auth
-        return unless current_event_from_api_key
+        return unless api_key_request?
         render json: { error: "API key is not authorized for notes" }, status: :forbidden
       end
 
@@ -44,10 +46,8 @@ module Api
         @event = Event.find(params[:event_id])
         Current.event = @event
 
-        if current_event_from_api_key
-          unless current_event_from_api_key.id == @event.id
-            render json: { error: "API key is not valid for this event" }, status: :forbidden
-          end
+        if api_key_request?
+          require_api_key_event_scope!(@event)
         else
           authorize @event, :api_participants?
         end

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -162,14 +162,15 @@ module Api
 
       private
 
-      # An event API key may only send invitations and read minimal
+      # An API key may only send invitations and read minimal
       # identity/registration data (lookup, roster) — never the full
       # participant payload from index/show, which includes sensitive
-      # medical/safeguarding/travel PII.
+      # medical/safeguarding/travel PII. Applies to event and series keys
+      # alike: a series key is broader in reach, not in what it may read.
       API_KEY_ALLOWED_ACTIONS = %w[create lookup roster].freeze
 
       def restrict_api_key_actions
-        return unless current_event_from_api_key
+        return unless api_key_request?
         return if API_KEY_ALLOWED_ACTIONS.include?(action_name)
 
         render json: { error: "API key is not authorized for this action" }, status: :forbidden
@@ -179,10 +180,8 @@ module Api
         @event = Event.find_by(id: params[:event_id]) || Event.find_by!(slug: params[:event_id])
         Current.event = @event
 
-        if current_event_from_api_key
-          unless current_event_from_api_key.id == @event.id
-            render json: { error: "API key is not valid for this event" }, status: :forbidden
-          end
+        if api_key_request?
+          require_api_key_event_scope!(@event)
         else
           authorize @event, :api_participants?
         end
@@ -218,9 +217,10 @@ module Api
           participant_event_id: pe.id,
           display_name: participant.display_name,
           full_name: participant.full_name,
-          email: participant.email,
+          # Contact details are omitted, not nulled, for PII-restricted roles —
+          # same contract as date_of_birth and address in #personal_json.
+          **(include_pii? ? { email: participant.email, phone: participant.phone } : {}),
           slack_user_id: participant.slack_user_id,
-          phone: participant.phone,
           pronouns: participant.pronouns,
           headshot_url: headshot_url_for(participant),
           status: pe.status,
@@ -427,14 +427,13 @@ module Api
           id: gpe.id,
           guardian_id: g&.id,
           name: g&.full_name,
-          email: g&.email,
-          phone: gpe.phone_override.presence || g&.phone,
+          **(include_pii? ? { email: g&.email, phone: gpe.phone_override.presence || g&.phone } : {}),
           relationship: gpe.relationship,
           is_primary: gpe.is_primary_guardian,
           status: gpe.status,
           accepted_at: gpe.accepted_at&.iso8601,
           completed_at: gpe.completed_at&.iso8601,
-          invited_via_email: gpe.invited_via_email,
+          **(include_pii? ? { invited_via_email: gpe.invited_via_email } : {}),
           invite_token_sent_at: gpe.invite_token_sent_at&.iso8601,
           media_permission: gpe.media_permission,
           photo_permission: gpe.photo_permission,
@@ -445,7 +444,12 @@ module Api
         }
       end
 
+      # An emergency contact's phone number is the one number a PII-restricted
+      # role keeps — you can't run an incident without being able to call
+      # someone — but they get the first name only, and no email address.
       def emergency_contact_json(ec)
+        return { id: ec.id, name: ec.first_name, phone: ec.phone, priority: ec.priority } unless include_pii?
+
         {
           id: ec.id,
           name: ec.name,
@@ -524,7 +528,8 @@ module Api
         }
       end
 
-      # Whether this caller gets exact dates of birth and addresses. Memoized
+      # Whether this caller gets exact dates of birth, addresses, and contact
+      # details (their own and their guardians'). Memoized
       # for the same reason as can_view_sensitive_data? below. A nil
       # current_user means an event API key, which never reaches the actions
       # that serve these fields (see API_KEY_ALLOWED_ACTIONS).
@@ -551,6 +556,8 @@ module Api
       def emergency_contacts_json(pe)
         pe.guardian_participant_events.flat_map do |gpe|
           gpe.emergency_contacts.sort_by { |ec| ec.priority || Float::INFINITY }.map do |ec|
+            next { name: ec.first_name, phone: ec.phone, priority: ec.priority } unless include_pii?
+
             {
               name: ec.name,
               phone: ec.phone,

--- a/app/controllers/api/v1/series/events_controller.rb
+++ b/app/controllers/api/v1/series/events_controller.rb
@@ -1,0 +1,187 @@
+module Api
+  module V1
+    module Series
+      # Events inside one series, addressed with a single series API key.
+      #
+      # Creating an event is the one write in the whole API that *requires* a
+      # series API key: a mobile token, a global token and an event key are all
+      # refused, because an event has to land in a series and only a series key
+      # names one unambiguously. The series comes from the key, never from the
+      # request body — a client cannot create an event anywhere else, even by
+      # passing a different `event_series_id`.
+      #
+      # Everything the web's new-event form requires is required here too
+      # (`name` and `support_email`, the latter on a Hack Club domain), and
+      # everything the rest of the web's setup wizard *accepts* — schedule,
+      # location, module toggles — may be sent in the same call.
+      class EventsController < BaseController
+        include Pundit::Authorization
+        include Api::V1::SeriesScoped
+        include Api::V1::EventSerialization
+
+        rescue_from Pundit::NotAuthorizedError do
+          render json: { error: "Forbidden" }, status: :forbidden
+        end
+
+        before_action :require_series_api_key!, only: [ :create ]
+        before_action :set_event, only: [ :show, :update ]
+
+        def index
+          events = @series.events
+            .includes(:event_series)
+            .order(Arel.sql("starts_at ASC NULLS LAST"))
+
+          render json: { events: events.map { |event| series_event_json(event, summary: true) } }
+        end
+
+        def show
+          render json: { event: series_event_json(@event) }
+        end
+
+        def create
+          if foreign_series_id?
+            return render json: {
+              error: "A series API key can only create events in its own series (#{@series.slug}); " \
+                     "remove event_series_id or set it to #{@series.id}."
+            }, status: :forbidden
+          end
+
+          missing = REQUIRED_ON_CREATE.reject { |field| params.dig(:event, field).present? }
+          if missing.any?
+            return render json: { error: "#{missing.join(' and ')} #{missing.one? ? 'is' : 'are'} required" },
+                          status: :unprocessable_entity
+          end
+
+          @event = Event.new(event_params.merge(event_series: @series))
+
+          if @event.save
+            grant_token_owner_event_admin
+            log_event_change(:record_create)
+            render json: { event: series_event_json(@event) }, status: :created
+          else
+            render json: { error: @event.errors.full_messages.to_sentence }, status: :unprocessable_entity
+          end
+        end
+
+        def update
+          if @event.update(event_params)
+            log_event_change(:record_update)
+            render json: { event: series_event_json(@event) }
+          else
+            render json: { error: @event.errors.full_messages.to_sentence }, status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        # Mirrors the two fields the web's new-event form marks required (name
+        # is validated by the model, support_email by both). Everything else on
+        # that form — slug, timezone, logo — is optional there and optional here.
+        REQUIRED_ON_CREATE = %i[name support_email].freeze
+
+        def require_series_api_key!
+          return if current_series_from_api_key
+
+          render json: {
+            error: "Creating an event requires a series API key. " \
+                   "Issue one from the series' API page in the Attend dashboard."
+          }, status: :forbidden
+        end
+
+        # The series is taken from the key, so a body that names a *different*
+        # one is a client bug worth reporting rather than silently overriding.
+        def foreign_series_id?
+          supplied = params.dig(:event, :event_series_id).presence
+          return false if supplied.blank?
+
+          ![ @series.id, @series.slug ].include?(supplied.to_s)
+        end
+
+        def set_event
+          @event = @series.events.find_by(id: params[:id]) || @series.events.find_by(slug: params[:id])
+
+          # Deliberately 404 rather than 403 for an event in another series:
+          # from this key's point of view the event does not exist, and saying
+          # otherwise would confirm a slug the caller has no standing over.
+          return render json: { error: "Event not found in this series" }, status: :not_found if @event.nil?
+
+          Current.event = @event
+
+          if api_key_request?
+            require_api_key_event_scope!(@event)
+          else
+            authorize @event, :update?
+          end
+        end
+
+        # Same permitted set as the web's Admin::EventsController#event_params,
+        # minus the attachments (logos are uploaded from the dashboard) and
+        # minus event_series_id, which the key decides. Keep the two in step.
+        def event_params
+          params.require(:event).permit(
+            :name,
+            :slug,
+            :starts_at,
+            :ends_at,
+            :registration_open_at,
+            :registration_close_at,
+            :location_city,
+            :location_country,
+            :location_address,
+            :location_latitude,
+            :location_longitude,
+            :venue_name,
+            :timezone,
+            :support_email,
+            :freedom_waivers_enabled,
+            :travel_enabled,
+            :visa_options_enabled,
+            :visa_application_url,
+            :accommodation_enabled,
+            :roommate_preferences_enabled,
+            :guardian_invites_locked,
+            :hotel_scan_context_id,
+            :nfc_badges_enabled,
+            :nfc_badge_write_on_checkin_enabled,
+            :groups_enabled
+          )
+        end
+
+        # The web gives a series member who creates an event an explicit
+        # event_admin role (Admin::EventsController#ensure_creator_has_admin_role)
+        # so per-event staff tooling reflects them. An API-created event has no
+        # signed-in creator, so the token's owner stands in — they're the series
+        # member who issued the key.
+        def grant_token_owner_event_admin
+          owner = current_series_api_token&.user
+          return if owner.nil? || owner.global_admin?
+
+          @event.event_role_assignments.find_or_create_by!(user: owner, role: "event_admin")
+        end
+
+        # API-key requests have no current_user, so the token's owner is the
+        # closest thing to an actor; the token name goes in the metadata either
+        # way so a series key's writes are attributable.
+        def log_event_change(action)
+          AuditLog.log!(
+            action: action,
+            record: @event,
+            actor: current_user || current_series_api_token&.user,
+            event: @event,
+            changed_fields: @event.previous_changes.except("created_at", "updated_at"),
+            metadata: {
+              ip: request.remote_ip,
+              user_agent: request.user_agent,
+              source: "series_api",
+              series_id: @series.id,
+              series_api_token_name: current_series_api_token&.name
+            }.compact
+          )
+        rescue StandardError => e
+          Rails.logger.error("[SeriesApi] Failed to write audit log: #{e.class} - #{e.message}")
+          Sentry.capture_exception(e) if defined?(Sentry)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/series_controller.rb
+++ b/app/controllers/api/v1/series_controller.rb
@@ -1,0 +1,62 @@
+module Api
+  module V1
+    # Read-only view of an event series.
+    #
+    # The point of the Series API is that a series organizer holds one
+    # credential for a whole series: `GET /series/current` tells a client which
+    # series its key belongs to, and everything else hangs off
+    # `/series/:series_id/events`.
+    class SeriesController < BaseController
+      include Pundit::Authorization
+      include SeriesScoped
+
+      rescue_from Pundit::NotAuthorizedError do
+        render json: { error: "Forbidden" }, status: :forbidden
+      end
+
+      skip_before_action :set_series, only: [ :index ]
+
+      def index
+        render json: { series: visible_series.map { |series| series_json(series) } }
+      end
+
+      def show
+        render json: { series: series_json(@series, detailed: true) }
+      end
+
+      private
+
+      # A series key sees exactly one series — itself — so index doubles as
+      # "who am I?" for a client that only has the key.
+      def visible_series
+        if current_series_from_api_key
+          EventSeries.where(id: current_series_from_api_key.id)
+        elsif current_event_from_api_key
+          EventSeries.none
+        else
+          policy_scope(EventSeries)
+        end.order(:name)
+      end
+
+      def series_json(series, detailed: false)
+        payload = {
+          id: series.id,
+          slug: series.slug,
+          name: series.name,
+          description: series.description,
+          contact_email: series.contact_email,
+          event_count: series.events.size,
+          created_at: series.created_at.iso8601,
+          updated_at: series.updated_at.iso8601
+        }
+        return payload unless detailed
+
+        payload.merge(
+          events: series.events.order(:starts_at).map do |event|
+            { id: event.id, slug: event.slug, name: event.name, starts_at: event.starts_at&.iso8601 }
+          end
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/token_revocations_controller.rb
+++ b/app/controllers/api/v1/token_revocations_controller.rb
@@ -18,8 +18,8 @@ module Api
     # the owner on every successful revocation, since it can't tell whether the
     # caller (e.g. Revoker) sends its own notification.
     #
-    # Handles all three token kinds: GlobalApiToken, EventApiToken, and the
-    # legacy single Event#api_key.
+    # Handles every token kind: GlobalApiToken, SeriesApiToken, EventApiToken,
+    # and the legacy single Event#api_key.
     class TokenRevocationsController < ActionController::API
       # Deliberately no authenticate_token! — this endpoint is public by design.
 
@@ -62,6 +62,18 @@ module Api
           }
         end
 
+        if (series_token = SeriesApiToken.find_by_token(token))
+          series_token.revoke!
+          series = series_token.event_series
+          owner = series_token.user&.email
+          recipients = [ owner ].compact.presence || series_owner_emails(series)
+          send_email(recipients, token_name: series_token.name, kind: "series", series_name: series.name)
+          return {
+            owner_email: owner || recipients.first,
+            key_name: "#{series_token.name} (#{series.name})"
+          }
+        end
+
         if (event = Event.find_by_api_key(token))
           # Legacy single event key: revoking means clearing its digest.
           event.update!(api_key_digest: nil)
@@ -77,7 +89,13 @@ module Api
         event.event_role_assignments.event_admin.includes(:user).filter_map { |a| a.user&.email }
       end
 
-      def send_email(emails, token_name:, kind:, event_name: nil)
+      # Series owners are the people who can issue a replacement key, so
+      # they're who hears about it when the token's own creator is gone.
+      def series_owner_emails(series)
+        series.series_role_assignments.where(role: :owner).includes(:user).filter_map { |a| a.user&.email }
+      end
+
+      def send_email(emails, token_name:, kind:, event_name: nil, series_name: nil)
         emails.compact.uniq.each do |email|
           next if email.blank?
 
@@ -85,7 +103,8 @@ module Api
             email: email,
             token_name: token_name,
             token_kind: kind,
-            event_name: event_name
+            event_name: event_name,
+            series_name: series_name
           ).revoked.deliver_later
         end
       end

--- a/app/controllers/api/v1/travel_calendar_controller.rb
+++ b/app/controllers/api/v1/travel_calendar_controller.rb
@@ -22,16 +22,15 @@ module Api
       end
 
       def authorize_event
-        if current_event_from_api_key
-          unless current_event_from_api_key.id == @event.id
-            render json: { error: "API key is not valid for this event" }, status: :forbidden
-          end
+        if api_key_request?
+          require_api_key_event_scope!(@event)
         else
           require_event_access!(@event)
         end
       end
 
-      # No current_user means an event API key, which keeps the full payload.
+      # No current_user means an event or series API key, which keeps the full
+      # payload.
       def include_addresses?
         current_user.nil? || current_user.can_view_participant_pii?(@event)
       end

--- a/app/controllers/concerns/api/v1/event_serialization.rb
+++ b/app/controllers/concerns/api/v1/event_serialization.rb
@@ -1,0 +1,62 @@
+module Api
+  module V1
+    # One shape for an event across the Series API, so a POST response, a PATCH
+    # response and a GET of the same event never drift apart.
+    module EventSerialization
+      extend ActiveSupport::Concern
+
+      private
+
+      # `summary: true` drops the module flags and the setup detail — enough to
+      # list a series' events without paying for fields a list view ignores.
+      def series_event_json(event, summary: false)
+        payload = {
+          id: event.id,
+          slug: event.slug,
+          name: event.name,
+          series: {
+            id: event.event_series_id,
+            slug: event.event_series&.slug,
+            name: event.event_series&.name
+          },
+          support_email: event.support_email,
+          timezone: event.timezone_identifier,
+          starts_at: event.starts_at&.iso8601,
+          ends_at: event.ends_at&.iso8601,
+          registration_open_at: event.registration_open_at&.iso8601,
+          registration_close_at: event.registration_close_at&.iso8601,
+          venue_name: event.venue_name,
+          location_city: event.location_city,
+          location_country: event.location_country,
+          location_address: event.location_address,
+          location_latitude: event.location_latitude&.to_f,
+          location_longitude: event.location_longitude&.to_f,
+          setup_complete: event.setup_complete?,
+          created_at: event.created_at.iso8601,
+          updated_at: event.updated_at.iso8601
+        }
+        return payload if summary
+
+        payload.merge(
+          # Read through the `?` predicates: the flags live in a jsonb store
+          # and hold whatever the web form last wrote ("1", "true", true), so
+          # only the predicates give a client a real boolean.
+          modules: {
+            freedom_waivers_enabled: event.freedom_waivers_enabled?,
+            travel_enabled: event.travel_enabled?,
+            visa_options_enabled: event.visa_options_enabled?,
+            visa_application_url: event.visa_application_url,
+            accommodation_enabled: event.accommodation_enabled?,
+            roommate_preferences_enabled: event.roommate_preferences_enabled?,
+            guardian_invites_locked: event.guardian_invites_locked?,
+            nfc_badges_enabled: event.nfc_badges_enabled?,
+            nfc_badge_write_on_checkin_enabled: event.nfc_badge_write_on_checkin_enabled?,
+            groups_enabled: event.groups_enabled?
+          },
+          hotel_scan_context_id: event.hotel_scan_context_id,
+          participant_count: event.participant_events.size
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/v1/series_scoped.rb
+++ b/app/controllers/concerns/api/v1/series_scoped.rb
@@ -1,0 +1,71 @@
+module Api
+  module V1
+    # Resolves the `:series_id` / `:id` path segment for the Series API and
+    # decides who may touch it.
+    #
+    # Two credentials reach these endpoints:
+    #
+    # * a **series API key**, which carries its series with it. It may only
+    #   ever address that one series, so the path segment is checked against
+    #   the token rather than against a policy — and may be given as the
+    #   literal `current` so a client never has to hardcode an id.
+    # * a **user token** (mobile or global), which is authorized through
+    #   EventSeriesPolicy exactly as the web is.
+    module SeriesScoped
+      extend ActiveSupport::Concern
+
+      # Stand-in for "whichever series this key belongs to".
+      CURRENT_SERIES_KEYWORD = "current".freeze
+
+      included do
+        before_action :set_series
+      end
+
+      private
+
+      def set_series
+        identifier = params[:series_id] || params[:id]
+
+        if identifier == CURRENT_SERIES_KEYWORD
+          unless current_series_from_api_key
+            render json: { error: "`current` is only meaningful for a series API key" },
+                   status: :bad_request
+            return
+          end
+
+          @series = current_series_from_api_key
+        else
+          @series = find_series(identifier)
+          return render json: { error: "Series not found" }, status: :not_found if @series.nil?
+        end
+
+        authorize_series
+      end
+
+      # Slugs are what organizers actually have to hand; ids keep the endpoint
+      # usable from stored references. Slugs can't collide with UUIDs, so
+      # trying the id first is unambiguous (a non-UUID string casts to NULL
+      # and simply misses).
+      def find_series(identifier)
+        return nil if identifier.blank?
+
+        EventSeries.find_by(id: identifier) || EventSeries.find_by(slug: identifier)
+      end
+
+      def authorize_series
+        if current_series_from_api_key
+          unless current_series_from_api_key.id == @series.id
+            render json: { error: "API key is not valid for this series" }, status: :forbidden
+          end
+        elsif current_event_from_api_key
+          # An event key is scoped to a single event and has no standing over
+          # the series that event happens to sit in.
+          render json: { error: "An event API key cannot be used on the Series API" },
+                 status: :forbidden
+        else
+          authorize @series, :show?
+        end
+      end
+    end
+  end
+end

--- a/app/models/event_series.rb
+++ b/app/models/event_series.rb
@@ -15,6 +15,7 @@ class EventSeries < ApplicationRecord
   has_many :events, dependent: :nullify
   has_many :series_role_assignments, dependent: :destroy
   has_many :members, through: :series_role_assignments, source: :user
+  has_many :series_api_tokens, dependent: :destroy
 
   RESERVED_SLUGS = %w[new].freeze
 

--- a/app/models/series_api_token.rb
+++ b/app/models/series_api_token.rb
@@ -1,0 +1,85 @@
+# A single API key scoped to one event series.
+#
+# Where an EventApiToken can only ever act on the one event it was issued for,
+# a series token acts on every event inside its series — so a series organizer
+# running a dozen events holds one credential instead of a dozen. It is also
+# the only credential that may create events through the API, and the series it
+# belongs to is the series the new event lands in (callers never choose).
+#
+# Like the other token kinds it authenticates without a user: requests carrying
+# one have no `current_user`, so endpoints that need a person (notes, the full
+# participant payload) stay closed to it.
+class SeriesApiToken < ApplicationRecord
+  self.implicit_order_column = "created_at"
+
+  belongs_to :event_series
+  belongs_to :user, optional: true
+
+  validates :name, presence: true
+  validates :token_digest, presence: true, uniqueness: true
+
+  scope :active, -> { where(revoked_at: nil) }
+
+  # Raw token is exposed once, right after generate/rotate, then never again.
+  attr_accessor :token
+
+  # Prefixes distinguish Attend tokens at a glance and help secret scanners
+  # (GitHub push protection, Revoker) recognize a leaked credential. Shared
+  # with the event and global token kinds on purpose — a scanner only has to
+  # know the one prefix.
+  TOKEN_PREFIX = "attn_".freeze
+
+  # Builds the stored display name by prefixing the creator's email local part,
+  # e.g. creator avery@hackclub.com + "outernet-ops" => "avery@outernet-ops".
+  # Mirrors EventApiToken.build_name so both lists read the same way.
+  def self.build_name(user, raw_name)
+    local = user&.email.to_s.split("@").first.presence
+    cleaned = raw_name.to_s.strip
+    return cleaned if local.blank?
+
+    "#{local}@#{cleaned}"
+  end
+
+  def self.generate_for(event_series, user:, name:)
+    token = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(32)}"
+    series_api_token = create!(
+      event_series: event_series,
+      user: user,
+      name: build_name(user, name),
+      token_digest: Digest::SHA256.hexdigest(token)
+    )
+    series_api_token.token = token
+    series_api_token
+  end
+
+  def self.find_by_token(token)
+    return nil if token.blank?
+
+    digest = Digest::SHA256.hexdigest(token)
+    active.find_by(token_digest: digest)
+  end
+
+  # Issues a fresh secret for this token, keeping its name and history.
+  def rotate!
+    token = "#{TOKEN_PREFIX}#{SecureRandom.urlsafe_base64(32)}"
+    update!(token_digest: Digest::SHA256.hexdigest(token), last_used_at: nil)
+    self.token = token
+    token
+  end
+
+  def revoke!
+    update!(revoked_at: Time.current)
+  end
+
+  def touch_last_used!
+    update_column(:last_used_at, Time.current)
+  end
+
+  def revoked?
+    revoked_at.present?
+  end
+
+  def active?
+    !revoked?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,15 @@ class User < ApplicationRecord
   has_many :mobile_tokens, dependent: :destroy
   has_many :push_tokens, dependent: :destroy
   has_many :passports, dependent: :destroy
+  # API tokens name their creator, and each kind survives that person
+  # differently. Event and series keys belong to the event or series and keep
+  # working with a null creator; a global key's authority *is* its owner's
+  # global-admin status (re-checked per request), so it goes with them. The
+  # matching ON DELETE actions are on the foreign keys too — these are what
+  # make `user.destroy` work, the FKs are the backstop.
+  has_many :event_api_tokens, dependent: :nullify
+  has_many :series_api_tokens, dependent: :nullify
+  has_many :global_api_tokens, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
 

--- a/app/policies/event_series_policy.rb
+++ b/app/policies/event_series_policy.rb
@@ -21,6 +21,13 @@ class EventSeriesPolicy < ApplicationPolicy
     user.series_owner_for?(record)
   end
 
+  # A series API key acts as an event admin on every event in the series and
+  # can create new ones, so issuing it is owner-only — the same bar as handing
+  # someone series membership.
+  def manage_api_tokens?
+    user.series_owner_for?(record)
+  end
+
   def destroy?
     user.global_admin?
   end

--- a/app/views/admin/event_series/show.html.erb
+++ b/app/views/admin/event_series/show.html.erb
@@ -59,6 +59,12 @@
           Members
         <% end %>
       <% end %>
+      <% if policy(@series).manage_api_tokens? %>
+        <%= link_to admin_series_api_tokens_path(@series), class: "inline-flex items-center gap-2 cursor-pointer border border-(--border-strong) bg-(--bg-elev) text-(--text) hover:bg-(--bg-elev-3) hover:text-(--text-strong) text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
+          <svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l6.964-6.964A6 6 0 1121 9z"></path></svg>
+          API Keys
+        <% end %>
+      <% end %>
       <% if policy(@series).update? %>
         <%= link_to edit_admin_series_path(@series), class: "inline-flex items-center gap-2 cursor-pointer border border-(--border-strong) bg-(--bg-elev) text-(--text) hover:bg-(--bg-elev-3) hover:text-(--text-strong) text-sm font-medium py-2 px-4 rounded-md transition-colors" do %>
           <svg class="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>

--- a/app/views/admin/series_api_tokens/index.html.erb
+++ b/app/views/admin/series_api_tokens/index.html.erb
@@ -1,0 +1,91 @@
+<% content_for :title, "#{@series.name} API Keys – Attend" %>
+
+<div class="max-w-5xl mx-auto space-y-6">
+  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+    <div class="flex items-center gap-3 min-w-0">
+      <%= render "admin/events/avatar", event: @series, size: 32, rounded: "rounded-lg" %>
+      <h1 class="text-2xl font-bold text-gray-900 truncate"><%= @series.name %> API Keys</h1>
+    </div>
+    <%= link_to "Members", admin_series_members_path(@series), class: "w-full sm:w-auto text-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors" %>
+  </div>
+
+  <% if flash[:series_api_token] %>
+    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
+      <p class="text-sm font-medium text-amber-900 mb-2">Your new API key</p>
+      <code class="block bg-amber-100 px-3 py-2 rounded text-sm font-mono break-all text-amber-950"><%= flash[:series_api_token] %></code>
+      <p class="text-xs text-amber-700 mt-2">⚠️ Copy this now — it won't be shown again. Send it as <code>Authorization: Bearer &lt;key&gt;</code>.</p>
+    </div>
+  <% end %>
+
+  <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+    <% if @series_api_tokens.any? %>
+      <table class="min-w-full divide-y divide-gray-100">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last used</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-100">
+          <% @series_api_tokens.each do |token| %>
+            <tr>
+              <td class="px-6 py-4">
+                <div class="text-sm font-mono text-gray-900 break-all"><%= token.name %></div>
+                <% if token.user %>
+                  <div class="text-sm text-gray-500">Created by <%= token.user.email %></div>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= token.last_used_at ? "#{time_ago_in_words(token.last_used_at)} ago" : "Never" %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= token.created_at.strftime("%B %d, %Y") %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <div class="flex items-center justify-end gap-4">
+                  <%= button_to "Rotate", rotate_admin_series_api_token_path(@series, token), method: :post,
+                        class: "text-[#ec3750] hover:text-[#d42f46]",
+                        data: { turbo_confirm: "Rotating issues a new secret and invalidates the current one. Integrations using this key will stop working until updated. Continue?" } %>
+                  <%= button_to "Revoke", admin_series_api_token_path(@series, token), method: :delete,
+                        class: "text-gray-500 hover:text-gray-700",
+                        data: { turbo_confirm: "This permanently revokes the key. Any integration using it will stop working. Continue?" } %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="px-6 py-12 text-center">
+        <p class="text-gray-500">No API keys for this series yet.</p>
+        <p class="text-sm text-gray-400 mt-2">One key covers every event in the series — and it's the only credential that can create new ones.</p>
+      </div>
+    <% end %>
+
+    <div class="border-t border-gray-100 bg-gray-50 px-6 py-4">
+      <%= form_with url: admin_series_api_tokens_path(@series), method: :post, class: "flex flex-col sm:flex-row items-stretch sm:items-center gap-2" do |f| %>
+        <div class="flex flex-1 items-center bg-white border border-gray-300 rounded-md overflow-hidden focus-within:ring-2 focus-within:ring-[#ec3750]">
+          <span class="pl-3 text-sm font-mono text-gray-400 select-none"><%= current_user.email.to_s.split("@").first %>@</span>
+          <%= f.text_field :name, placeholder: "series-ops-integration", required: true,
+                class: "flex-1 bg-transparent px-1 py-2 text-sm font-mono focus:outline-none text-gray-900" %>
+        </div>
+        <%= f.submit "Create API key", class: "px-4 py-2 bg-[#d42f46] text-white rounded-md hover:bg-[#b82840] transition-colors cursor-pointer text-sm font-medium" %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <h3 class="text-sm font-medium text-blue-800 mb-2">What a series API key can do</h3>
+    <ul class="text-sm text-blue-700 space-y-1">
+      <li><strong>Create events</strong> in this series, and only this series — the series is taken from the key, not the request</li>
+      <li><strong>Read and update</strong> every event in this series (schedule, location, module toggles)</li>
+      <li><strong>Act as an event API key</strong> on every event in the series: participant lookup, roster, invitations, travel calendar</li>
+      <li><strong>Not</strong> read medical, safeguarding or note data — those need a signed-in person, whatever key you hold</li>
+    </ul>
+    <p class="text-sm text-blue-700 mt-3">
+      Full reference: <%= link_to "API docs", docs_path, class: "underline font-medium" %> (Series section).
+    </p>
+  </div>
+</div>

--- a/app/views/api_token_mailer/revoked.html.erb
+++ b/app/views/api_token_mailer/revoked.html.erb
@@ -8,6 +8,9 @@
   <% if @token_kind == "event" && @event_name.present? %>
     for the event <strong><%= @event_name %></strong>
   <% end %>
+  <% if @token_kind == "series" && @series_name.present? %>
+    for the <strong><%= @series_name %></strong> series
+  <% end %>
   was just <strong>revoked</strong> using the token revocation endpoint.
 </p>
 
@@ -20,7 +23,8 @@
 
 <p>
   <strong>If this was you,</strong> no further action is needed — you can create a
-  new token from the event's Integrations page (or the global API tokens page).
+  new token from the event's Integrations page, the series' API Keys page, or the
+  global API tokens page.
 </p>
 
 <p>

--- a/app/views/api_token_mailer/revoked.text.erb
+++ b/app/views/api_token_mailer/revoked.text.erb
@@ -1,10 +1,10 @@
 Hi,
 
-An Attend API token<%= @token_name.present? ? " (#{@token_name})" : "" %><%= (@token_kind == "event" && @event_name.present?) ? " for the event #{@event_name}" : "" %> was just REVOKED using the token revocation endpoint.
+An Attend API token<%= @token_name.present? ? " (#{@token_name})" : "" %><%= (@token_kind == "event" && @event_name.present?) ? " for the event #{@event_name}" : "" %><%= (@token_kind == "series" && @series_name.present?) ? " for the #{@series_name} series" : "" %> was just REVOKED using the token revocation endpoint.
 
 This happens when someone submits the token's secret value to /api/v1/tokens/revoke -- typically because the token was leaked or exposed. The token no longer works, and any integration using it will stop functioning until you issue a replacement.
 
-If this was you, no further action is needed -- you can create a new token from the event's Integrations page (or the global API tokens page).
+If this was you, no further action is needed -- you can create a new token from the event's Integrations page, the series' API Keys page, or the global API tokens page.
 
 If this was not you, your token secret may have been exposed. Revoking it was the right outcome, but you should review where the token was stored and rotate any related credentials.
 

--- a/config/openapi.yml
+++ b/config/openapi.yml
@@ -16,7 +16,7 @@ info:
     Authorization: Bearer <token>
     ```
 
-    Three kinds of token are accepted:
+    Four kinds of token are accepted:
 
     - **Mobile token** — issued to a signed-in user by `POST /session`. Sets the
       current user. May return the response header
@@ -24,12 +24,36 @@ info:
       call `POST /session/refresh` to rotate it.
     - **Global API token** — a superadmin-issued token. Only honoured while its
       owner is still a global admin. Sets the current user.
-    - **Event API key** — per-event key (`Event#api_key`). Does **not** set a
-      current user, so it only works on the subset of endpoints that don't
-      require one (participant `lookup`, `roster`, `create`, and the travel
-      calendar).
+    - **Series API key** — one key for a whole event series, issued from
+      **Series → API Keys** in the dashboard by a series owner. Does **not** set
+      a current user. It acts as an event API key on *every* event in its
+      series, and it is the only credential that can create an event. See the
+      **Series** section.
+    - **Event API key** — per-event key (`EventApiToken`, or the legacy
+      `Event#api_key`). Does **not** set a current user, so it only works on the
+      subset of endpoints that don't require one (participant `lookup`,
+      `roster`, `create`, and the travel calendar).
 
     Missing or invalid credentials return `401 { "error": "Unauthorized" }`.
+
+    ### What an API key cannot do
+
+    Neither key kind sets a current user, so endpoints that must attribute work
+    to a person stay closed to both — regardless of how broad the key is. A
+    series key is wider in *reach* (more events), never in *depth*:
+
+    | Endpoint | Series key | Event key |
+    | --- | --- | --- |
+    | `GET/POST /series/…` | ✅ its own series | ❌ `403` |
+    | `POST /series/{id}/events` | ✅ its own series | ❌ `403` |
+    | Participant `lookup`, `roster`, `create` | ✅ any event in the series | ✅ its own event |
+    | `GET /events/{id}/travel` | ✅ any event in the series | ✅ its own event |
+    | `GET /events/{id}/participants` (full payload) | ❌ `403` | ❌ `403` |
+    | Notes, scans, scan contexts, Slack blasts, NFC badges | ❌ `403` | ❌ `403` |
+
+    Either key can be revoked without credentials by POSTing its own secret to
+    `POST /tokens/revoke`; Attend emails the key's owner (or, if their account
+    is gone, the series owners) when that happens.
 
     ## Conventions
 
@@ -56,6 +80,11 @@ tags:
     description: Obtain, refresh, and revoke mobile bearer tokens.
   - name: Account
     description: The authenticated user's profile and accessible events.
+  - name: Series
+    description: >-
+      Event series, and the events inside one, addressed with a single series
+      API key. Creating an event lives here — an event has to belong to a
+      series, and only a series key names one unambiguously.
   - name: Participants
     description: Participant registrations for an event.
   - name: Notes
@@ -244,6 +273,293 @@ paths:
               schema: { $ref: "#/components/schemas/Success" }
         "404":
           description: Token not found.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /series:
+    get:
+      tags: [Series]
+      summary: List series
+      description: |
+        With a **series API key**, returns exactly one series — the one the key
+        belongs to. This is how a client discovers its own series when all it
+        has been given is a key.
+
+        With a **user token**, returns every series the user is a member of
+        (all series for a global admin), ordered by name.
+
+        An **event API key** gets an empty list: it has no standing over the
+        series its event happens to sit in.
+      responses:
+        "200":
+          description: Series the caller can see.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  series:
+                    type: array
+                    items: { $ref: "#/components/schemas/Series" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /series/{id}:
+    get:
+      tags: [Series]
+      summary: Get one series
+      description: >-
+        The series plus a compact list of its events. Pass `current` as the id
+        to mean "whichever series this key belongs to".
+      parameters:
+        - $ref: "#/components/parameters/SeriesId"
+      responses:
+        "200":
+          description: The series.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  series: { $ref: "#/components/schemas/SeriesDetail" }
+        "400":
+          description: >-
+            `current` was used with a credential that is not a series API key.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403":
+          description: >-
+            The series API key belongs to a different series, the caller is an
+            event API key, or the user is not a member of this series.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /series/{series_id}/events:
+    get:
+      tags: [Series]
+      summary: List the events in a series
+      description: >-
+        Summary records for every event in the series, earliest start first
+        (events with no start date last).
+      parameters:
+        - $ref: "#/components/parameters/SeriesIdNested"
+      responses:
+        "200":
+          description: The series' events.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items: { $ref: "#/components/schemas/SeriesEventSummary" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+    post:
+      tags: [Series]
+      summary: Create an event in the series
+      description: |
+        **Requires a series API key.** A mobile token, a global API token and an
+        event API key are all refused with `403` — an event has to land in a
+        series, and only a series key names one unambiguously.
+
+        The series is taken from the key, never from the request body. You
+        cannot create an event in another series by passing a different
+        `event_series_id`: a foreign value is rejected with `403` rather than
+        silently overridden (passing the key's own series id or slug is fine and
+        redundant).
+
+        ### Required fields
+
+        `name` and `support_email` — exactly what the web's new-event form
+        requires. `support_email` must be on `@hackclub.com` or
+        `@events.hackclub.com`: it is the from and reply-to address on every
+        participant and guardian email, so it has to be an address Hack Club
+        controls.
+
+        Everything else is optional here because it is optional on the web too:
+
+        - `slug` is generated from `name` when omitted (lowercase, dashes).
+        - `timezone` defaults to `UTC`.
+        - Schedule, location and module fields are collected by the web's setup
+          wizard *after* creation, and may all be sent in this one call instead.
+
+        ### What this does not do
+
+        - **Logo and banner** are not accepted. Upload them from the event's
+          dashboard; multipart uploads are out of scope for this endpoint.
+        - **Setup is not marked complete.** Like the web's create step, the new
+          event is a draft (`setup_complete: false`) until someone finishes the
+          setup wizard — which is also where waiver templates are configured.
+          Registration should not be opened before that.
+        - **Waiver / DocuSeal templates** are not settable here.
+
+        ### Side effects
+
+        The key's owner is given an explicit `event_admin` role on the new
+        event, mirroring what the web does for the series member who creates
+        one. The creation is written to the audit log, attributed to the key's
+        owner with the key's name in the metadata.
+      parameters:
+        - $ref: "#/components/parameters/SeriesIdNested"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [event]
+              properties:
+                event: { $ref: "#/components/schemas/EventCreateAttributes" }
+            examples:
+              minimal:
+                summary: Only what the web requires
+                value:
+                  event:
+                    name: Sunbeam Summer 2027
+                    support_email: sunbeam@hackclub.com
+              fully_configured:
+                summary: Basics, schedule, location and modules in one call
+                value:
+                  event:
+                    name: Sunbeam Summer 2027
+                    slug: sunbeam-summer-2027
+                    support_email: sunbeam@hackclub.com
+                    timezone: Europe/Helsinki
+                    starts_at: "2027-07-12T09:00:00Z"
+                    ends_at: "2027-07-15T17:00:00Z"
+                    registration_open_at: "2027-04-01T00:00:00Z"
+                    registration_close_at: "2027-06-01T00:00:00Z"
+                    venue_name: Kaapelitehdas
+                    location_city: Helsinki
+                    location_country: Finland
+                    location_address: Tallberginkatu 1
+                    travel_enabled: true
+                    accommodation_enabled: true
+                    groups_enabled: true
+      responses:
+        "201":
+          description: Event created, in the key's own series.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/SeriesEvent" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403":
+          description: |
+            One of:
+
+            - the caller is not a series API key (`Creating an event requires a
+              series API key.`)
+            - the key belongs to a different series
+            - the body named a different series in `event_series_id`
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422":
+          description: >-
+            A required field was missing, or the event failed validation (bad
+            support-email domain, slug already taken, reserved slug).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+              examples:
+                missing_required:
+                  value: { error: name and support_email are required }
+                bad_support_email:
+                  value: { error: Support email must be a @hackclub.com or @events.hackclub.com address }
+
+  /series/{series_id}/events/{id}:
+    get:
+      tags: [Series]
+      summary: Get one event in the series
+      description: >-
+        An event outside the series returns `404`, not `403` — from this key's
+        point of view it does not exist.
+      parameters:
+        - $ref: "#/components/parameters/SeriesIdNested"
+        - $ref: "#/components/parameters/SeriesEventId"
+      responses:
+        "200":
+          description: The event.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/SeriesEvent" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404":
+          description: No such event in this series.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+    patch:
+      tags: [Series]
+      summary: Update an event in the series
+      description: |
+        One series key updates any event in its series — that is the point of a
+        series key. Accepts the same fields as the web's event settings form and
+        setup wizard (basics, schedule, location, module toggles); send only the
+        fields you want to change.
+
+        `event_series_id` is not writable: an event cannot be moved out of its
+        series through this API (a value in the body is ignored, not rejected,
+        so a client can round-trip a `GET` response). Moving an event between
+        series is a global-admin action on the web.
+
+        A user token also works here if the caller could update the event on the
+        web — unlike `POST`, which is series-key-only.
+      parameters:
+        - $ref: "#/components/parameters/SeriesIdNested"
+        - $ref: "#/components/parameters/SeriesEventId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [event]
+              properties:
+                event: { $ref: "#/components/schemas/EventUpdateAttributes" }
+            examples:
+              move_the_venue:
+                summary: Change the venue and turn on groups
+                value:
+                  event:
+                    venue_name: Kaapelitehdas
+                    location_address: Tallberginkatu 1
+                    groups_enabled: true
+      responses:
+        "200":
+          description: Event updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/SeriesEvent" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404":
+          description: No such event in this series.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "422":
+          description: The event failed validation.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
@@ -927,7 +1243,9 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      description: Mobile token, global API token, or event API key.
+      description: >-
+        Mobile token, global API token, series API key, or event API key. See
+        Authentication above for which endpoints each one reaches.
     sessionCookie:
       type: apiKey
       in: cookie
@@ -941,6 +1259,30 @@ components:
       required: true
       schema: { type: string }
       description: Event id or slug.
+    SeriesId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+      description: >-
+        Series UUID, series slug, or the literal `current` — the series the
+        calling series API key belongs to. `current` is only valid for a series
+        API key.
+    SeriesIdNested:
+      name: series_id
+      in: path
+      required: true
+      schema: { type: string }
+      description: >-
+        Series UUID, series slug, or the literal `current` — the series the
+        calling series API key belongs to. `current` is only valid for a series
+        API key.
+    SeriesEventId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string }
+      description: Event UUID or slug. Must belong to the series in the path.
     EventIdNumeric:
       name: event_id
       in: path
@@ -1020,6 +1362,181 @@ components:
         location_city: { type: string, nullable: true, example: New York }
         logo_url: { type: string, nullable: true }
         banner_url: { type: string, nullable: true }
+
+    Series:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        slug: { type: string, example: sunbeam }
+        name: { type: string, example: Sunbeam }
+        description: { type: string, nullable: true }
+        contact_email: { type: string, format: email, nullable: true }
+        event_count: { type: integer, example: 4 }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    SeriesDetail:
+      allOf:
+        - $ref: "#/components/schemas/Series"
+        - type: object
+          properties:
+            events:
+              type: array
+              description: The series' events, earliest start first.
+              items:
+                type: object
+                properties:
+                  id: { type: string, format: uuid }
+                  slug: { type: string }
+                  name: { type: string }
+                  starts_at: { type: string, format: date-time, nullable: true }
+
+    SeriesEventSummary:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        slug: { type: string, example: sunbeam-summer-2027 }
+        name: { type: string, example: Sunbeam Summer 2027 }
+        series:
+          type: object
+          properties:
+            id: { type: string, format: uuid, nullable: true }
+            slug: { type: string, nullable: true }
+            name: { type: string, nullable: true }
+        support_email: { type: string, format: email, nullable: true }
+        timezone:
+          type: string
+          nullable: true
+          description: IANA identifier, e.g. `Europe/Helsinki`.
+          example: Europe/Helsinki
+        starts_at: { type: string, format: date-time, nullable: true }
+        ends_at: { type: string, format: date-time, nullable: true }
+        registration_open_at: { type: string, format: date-time, nullable: true }
+        registration_close_at: { type: string, format: date-time, nullable: true }
+        venue_name: { type: string, nullable: true }
+        location_city: { type: string, nullable: true }
+        location_country: { type: string, nullable: true }
+        location_address: { type: string, nullable: true }
+        location_latitude: { type: number, format: double, nullable: true }
+        location_longitude: { type: number, format: double, nullable: true }
+        setup_complete:
+          type: boolean
+          description: >-
+            False until someone finishes the setup wizard on the web. An event
+            created through this API starts as a draft.
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    SeriesEvent:
+      allOf:
+        - $ref: "#/components/schemas/SeriesEventSummary"
+        - type: object
+          properties:
+            modules: { $ref: "#/components/schemas/EventModules" }
+            hotel_scan_context_id: { type: string, format: uuid, nullable: true }
+            participant_count: { type: integer, example: 120 }
+
+    EventModules:
+      type: object
+      description: >-
+        The event's feature toggles, always returned as real booleans (they are
+        stored loosely, so read them from here rather than assuming a shape).
+      properties:
+        freedom_waivers_enabled: { type: boolean }
+        travel_enabled: { type: boolean }
+        visa_options_enabled: { type: boolean }
+        visa_application_url: { type: string, nullable: true }
+        accommodation_enabled: { type: boolean }
+        roommate_preferences_enabled: { type: boolean }
+        guardian_invites_locked: { type: boolean }
+        nfc_badges_enabled: { type: boolean }
+        nfc_badge_write_on_checkin_enabled: { type: boolean }
+        groups_enabled: { type: boolean }
+
+    EventWritableAttributes:
+      type: object
+      description: >-
+        Every event field this API can write — the same set as the web's event
+        settings form plus its setup wizard, minus the series (decided by the
+        key), the logo/banner (uploaded from the dashboard) and the DocuSeal
+        waiver templates (configured in the setup wizard).
+      properties:
+        name: { type: string, example: Sunbeam Summer 2027 }
+        slug:
+          type: string
+          description: >-
+            Lowercase letters, numbers and dashes. Generated from `name` when
+            omitted. Must be unique, and cannot be a reserved word (`new`,
+            `admin`, `api`, `series`, …).
+          example: sunbeam-summer-2027
+        support_email:
+          type: string
+          format: email
+          description: >-
+            Must be `@hackclub.com` or `@events.hackclub.com` — it is the from
+            and reply-to address on every participant and guardian email.
+          example: sunbeam@hackclub.com
+        timezone:
+          type: string
+          description: >-
+            IANA identifier or Rails zone name. Defaults to `UTC`. Zone-less
+            timestamps (`2027-07-12T09:00`) are interpreted in this zone, so
+            send it alongside the schedule; timestamps with an offset or `Z` are
+            taken as given.
+          example: Europe/Helsinki
+        starts_at: { type: string, format: date-time, nullable: true }
+        ends_at: { type: string, format: date-time, nullable: true }
+        registration_open_at: { type: string, format: date-time, nullable: true }
+        registration_close_at: { type: string, format: date-time, nullable: true }
+        venue_name: { type: string, nullable: true, example: Kaapelitehdas }
+        location_city: { type: string, nullable: true, example: Helsinki }
+        location_country: { type: string, nullable: true, example: Finland }
+        location_address:
+          type: string
+          nullable: true
+          description: >-
+            Saving an address, venue, city or country geocodes it in the
+            background, filling in latitude and longitude — so a later `GET` may
+            show coordinates you never sent.
+          example: Tallberginkatu 1
+        location_latitude: { type: number, format: double, nullable: true }
+        location_longitude: { type: number, format: double, nullable: true }
+        freedom_waivers_enabled: { type: boolean, description: "Defaults to true on create." }
+        travel_enabled: { type: boolean, description: "Defaults to true on create." }
+        visa_options_enabled: { type: boolean, description: "Defaults to true on create." }
+        visa_application_url: { type: string, nullable: true }
+        accommodation_enabled: { type: boolean, description: "Defaults to true on create." }
+        roommate_preferences_enabled: { type: boolean, description: "Defaults to true on create." }
+        guardian_invites_locked: { type: boolean }
+        nfc_badges_enabled: { type: boolean }
+        nfc_badge_write_on_checkin_enabled: { type: boolean }
+        groups_enabled: { type: boolean }
+        hotel_scan_context_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Must be a scan context belonging to this event.
+
+    EventCreateAttributes:
+      allOf:
+        - $ref: "#/components/schemas/EventWritableAttributes"
+        - type: object
+          required: [name, support_email]
+          properties:
+            event_series_id:
+              type: string
+              description: >-
+                Not needed — the series comes from the key. If sent it must
+                match the key's own series (id or slug); any other value is
+                rejected with `403`.
+
+    EventUpdateAttributes:
+      allOf:
+        - $ref: "#/components/schemas/EventWritableAttributes"
+        - type: object
+          description: >-
+            Send only the fields you want to change. `event_series_id` is not
+            writable and is ignored if present.
 
     SessionResponse:
       type: object

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,11 @@ Rails.application.routes.draw do
 
     resources :series, controller: "event_series", param: :slug, except: [ :destroy ] do
       resources :members, only: [ :index, :new, :create, :destroy ], controller: "series_members"
+      resources :api_tokens, only: [ :index, :create, :destroy ], controller: "series_api_tokens" do
+        member do
+          post :rotate
+        end
+      end
     end
 
     resources :users, only: [ :index, :show, :new, :create, :edit, :update ] do
@@ -433,6 +438,15 @@ Rails.application.routes.draw do
 
       resources :events, only: [ :index ]
       resources :push_tokens, only: [ :create, :destroy ], param: :token
+
+      # Series API: one key per event series. `:series_id` accepts the series
+      # id, its slug, or the literal `current` (the series the calling key
+      # belongs to). Event creation lives here and nowhere else — it needs a
+      # series, and only a series key names one.
+      resources :series, only: [ :index, :show ], controller: "series", param: :id do
+        resources :events, only: [ :index, :show, :create, :update ],
+                  controller: "series/events", param: :id
+      end
 
       get "travel/search_airports", to: "travel#search_airports"
       post "travel/validate_flight", to: "travel#validate_flight"

--- a/db/migrate/20260903120000_create_series_api_tokens.rb
+++ b/db/migrate/20260903120000_create_series_api_tokens.rb
@@ -1,0 +1,22 @@
+class CreateSeriesApiTokens < ActiveRecord::Migration[8.0]
+  def change
+    create_table :series_api_tokens, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.references :event_series, type: :uuid, null: false, foreign_key: true
+      # The user who created the token. Nullable so a token outlives its
+      # creator's account, but retained for the display name and audit context.
+      # ON DELETE SET NULL rather than plain FK: a deleted organizer must not
+      # take a whole series' integration down with them.
+      t.references :user, type: :uuid, null: true,
+                   foreign_key: { on_delete: :nullify }
+      t.string :name, null: false
+      t.string :token_digest, null: false
+      t.datetime :last_used_at
+      t.datetime :revoked_at
+
+      t.timestamps
+    end
+
+    add_index :series_api_tokens, :token_digest, unique: true
+    add_index :series_api_tokens, [ :event_series_id, :revoked_at ]
+  end
+end

--- a/db/migrate/20260903130000_fix_api_token_user_foreign_keys.rb
+++ b/db/migrate/20260903130000_fix_api_token_user_foreign_keys.rb
@@ -1,0 +1,32 @@
+# Deleting a user used to raise ActiveRecord::InvalidForeignKey if they had ever
+# created an API token, because both token tables pointed at users with a plain
+# FK and no ON DELETE action. Each table gets the action that matches what the
+# token actually is:
+#
+# * event_api_tokens.user_id is already nullable, and the token belongs to an
+#   *event* — the creator is kept for the display name and audit context only.
+#   An event integration must not die because the organizer who set it up left,
+#   so the reference nullifies. (series_api_tokens shipped this way already.)
+#
+# * global_api_tokens.user_id is NOT NULL, and GlobalApiToken validates that
+#   its owner is a global admin — a check Api::V1::BaseController repeats on
+#   every request. A token whose owner is gone therefore cannot authenticate
+#   and cannot even be saved, so it cascades rather than lingering as a row
+#   that no longer validates.
+class FixApiTokenUserForeignKeys < ActiveRecord::Migration[8.0]
+  def up
+    remove_foreign_key :event_api_tokens, :users
+    add_foreign_key :event_api_tokens, :users, on_delete: :nullify
+
+    remove_foreign_key :global_api_tokens, :users
+    add_foreign_key :global_api_tokens, :users, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :event_api_tokens, :users
+    add_foreign_key :event_api_tokens, :users
+
+    remove_foreign_key :global_api_tokens, :users
+    add_foreign_key :global_api_tokens, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -1108,6 +1108,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
     t.index ["user_id"], name: "index_scans_on_user_id"
   end
 
+  create_table "series_api_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "event_series_id", null: false
+    t.datetime "last_used_at"
+    t.string "name", null: false
+    t.datetime "revoked_at"
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id"
+    t.index ["event_series_id", "revoked_at"], name: "index_series_api_tokens_on_event_series_id_and_revoked_at"
+    t.index ["event_series_id"], name: "index_series_api_tokens_on_event_series_id"
+    t.index ["token_digest"], name: "index_series_api_tokens_on_token_digest", unique: true
+    t.index ["user_id"], name: "index_series_api_tokens_on_user_id"
+  end
+
   create_table "series_role_assignments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "event_series_id", null: false
@@ -1382,7 +1397,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
   add_foreign_key "emergency_contacts", "guardian_participant_events"
   add_foreign_key "emergency_contacts", "participant_events"
   add_foreign_key "event_api_tokens", "events"
-  add_foreign_key "event_api_tokens", "users"
+  add_foreign_key "event_api_tokens", "users", on_delete: :nullify
   add_foreign_key "event_role_assignments", "events"
   add_foreign_key "event_role_assignments", "users"
   add_foreign_key "events", "event_series"
@@ -1390,7 +1405,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
   add_foreign_key "events", "users", column: "airtable_config_updated_by_id"
   add_foreign_key "export_templates", "events"
   add_foreign_key "export_templates", "users", column: "created_by_id"
-  add_foreign_key "global_api_tokens", "users"
+  add_foreign_key "global_api_tokens", "users", on_delete: :cascade
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "participant_events"
   add_foreign_key "groups", "events"
@@ -1460,6 +1475,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_120000) do
   add_foreign_key "scans", "participant_events"
   add_foreign_key "scans", "scan_contexts"
   add_foreign_key "scans", "users"
+  add_foreign_key "series_api_tokens", "event_series"
+  add_foreign_key "series_api_tokens", "users", on_delete: :nullify
   add_foreign_key "series_role_assignments", "event_series"
   add_foreign_key "series_role_assignments", "users"
   add_foreign_key "sibling_memberships", "participants"

--- a/spec/factories/event_series.rb
+++ b/spec/factories/event_series.rb
@@ -4,6 +4,13 @@ FactoryBot.define do
     sequence(:slug) { |n| "test-series-#{n}" }
   end
 
+  factory :series_api_token do
+    event_series
+    user
+    name { "test@series-integration" }
+    token_digest { Digest::SHA256.hexdigest(SecureRandom.hex(16)) }
+  end
+
   factory :series_role_assignment do
     user
     event_series

--- a/spec/models/series_api_token_spec.rb
+++ b/spec/models/series_api_token_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe SeriesApiToken, type: :model do
+  let(:series) { create(:event_series) }
+  let(:user) { create(:user, email: "organizer@hackclub.com") }
+
+  describe ".generate_for" do
+    it "returns the raw secret once and stores only its digest" do
+      token = described_class.generate_for(series, user: user, name: "ops")
+
+      expect(token.token).to start_with("attn_")
+      expect(token.token_digest).to eq(Digest::SHA256.hexdigest(token.token))
+      expect(described_class.find(token.id).token).to be_nil
+    end
+
+    it "prefixes the name with the creator's email local part" do
+      token = described_class.generate_for(series, user: user, name: "ops")
+
+      expect(token.name).to eq("organizer@ops")
+    end
+
+    it "keeps the raw name when there is no creator" do
+      token = described_class.generate_for(series, user: nil, name: "ops")
+
+      expect(token.name).to eq("ops")
+    end
+  end
+
+  describe ".find_by_token" do
+    it "finds an active token by its secret" do
+      token = described_class.generate_for(series, user: user, name: "ops")
+
+      expect(described_class.find_by_token(token.token)).to eq(token)
+    end
+
+    it "ignores a revoked token" do
+      token = described_class.generate_for(series, user: user, name: "ops")
+      token.revoke!
+
+      expect(described_class.find_by_token(token.token)).to be_nil
+    end
+
+    it "returns nil for a blank or unknown secret" do
+      expect(described_class.find_by_token(nil)).to be_nil
+      expect(described_class.find_by_token("")).to be_nil
+      expect(described_class.find_by_token("attn_nope")).to be_nil
+    end
+  end
+
+  describe "#rotate!" do
+    it "swaps the secret, keeps the name, and clears the usage stamp" do
+      token = described_class.generate_for(series, user: user, name: "ops")
+      original = token.token
+      token.touch_last_used!
+
+      new_secret = token.rotate!
+
+      expect(new_secret).not_to eq(original)
+      expect(described_class.find_by_token(original)).to be_nil
+      expect(described_class.find_by_token(new_secret)).to eq(token)
+      expect(token.reload.name).to eq("organizer@ops")
+      expect(token.last_used_at).to be_nil
+    end
+  end
+
+  it "outlives its creator's user row" do
+    token = described_class.generate_for(series, user: user, name: "ops")
+    user.destroy!
+
+    expect(token.reload.user).to be_nil
+    expect(described_class.find_by_token(token.token)).to eq(token)
+  end
+
+  it "goes away with its series" do
+    token = described_class.generate_for(series, user: user, name: "ops")
+
+    series.destroy!
+
+    expect(described_class).not_to exist(token.id)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -409,6 +409,75 @@ RSpec.describe User, type: :model do
     end
   end
 
+  # Deleting a user used to raise ActiveRecord::InvalidForeignKey the moment
+  # they had ever issued an API token. Each kind now survives its creator
+  # differently, and the FK carries the matching ON DELETE so a raw SQL delete
+  # behaves the same way as user.destroy.
+  describe "destroying a user who issued API tokens" do
+    let(:user) { create(:user, email: "departing@hackclub.com", global_role: "global_admin") }
+    let(:event) { create(:event) }
+    let(:series) { create(:event_series) }
+
+    it "leaves an event API key working, with its creator nulled" do
+      token = EventApiToken.generate_for(event, user: user, name: "integration")
+      secret = token.token
+
+      user.destroy!
+
+      expect(token.reload.user_id).to be_nil
+      expect(token.name).to eq("departing@integration")
+      expect(EventApiToken.find_by_token(secret)).to eq(token)
+    end
+
+    it "leaves a series API key working, with its creator nulled" do
+      token = SeriesApiToken.generate_for(series, user: user, name: "integration")
+      secret = token.token
+
+      user.destroy!
+
+      expect(token.reload.user_id).to be_nil
+      expect(SeriesApiToken.find_by_token(secret)).to eq(token)
+    end
+
+    # A global key's authority *is* its owner's global-admin standing, which
+    # Api::V1::BaseController re-checks per request — so once they're gone the
+    # key could never authenticate again, and its row cannot even be saved
+    # (GlobalApiToken validates the owner is a global admin).
+    it "takes the owner's global API tokens with them" do
+      token = GlobalApiToken.generate_for(user, name: "superadmin")
+      secret = token.token
+
+      user.destroy!
+
+      expect(GlobalApiToken).not_to exist(token.id)
+      expect(GlobalApiToken.find_by_token(secret)).to be_nil
+    end
+
+    it "destroys a user holding all three kinds at once" do
+      EventApiToken.generate_for(event, user: user, name: "e")
+      SeriesApiToken.generate_for(series, user: user, name: "s")
+      GlobalApiToken.generate_for(user, name: "g")
+
+      expect { user.destroy! }.not_to raise_error
+      expect(User).not_to exist(user.id)
+    end
+
+    # The FK is the backstop for anything that bypasses Active Record.
+    it "applies the same rules to a raw SQL delete" do
+      event_token = EventApiToken.generate_for(event, user: user, name: "e")
+      series_token = SeriesApiToken.generate_for(series, user: user, name: "s")
+      global_token = GlobalApiToken.generate_for(user, name: "g")
+
+      User.connection.execute(
+        User.sanitize_sql_array([ "DELETE FROM users WHERE id = ?", user.id ])
+      )
+
+      expect(event_token.reload.user_id).to be_nil
+      expect(series_token.reload.user_id).to be_nil
+      expect(GlobalApiToken).not_to exist(global_token.id)
+    end
+  end
+
   describe "#placeholder_account?" do
     it "is true for a user created by an admin invite" do
       expect(create(:user).placeholder_account?).to be(true)

--- a/spec/requests/admin/series_api_tokens_spec.rb
+++ b/spec/requests/admin/series_api_tokens_spec.rb
@@ -1,0 +1,137 @@
+require "rails_helper"
+
+RSpec.describe "Admin::SeriesApiTokens", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:series) { create(:event_series, name: "Sunbeam", slug: "sunbeam-tokens") }
+  let(:other_series) { create(:event_series, slug: "moonbeam-tokens") }
+
+  let(:owner) do
+    User.create!(email: "owner-tokens@example.com", name: "Owner").tap do |user|
+      SeriesRoleAssignment.create!(user: user, event_series: series, role: "owner")
+    end
+  end
+  let(:organizer) do
+    User.create!(email: "organizer-tokens@example.com", name: "Organizer").tap do |user|
+      SeriesRoleAssignment.create!(user: user, event_series: series, role: "organizer")
+    end
+  end
+  let(:global_admin) do
+    User.create!(email: "ga-tokens@example.com", name: "Global Admin", global_role: "global_admin")
+  end
+
+  describe "issuing a key" do
+    it "shows the secret exactly once and never again" do
+      sign_in owner
+
+      post admin_series_api_tokens_path(series), params: { name: "series-ops" }
+      raw_secret = flash[:series_api_token]
+      follow_redirect!
+
+      expect(SeriesApiToken.last.name).to eq("owner-tokens@series-ops")
+      expect(raw_secret).to start_with("attn_")
+      expect(response.body).to include(raw_secret)
+
+      # Reloading the page has nothing left to show — only the digest is stored.
+      get admin_series_api_tokens_path(series)
+      expect(response.body).to include("owner-tokens@series-ops")
+      expect(response.body).not_to include(raw_secret)
+    end
+
+    it "rejects a blank name" do
+      sign_in owner
+
+      expect {
+        post admin_series_api_tokens_path(series), params: { name: "  " }
+      }.not_to change(SeriesApiToken, :count)
+
+      expect(flash[:alert]).to match(/enter a name/)
+    end
+  end
+
+  describe "rotating and revoking" do
+    let!(:token) { SeriesApiToken.generate_for(series, user: owner, name: "series-ops") }
+
+    it "rotates in place, keeping the row and its name" do
+      sign_in owner
+      original_digest = token.token_digest
+
+      post rotate_admin_series_api_token_path(series, token)
+
+      expect(token.reload.token_digest).not_to eq(original_digest)
+      expect(token.name).to eq("owner-tokens@series-ops")
+    end
+
+    it "revokes without deleting the row, so the audit trail survives" do
+      sign_in owner
+
+      delete admin_series_api_token_path(series, token)
+
+      expect(token.reload).to be_revoked
+      expect(SeriesApiToken.active).not_to include(token)
+    end
+
+    it "will not touch a key belonging to another series" do
+      elsewhere = SeriesApiToken.generate_for(other_series, user: global_admin, name: "theirs")
+      sign_in owner
+
+      delete admin_series_api_token_path(series, elsewhere)
+
+      # ApplicationController turns the missing scoped lookup into a redirect.
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:alert]).to match(/could not be found/)
+      expect(elsewhere.reload).not_to be_revoked
+    end
+  end
+
+  describe "who may manage keys" do
+    it "lets a series owner in" do
+      sign_in owner
+
+      get admin_series_api_tokens_path(series)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("API Keys")
+    end
+
+    it "lets a global admin in" do
+      sign_in global_admin
+
+      get admin_series_api_tokens_path(series)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # An organizer can already create events through the web; a key that also
+    # works unattended is an owner-level grant, same bar as adding a member.
+    it "turns a series organizer away" do
+      sign_in organizer
+
+      get admin_series_api_tokens_path(series)
+
+      expect(response).to redirect_to(admin_series_path(series))
+      expect(flash[:alert]).to match(/Only series owners/)
+    end
+
+    it "turns away an event admin from another series" do
+      elsewhere_admin = User.create!(email: "outsider-tokens@example.com", name: "Outsider")
+      EventRoleAssignment.create!(user: elsewhere_admin, event: create(:event, event_series: other_series), role: "event_admin")
+      sign_in elsewhere_admin
+
+      get admin_series_api_tokens_path(series)
+
+      expect(response).to have_http_status(:redirect)
+      expect(SeriesApiToken.count).to eq(0)
+    end
+  end
+
+  it "audit-logs every write, since a key is a standing grant" do
+    sign_in owner
+
+    expect {
+      post admin_series_api_tokens_path(series), params: { name: "series-ops" }
+    }.to change(AuditLog, :count).by(1)
+
+    expect(AuditLog.order(:created_at).last.action).to eq("record_create")
+  end
+end

--- a/spec/requests/api/v1/series_events_spec.rb
+++ b/spec/requests/api/v1/series_events_spec.rb
@@ -1,0 +1,360 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Series::Events", type: :request do
+  let(:series) { create(:event_series, name: "Sunbeam", slug: "sunbeam-events-api") }
+  let(:other_series) { create(:event_series, name: "Moonbeam", slug: "moonbeam-events-api") }
+
+  let(:owner) do
+    User.create!(email: "owner-series-events@example.com", name: "Owner").tap do |user|
+      SeriesRoleAssignment.create!(user: user, event_series: series, role: "owner")
+    end
+  end
+  let(:global_admin) do
+    User.create!(email: "ga-series-events@example.com", name: "Global Admin", global_role: "global_admin")
+  end
+
+  let(:series_key) { SeriesApiToken.generate_for(series, user: owner, name: "ops").token }
+  let(:series_headers) { { "Authorization" => "Bearer #{series_key}" } }
+
+  def user_headers(user)
+    { "Authorization" => "Bearer #{MobileToken.generate_for(user).token}" }
+  end
+
+  # Saving an address geocodes it (Event#geocode_location), which the setup
+  # wizard triggers just the same. The Series API doesn't own that behaviour,
+  # so it only needs to not blow up on it.
+  before do
+    stub_request(:get, /geocoder\.hackclub\.com/).to_return(
+      status: 200,
+      body: { lat: 60.1611, lng: 24.8918, formatted_address: "Helsinki, Finland" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    )
+  end
+
+  def valid_attributes(overrides = {})
+    {
+      name: "Sunbeam Summer",
+      support_email: "sunbeam@hackclub.com"
+    }.merge(overrides)
+  end
+
+  describe "POST /series/:series_id/events" do
+    it "creates the event in the key's own series without being told which series" do
+      post "/api/v1/series/current/events", params: { event: valid_attributes }, headers: series_headers
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)["event"]
+      expect(body["name"]).to eq("Sunbeam Summer")
+      expect(body["slug"]).to eq("sunbeam-summer")
+      expect(body["series"]["slug"]).to eq(series.slug)
+      expect(Event.find(body["id"]).event_series_id).to eq(series.id)
+    end
+
+    it "accepts the whole web setup surface — schedule, location, and module toggles — in one call" do
+      post "/api/v1/series/current/events",
+        params: {
+          event: valid_attributes(
+            slug: "sunbeam-autumn",
+            timezone: "Europe/Helsinki",
+            starts_at: "2026-10-01T09:00:00Z",
+            ends_at: "2026-10-04T17:00:00Z",
+            registration_open_at: "2026-09-01T00:00:00Z",
+            registration_close_at: "2026-09-20T00:00:00Z",
+            venue_name: "Kaapelitehdas",
+            location_city: "Helsinki",
+            location_country: "Finland",
+            location_address: "Tallberginkatu 1",
+            travel_enabled: false,
+            groups_enabled: true,
+            nfc_badges_enabled: true
+          )
+        },
+        headers: series_headers
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)["event"]
+      expect(body["timezone"]).to eq("Europe/Helsinki")
+      expect(body["venue_name"]).to eq("Kaapelitehdas")
+      expect(body["starts_at"]).to be_present
+      expect(body["modules"]).to include(
+        "travel_enabled" => false,
+        "groups_enabled" => true,
+        "nfc_badges_enabled" => true
+      )
+    end
+
+    # The web's new-event form marks exactly these two required.
+    it "requires the same fields the web form requires" do
+      post "/api/v1/series/current/events", params: { event: { slug: "no-name" } }, headers: series_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("name and support_email are required")
+    end
+
+    it "enforces the web's support email domain rule" do
+      post "/api/v1/series/current/events",
+        params: { event: valid_attributes(support_email: "team@example.com") },
+        headers: series_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/@hackclub.com or @events.hackclub.com/)
+    end
+
+    it "surfaces model validation failures rather than a 500" do
+      create(:event, slug: "taken-slug", event_series: series)
+
+      post "/api/v1/series/current/events",
+        params: { event: valid_attributes(slug: "taken-slug") },
+        headers: series_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/Slug has already been taken/)
+    end
+
+    it "refuses to create an event in a series the key does not own" do
+      post "/api/v1/series/#{other_series.slug}/events",
+        params: { event: valid_attributes },
+        headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(other_series.events).to be_empty
+    end
+
+    it "rejects a body that names a different series rather than silently overriding it" do
+      post "/api/v1/series/current/events",
+        params: { event: valid_attributes(event_series_id: other_series.id) },
+        headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to match(/only create events in its own series/)
+      expect(Event.where(name: "Sunbeam Summer")).to be_empty
+    end
+
+    it "tolerates a body that names the key's own series" do
+      post "/api/v1/series/current/events",
+        params: { event: valid_attributes(event_series_id: series.id) },
+        headers: series_headers
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it "gives the key's owner an explicit event_admin role, as the web does for its creator" do
+      post "/api/v1/series/current/events", params: { event: valid_attributes }, headers: series_headers
+
+      event = Event.find(JSON.parse(response.body)["event"]["id"])
+      expect(event.event_role_assignments.where(user: owner, role: "event_admin")).to exist
+    end
+
+    it "records an audit log attributed to the key" do
+      expect {
+        post "/api/v1/series/current/events", params: { event: valid_attributes }, headers: series_headers
+      }.to change(AuditLog, :count).by(1)
+
+      log = AuditLog.order(:created_at).last
+      expect(log.action).to eq("record_create")
+      expect(log.actor).to eq(owner)
+      expect(log.metadata["source"]).to eq("series_api")
+      expect(log.metadata["series_api_token_name"]).to eq("owner-series-events@ops")
+    end
+
+    describe "non-series credentials" do
+      it "refuses an event API key" do
+        event = create(:event, event_series: series)
+        key = EventApiToken.generate_for(event, user: owner, name: "event-key").token
+
+        post "/api/v1/series/#{series.slug}/events",
+          params: { event: valid_attributes },
+          headers: { "Authorization" => "Bearer #{key}" }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to match(/cannot be used on the Series API/)
+      end
+
+      it "refuses a series owner's user token" do
+        post "/api/v1/series/#{series.slug}/events",
+          params: { event: valid_attributes },
+          headers: user_headers(owner)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to match(/requires a series API key/)
+      end
+
+      it "refuses a global API token" do
+        key = GlobalApiToken.generate_for(global_admin, name: "superadmin").token
+
+        post "/api/v1/series/#{series.slug}/events",
+          params: { event: valid_attributes },
+          headers: { "Authorization" => "Bearer #{key}" }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to match(/requires a series API key/)
+      end
+
+      it "refuses an unauthenticated request" do
+        post "/api/v1/series/#{series.slug}/events", params: { event: valid_attributes }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /series/:series_id/events" do
+    it "lists only the series' own events" do
+      create(:event, event_series: series, name: "In Series")
+      create(:event, event_series: other_series, name: "Elsewhere")
+      create(:event, name: "Standalone")
+
+      get "/api/v1/series/current/events", headers: series_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["events"].map { |e| e["name"] }).to eq([ "In Series" ])
+    end
+  end
+
+  describe "GET /series/:series_id/events/:id" do
+    let!(:event) { create(:event, event_series: series, slug: "sunbeam-one") }
+
+    it "accepts the event slug or id" do
+      get "/api/v1/series/current/events/#{event.slug}", headers: series_headers
+      expect(response).to have_http_status(:ok)
+
+      get "/api/v1/series/current/events/#{event.id}", headers: series_headers
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["event"]["modules"]).to be_present
+    end
+
+    it "404s an event in another series — from this key it does not exist" do
+      elsewhere = create(:event, event_series: other_series, slug: "moonbeam-one")
+
+      get "/api/v1/series/current/events/#{elsewhere.slug}", headers: series_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s a standalone event" do
+      standalone = create(:event, slug: "standalone-one")
+
+      get "/api/v1/series/current/events/#{standalone.slug}", headers: series_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /series/:series_id/events/:id" do
+    let!(:event) { create(:event, event_series: series, slug: "sunbeam-one", venue_name: "Old Hall") }
+
+    it "updates any event in the series with the one key" do
+      second = create(:event, event_series: series, slug: "sunbeam-two")
+
+      patch "/api/v1/series/current/events/#{event.slug}",
+        params: { event: { venue_name: "New Hall", groups_enabled: true } },
+        headers: series_headers
+      expect(response).to have_http_status(:ok)
+
+      patch "/api/v1/series/current/events/#{second.slug}",
+        params: { event: { venue_name: "Second Hall" } },
+        headers: series_headers
+      expect(response).to have_http_status(:ok)
+
+      expect(event.reload.venue_name).to eq("New Hall")
+      expect(event.groups_enabled?).to be(true)
+      expect(second.reload.venue_name).to eq("Second Hall")
+    end
+
+    it "cannot move an event out of the series" do
+      patch "/api/v1/series/current/events/#{event.slug}",
+        params: { event: { event_series_id: other_series.id, venue_name: "Moved" } },
+        headers: series_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(event.reload.event_series_id).to eq(series.id)
+      expect(event.venue_name).to eq("Moved")
+    end
+
+    it "refuses an event in another series" do
+      elsewhere = create(:event, event_series: other_series, slug: "moonbeam-two", venue_name: "Theirs")
+
+      patch "/api/v1/series/current/events/#{elsewhere.slug}",
+        params: { event: { venue_name: "Hijacked" } },
+        headers: series_headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(elsewhere.reload.venue_name).to eq("Theirs")
+    end
+
+    it "returns validation errors" do
+      patch "/api/v1/series/current/events/#{event.slug}",
+        params: { event: { support_email: "team@example.com" } },
+        headers: series_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(event.reload.support_email).not_to eq("team@example.com")
+    end
+
+    it "lets a series member's user token update too, as the web does" do
+      patch "/api/v1/series/#{series.slug}/events/#{event.slug}",
+        params: { event: { venue_name: "From the web" } },
+        headers: user_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(event.reload.venue_name).to eq("From the web")
+    end
+  end
+
+  # The whole point of the series key: it stands in for a per-event key on
+  # every event in the series, so an organizer holds one credential.
+  describe "acting as an event key across the series" do
+    let!(:event) { create(:event, event_series: series) }
+
+    it "reads the roster of any event in the series" do
+      get "/api/v1/events/#{event.slug}/participants/roster", headers: series_headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "is refused on an event outside the series" do
+      elsewhere = create(:event, event_series: other_series)
+
+      get "/api/v1/events/#{elsewhere.slug}/participants/roster", headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to match(/not valid for this event/)
+    end
+
+    it "is refused on a standalone event" do
+      standalone = create(:event)
+
+      get "/api/v1/events/#{standalone.slug}/participants/roster", headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "still cannot read the full participant payload — that needs a person" do
+      get "/api/v1/events/#{event.slug}/participants", headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to match(/not authorized for this action/)
+    end
+
+    it "still cannot read or write notes" do
+      participant_event = create(:participant_event, event: event)
+
+      get "/api/v1/events/#{event.id}/participants/#{participant_event.id}/notes", headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to match(/not authorized for notes/)
+    end
+
+    it "reads the travel calendar of an event in the series" do
+      get "/api/v1/events/#{event.id}/travel", headers: series_headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "answers 403 rather than raising on an endpoint that needs a person" do
+      get "/api/v1/events/#{event.id}/scan_contexts", headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/api/v1/series_spec.rb
+++ b/spec/requests/api/v1/series_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Series", type: :request do
+  let(:series) { create(:event_series, name: "Sunbeam", slug: "sunbeam-api") }
+  let(:other_series) { create(:event_series, name: "Moonbeam", slug: "moonbeam-api") }
+
+  let(:owner) do
+    User.create!(email: "owner-series-api@example.com", name: "Owner").tap do |user|
+      SeriesRoleAssignment.create!(user: user, event_series: series, role: "owner")
+    end
+  end
+  let(:outsider) { User.create!(email: "outsider-series-api@example.com", name: "Outsider") }
+
+  let(:series_key) { SeriesApiToken.generate_for(series, user: owner, name: "ops").token }
+  let(:series_headers) { { "Authorization" => "Bearer #{series_key}" } }
+
+  def user_headers(user)
+    { "Authorization" => "Bearer #{MobileToken.generate_for(user).token}" }
+  end
+
+  describe "GET /series" do
+    it "returns only the key's own series, so a client can discover it from the key alone" do
+      other_series
+
+      get "/api/v1/series", headers: series_headers
+
+      expect(response).to have_http_status(:ok)
+      slugs = JSON.parse(response.body)["series"].map { |s| s["slug"] }
+      expect(slugs).to eq([ series.slug ])
+    end
+
+    it "returns the caller's series for a user token" do
+      other_series
+
+      get "/api/v1/series", headers: user_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["series"].map { |s| s["slug"] }).to eq([ series.slug ])
+    end
+
+    it "returns nothing for an event API key" do
+      event = create(:event, event_series: series)
+      key = EventApiToken.generate_for(event, user: owner, name: "event-key").token
+
+      get "/api/v1/series", headers: { "Authorization" => "Bearer #{key}" }
+
+      expect(JSON.parse(response.body)["series"]).to be_empty
+    end
+
+    it "rejects a request with no credentials" do
+      get "/api/v1/series"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /series/:id" do
+    it "resolves `current` to the series the key belongs to" do
+      create(:event, event_series: series, name: "Sunbeam One")
+
+      get "/api/v1/series/current", headers: series_headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)["series"]
+      expect(body["slug"]).to eq(series.slug)
+      expect(body["events"].map { |e| e["name"] }).to eq([ "Sunbeam One" ])
+    end
+
+    it "accepts the slug or the id" do
+      get "/api/v1/series/#{series.slug}", headers: series_headers
+      expect(response).to have_http_status(:ok)
+
+      get "/api/v1/series/#{series.id}", headers: series_headers
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "refuses another series to a series key" do
+      get "/api/v1/series/#{other_series.slug}", headers: series_headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to match(/not valid for this series/)
+    end
+
+    it "rejects `current` when the caller is not a series key" do
+      get "/api/v1/series/current", headers: user_headers(owner)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "refuses a user who is not a member of the series" do
+      get "/api/v1/series/#{series.slug}", headers: user_headers(outsider)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "404s an unknown series" do
+      get "/api/v1/series/does-not-exist", headers: series_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "stops working once the key is revoked" do
+      token = SeriesApiToken.generate_for(series, user: owner, name: "short-lived")
+      headers = { "Authorization" => "Bearer #{token.token}" }
+
+      get "/api/v1/series/current", headers: headers
+      expect(response).to have_http_status(:ok)
+
+      token.revoke!
+
+      get "/api/v1/series/current", headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
Closes nothing — new capability.

A series organizer running many events had to juggle one API key per event, and there was no way to create an event through the API at all. This adds `SeriesApiToken`: **one key per series**, issued by a series owner from a new **Series → API Keys** page.

```
GET   /api/v1/series[/:id]
GET   /api/v1/series/:series_id/events[/:id]
POST  /api/v1/series/:series_id/events
PATCH /api/v1/series/:series_id/events/:id
```

`:series_id` accepts a UUID, a slug, or the literal `current` — the series the calling key belongs to — so a client holding only a key never hardcodes an id.

### The three rules

- **Scoped to its own series.** Another series → 403. An event outside the series → 404, not 403: from that key the event does not exist, and saying otherwise would confirm a slug the caller has no standing over.
- **Event creation requires a series key.** Event keys, global API tokens and user tokens are all refused. An event has to land in a series, and only a series key names one unambiguously.
- **The series comes from the key, never the body.** `event_series_id` is not a permitted param, so an event cannot be created in — or moved to — another series. On create, a body naming a *foreign* series is rejected with 403 rather than silently overridden, so a buggy client hears about it; on update it is ignored, so a client can round-trip a `GET` response.

### Parity with the web

Create requires exactly what the web's new-event form requires: `name` and a `@hackclub.com` / `@events.hackclub.com` `support_email`. Slug auto-generates, timezone defaults to UTC — optional there, optional here. Beyond that it accepts everything the rest of the setup wizard collects (schedule, location, module toggles), so one call can produce a fully configured event. Like the web's create step the event starts as a draft; logos and waiver templates still come from the dashboard. The key's owner gets an explicit `event_admin` role, mirroring `ensure_creator_has_admin_role`.

### Wider in reach, not in depth

A series key stands in for an event key on every event in its series (participant `lookup`/`roster`/`create`, travel calendar) and is still refused the full participant payload, notes and scans — those need a signed-in person. The OpenAPI doc carries a table of what each token kind reaches.

While wiring that up: `require_event_access!` called `current_user.can_access_event?` with no nil check, so **any** API key hitting `scans`, `scan_contexts`, `slack_blasts` or NFC crashed with a 500 rather than answering. Pre-existing with event keys; now a 403.

### Also: API token foreign keys

Both token tables pointed at `users` with a plain FK and no `ON DELETE`, so **destroying a user raised `ActiveRecord::InvalidForeignKey` as soon as they had ever issued a token** — despite `EventApiToken#user` being `optional: true` and documented as outliving its creator. Each table now gets the action matching what the token is:

| Table | Action | Why |
| --- | --- | --- |
| `event_api_tokens` | `nullify` | Belongs to the *event*; creator kept for the display name only, so an integration must not die when the organizer who set it up leaves |
| `series_api_tokens` | `nullify` | Same reasoning |
| `global_api_tokens` | `cascade` | `user_id` is `NOT NULL` and the model validates the owner *is* a global admin — a check repeated on every request. A nulled row could neither authenticate nor be saved, so it cascades rather than lingering as a row that no longer validates |

`User` gained the matching `dependent:` options so Active Record and the FKs agree; the FK is the backstop for anything bypassing AR. Specs cover both `user.destroy` and a raw SQL delete.

**Still open, not fixed here:** ~30 other FKs into `users` have the same problem (`notes.author_user_id`, `tickets.*_by_id`, `passports.paired_by_id`, `audit_logs.actor_user_id`, …). Each needs its own judgement about nullify vs cascade, so it is not a one-line sweep.

### Testing

49 new specs, all green; rubocop and brakeman clean. Also verified end-to-end against a local server: creation, every rejection path, cross-series isolation, and create/rotate/revoke through the real UI forms. The migration round-trips (`down` then `up`), which matters because `db:prepare` runs per pod on deploy.

**One thing left for a human:** the new API Keys page has not had a visual pass in light/dark or on mobile. It matches its sibling Members page, but worth an eyeball before merge.
