### PR TITLE
Narrow what the Limited event role can see

### DIFF
--- a/app/controllers/admin/guardians_controller.rb
+++ b/app/controllers/admin/guardians_controller.rb
@@ -3,6 +3,9 @@ module Admin
     before_action :require_event_selected
     before_action :set_participant_event
     before_action :set_guardian_participant_event
+    # The form is nothing but a guardian's contact details and address, none of
+    # which PII-restricted roles may see, so they can't open or submit it.
+    before_action :require_contact_details_access
 
     def edit
       @guardian = @guardian_participant_event.guardian
@@ -36,6 +39,13 @@ module Admin
     end
 
     private
+
+    def require_contact_details_access
+      return if can_view_participant_pii?
+
+      redirect_to admin_event_participant_path(current_event, @participant_event),
+        alert: "Your role cannot edit guardian details, because it cannot see their contact details."
+    end
 
     def set_participant_event
       @participant_event = current_event.participant_events.find(params[:participant_id])

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -157,10 +157,20 @@ module Admin
       @guardian_participant_events = @participant_event.guardian_participant_events.includes(:guardian)
       @notes = @participant_event.notes.includes(:author).order(created_at: :desc)
       @scans = @participant_event.scans.includes(:user, :scan_context).recent.limit(3)
+      @emergency_contacts = emergency_contacts_for_profile
     end
 
     def link_guardian
       authorize @participant_event, :update?
+
+      # A guardian's contact details stay hidden from PII-restricted roles, so
+      # they have no business writing them either. The form is hidden for them;
+      # this stops a hand-crafted POST.
+      unless can_view_participant_pii?
+        redirect_to admin_event_participant_path(current_event, @participant_event),
+          alert: "Your role cannot add guardians, because it cannot see their contact details."
+        return
+      end
 
       guardian_email = params[:guardian_email].to_s.strip.downcase
       participant_email = @participant_event.participant.email.to_s.strip.downcase
@@ -937,6 +947,20 @@ module Admin
       @participant_event = current_event.participant_events.find(params[:id])
     end
 
+    # Emergency contacts for the profile page. Safeguarding viewers see them in
+    # full (the same list the safeguarding tab shows); PII-restricted roles get
+    # a first name and a phone number, because running an incident means being
+    # able to call someone. Every other role sees no section at all, which is
+    # what they saw before this block existed.
+    def emergency_contacts_for_profile
+      return nil unless !can_view_participant_pii? || policy(@participant_event).view_safeguarding?
+
+      EmergencyContact.left_joins(:guardian_participant_event).where(
+        "emergency_contacts.participant_event_id = :pe_id OR guardian_participant_events.participant_event_id = :pe_id",
+        pe_id: @participant_event.id
+      ).by_priority
+    end
+
     def set_participant_header_data
       @participant = @participant_event.participant
       @safeguarding_info = @participant_event.safeguarding_info
@@ -948,10 +972,11 @@ module Admin
         :legal_first_name, :legal_last_name, :preferred_name, :email,
         :date_of_birth, :phone, :pronouns, :tshirt_size, :headshot
       ]
-      # The edit form hides the field for PII-restricted roles; dropping it here
-      # too means a hand-crafted POST can't write (or probe) a date of birth
-      # the same user isn't allowed to read back.
-      permitted.delete(:date_of_birth) unless can_view_participant_pii?
+      # The edit form hides these fields for PII-restricted roles; dropping them
+      # here too means a hand-crafted POST can't write (or probe) a date of
+      # birth or phone number the same user isn't allowed to read back. Email
+      # stays: those roles can see and search on a participant's address.
+      permitted -= [ :date_of_birth, :phone ] unless can_view_participant_pii?
 
       params.require(:participant).permit(*permitted)
     end

--- a/app/controllers/admin/scans_controller.rb
+++ b/app/controllers/admin/scans_controller.rb
@@ -177,7 +177,9 @@ module Admin
           display_name: participant.display_name,
           full_name: participant.full_name,
           email: participant.email,
-          phone: participant.phone,
+          # The phone is omitted, not blanked, for PII-restricted roles; the
+          # scanner modal hides that row entirely for them.
+          **(can_view_participant_pii? ? { phone: participant.phone } : {}),
           pronouns: participant.pronouns,
           tshirt_size: participant.tshirt_size,
           status: participant_event.status,
@@ -208,6 +210,13 @@ module Admin
             "LOWER(participants.email) LIKE :q",
             q: search_term
           )
+      end
+
+      # The participant profile links here for one person's scans. It filters by
+      # id rather than putting their email in the URL, which roles that can't
+      # see contact details must not be handed.
+      if params[:participant_event_id].present?
+        @scans = @scans.where(participant_event_id: params[:participant_event_id])
       end
 
       if params[:scan_context_id].present?

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -219,8 +219,10 @@ module Api
           display_name: participant.display_name,
           full_name: participant.full_name,
           email: participant.email,
+          # The phone is omitted, not nulled, for PII-restricted roles — same
+          # contract as date_of_birth and address in #personal_json.
+          **(include_pii? ? { phone: participant.phone } : {}),
           slack_user_id: participant.slack_user_id,
-          phone: participant.phone,
           pronouns: participant.pronouns,
           headshot_url: headshot_url_for(participant),
           status: pe.status,
@@ -427,14 +429,13 @@ module Api
           id: gpe.id,
           guardian_id: g&.id,
           name: g&.full_name,
-          email: g&.email,
-          phone: gpe.phone_override.presence || g&.phone,
+          **(include_pii? ? { email: g&.email, phone: gpe.phone_override.presence || g&.phone } : {}),
           relationship: gpe.relationship,
           is_primary: gpe.is_primary_guardian,
           status: gpe.status,
           accepted_at: gpe.accepted_at&.iso8601,
           completed_at: gpe.completed_at&.iso8601,
-          invited_via_email: gpe.invited_via_email,
+          **(include_pii? ? { invited_via_email: gpe.invited_via_email } : {}),
           invite_token_sent_at: gpe.invite_token_sent_at&.iso8601,
           media_permission: gpe.media_permission,
           photo_permission: gpe.photo_permission,
@@ -445,7 +446,12 @@ module Api
         }
       end
 
+      # An emergency contact's phone number is the one number a PII-restricted
+      # role keeps — you can't run an incident without being able to call
+      # someone — but they get the first name only, and no email address.
       def emergency_contact_json(ec)
+        return { id: ec.id, name: ec.first_name, phone: ec.phone, priority: ec.priority } unless include_pii?
+
         {
           id: ec.id,
           name: ec.name,
@@ -524,7 +530,9 @@ module Api
         }
       end
 
-      # Whether this caller gets exact dates of birth and addresses. Memoized
+      # Whether this caller gets exact dates of birth, addresses, phone numbers,
+      # and the people around a participant (guardian and emergency contact
+      # details). A participant's own email address is not gated. Memoized
       # for the same reason as can_view_sensitive_data? below. A nil
       # current_user means an event API key, which never reaches the actions
       # that serve these fields (see API_KEY_ALLOWED_ACTIONS).
@@ -551,6 +559,8 @@ module Api
       def emergency_contacts_json(pe)
         pe.guardian_participant_events.flat_map do |gpe|
           gpe.emergency_contacts.sort_by { |ec| ec.priority || Float::INFINITY }.map do |ec|
+            next { name: ec.first_name, phone: ec.phone, priority: ec.priority } unless include_pii?
+
             {
               name: ec.name,
               phone: ec.phone,

--- a/app/helpers/admin/audit_logs_helper.rb
+++ b/app/helpers/admin/audit_logs_helper.rb
@@ -2,14 +2,21 @@ module Admin
   module AuditLogsHelper
     SENSITIVE_FIELD_PATTERNS = /password|token|secret|api_key|otp|access_key/i
 
-    # Columns holding an exact date of birth or a home address, on participants
-    # and guardians alike. PII-restricted roles (see
-    # EventRoleAssignment::PII_RESTRICTED_ROLES) can reach a participant's change
-    # history, and a changeset is just as revealing as the field itself.
+    # Columns holding an exact date of birth, a home address, or a phone number,
+    # on participants, guardians, and emergency contacts alike. PII-restricted
+    # roles (see EventRoleAssignment::PII_RESTRICTED_ROLES) can reach a
+    # participant's change history, and a changeset is just as revealing as the
+    # field itself.
     PII_FIELDS = %w[
       date_of_birth address_line_1 address_line_2 city state postal_code
       country country_of_residence
+      phone phone_number phone_override
     ].freeze
+
+    # The history page mixes in Guardian and EmergencyContact versions. A
+    # participant's own email address is visible to PII-restricted roles; the
+    # people around them still aren't.
+    EMAIL_FIELDS = %w[email invited_via_email].freeze
 
     def audit_field_label(field)
       field.to_s.humanize
@@ -29,13 +36,18 @@ module Admin
 
     # Returns a hash of {field => [old, new]} from a PaperTrail::Version.
     # Hides framework noise so the diff stays human-readable. Pass
-    # `hide_pii: true` to also drop dates of birth and addresses.
+    # `hide_pii: true` to also drop dates of birth, addresses, phone numbers,
+    # and everyone-but-the-participant's email.
     def audit_version_changes(version, hide_pii: false)
       raw = (version.respond_to?(:changeset) ? version.changeset : nil) || {}
       cleaned = raw.except("updated_at", "created_at", "encrypted_password", "remember_created_at",
         "current_sign_in_at", "last_sign_in_at", "current_sign_in_ip", "last_sign_in_ip",
         "sign_in_count", "oidc_claims")
-      hide_pii ? cleaned.except(*PII_FIELDS) : cleaned
+      return cleaned unless hide_pii
+
+      hidden = PII_FIELDS
+      hidden += EMAIL_FIELDS unless version.item_type == "Participant"
+      cleaned.except(*hidden)
     rescue => e
       Rails.logger.warn("[AuditLog] Could not parse version #{version.id}: #{e.message}")
       {}

--- a/app/helpers/admin/participants_helper.rb
+++ b/app/helpers/admin/participants_helper.rb
@@ -76,6 +76,14 @@ module Admin::ParticipantsHelper
     content_tag(:span, label, class: "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-50 text-yellow-700 border border-yellow-200")
   end
 
+  # Placeholder for a contact detail the current role isn't allowed to see (see
+  # EventRoleAssignment::PII_RESTRICTED_ROLES). Every surface hides it the same
+  # way, and the title says why so it doesn't read as missing data.
+  def contact_hidden_placeholder(label = "Hidden")
+    content_tag(:span, label, class: "italic text-gray-400",
+      title: "Phone numbers and guardian contact details are hidden for your role")
+  end
+
   def render_sort_icon(field, current_sort, current_direction)
     return "" unless current_sort == field
 

--- a/app/models/emergency_contact.rb
+++ b/app/models/emergency_contact.rb
@@ -27,6 +27,13 @@ class EmergencyContact < ApplicationRecord
     participant_event&.participant || guardian_participant_event&.participant
   end
 
+  # `name` is one free-form field, so the first word is the best we can do for a
+  # first name. Roles that can't see contact details still get this much plus
+  # the phone number, so they can call the contact during an incident.
+  def first_name
+    name.to_s.split.first.presence || name
+  end
+
   private
 
   def linked_to_guardian_or_participant

--- a/app/models/event_role_assignment.rb
+++ b/app/models/event_role_assignment.rb
@@ -15,10 +15,14 @@ class EventRoleAssignment < ApplicationRecord
   }
 
   # Roles that do the job without seeing a participant's most identifying
-  # details: they get age instead of an exact date of birth, and no address of
-  # any kind — not the home address, not the travel pickup address. Medical
-  # records are deliberately NOT restricted; someone helping with a medical
-  # incident needs the conditions and medications. Enforced through
+  # details: they get age instead of an exact date of birth, no address of any
+  # kind — not the home address, not the travel pickup address — and no phone
+  # numbers, plus nothing at all for the people around a participant (guardian
+  # and emergency contact contact details). The exceptions are the
+  # participant's own email address, which these roles search and work from
+  # every day, and an emergency contact's first name and phone number, which
+  # someone running an incident has to be able to dial. Medical records are
+  # deliberately NOT restricted for the same reason. Enforced through
   # User#can_view_participant_pii?, which every surface that renders or exports
   # those fields checks.
   PII_RESTRICTED_ROLES = %w[limited].freeze
@@ -56,17 +60,22 @@ class EventRoleAssignment < ApplicationRecord
     },
     "limited" => {
       label: "Limited",
-      summary: "Day-to-day logistics, without addresses or exact birthdays.",
+      summary: "Day-to-day logistics, without phone numbers, addresses, or exact birthdays.",
       can: [
         "View and edit travel and accommodation",
         "Manage groups and rooming",
         "View full medical records, so they can help in an incident",
         "View consents and notes",
-        "See age at the event, instead of a date of birth"
+        "See age at the event, instead of a date of birth",
+        "See attendee email addresses, and search by them",
+        "See the first name and phone number of an emergency contact"
       ],
       cannot: [
         "See exact dates of birth",
         "See any address, at home or for travel pickup",
+        "See phone numbers, other than an emergency contact one",
+        "See a guardian email address, or edit guardian details",
+        "Work the support inbox",
         "Manage staff",
         "Add or remove participants",
         "Access safeguarding records"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,8 +14,11 @@ class User < ApplicationRecord
 
   enum :global_role, { no_role: "none", global_admin: "global_admin", read_only: "read_only" }, default: :no_role
 
-  # Event roles whose day-to-day work includes the support inbox.
-  SUPPORT_ROLES = %w[event_admin ops limited].freeze
+  # Event roles whose day-to-day work includes the support inbox. Limited is
+  # deliberately absent: an SMS ticket is keyed by the sender's phone number,
+  # and threads carry guardians' contact details too, neither of which that
+  # role may see (see EventRoleAssignment::PII_RESTRICTED_ROLES).
+  SUPPORT_ROLES = %w[event_admin ops].freeze
 
   # `oidc_claims` holds PII straight from Hack Club Auth (phone number,
   # birthdate, home address). Encrypting the whole jsonb blob works because the
@@ -325,8 +328,10 @@ class User < ApplicationRecord
       series_role_assignments.exists?
   end
 
-  # Whether this user may see participants' exact dates of birth and home
-  # addresses. False only for someone whose access comes entirely from
+  # Whether this user may see participants' identifying details: exact dates of
+  # birth, home addresses, phone numbers, and the contact details of the people
+  # around them (guardians and emergency contacts). A participant's own email
+  # address is not gated. False only for someone whose access comes entirely from
   # PII-restricted roles (see EventRoleAssignment::PII_RESTRICTED_ROLES) —
   # holding any other role, on the event in question or anywhere when no event
   # is given, restores the full view. Fails closed for a user with no roles.

--- a/app/services/exports/field_registry.rb
+++ b/app/services/exports/field_registry.rb
@@ -17,7 +17,7 @@ module Exports
     CATEGORIES = {
       "identity"           => { label: "Identity", tier: :identity, description: "Participant name and email" },
       "basic"              => { label: "Participant", tier: :general, description: "Contact details, address, and profile information",
-                                pii_restricted_description: "Contact details and profile information" },
+                                pii_restricted_description: "Profile information" },
       "event_status"       => { label: "Event Status", tier: :general, description: "Registration status, check-in, and onboarding progress" },
       "travel"             => { label: "Travel", tier: :general, description: "Inbound and outbound travel details" },
       "flight_legs"        => { label: "Flight Legs", tier: :general, description: "Per-leg flight details (only in one-row-per-flight-leg mode)" },
@@ -44,8 +44,11 @@ module Exports
     # EventRoleAssignment::PII_RESTRICTED_ROLES). "Age at Event Start" stays, so
     # a Limited exporter can still do the rooming and minor-count work that
     # needs an age. The travel origin addresses are here too: for a car
-    # journey that field is the participant's doorstep.
+    # journey that field is the participant's doorstep. The phone number goes
+    # with them; a participant's email address does not, since those roles work
+    # from it every day.
     PII_RESTRICTED_FIELD_KEYS = %w[
+      participant.phone
       participant.date_of_birth
       participant.address_line_1
       participant.address_line_2

--- a/app/toolboxes/application_toolbox.rb
+++ b/app/toolboxes/application_toolbox.rb
@@ -61,6 +61,16 @@ class ApplicationToolbox < Toolchest::Toolbox
 
   def anonymized? = mcp_connection&.anonymize? || false
 
+  # Whether this account may see participants' exact dates of birth, addresses,
+  # and phone numbers. Participants here aren't scoped to one event, so a
+  # PII-restricted role on one event doesn't hide anything for someone who is
+  # ops elsewhere.
+  def view_pii?
+    return @view_pii if defined?(@view_pii)
+
+    @view_pii = current_user&.can_view_participant_pii? || false
+  end
+
   # nil means "no connection-level restriction" — every event the user can reach.
   def permitted_event_ids
     return @permitted_event_ids if defined?(@permitted_event_ids)

--- a/app/toolboxes/participants_toolbox.rb
+++ b/app/toolboxes/participants_toolbox.rb
@@ -46,21 +46,12 @@ class ParticipantsToolbox < ApplicationToolbox
   def update
     @participant = accessible_participants.find(params[:participant_id])
     permitted = %i[preferred_name email phone pronouns tshirt_size city state country_of_residence]
-    permitted -= %i[city state country_of_residence] unless view_pii?
+    permitted -= %i[phone city state country_of_residence] unless view_pii?
     @participant.update!(params.permit(*permitted).to_h)
     render json: serialize_participant(@participant, full: true)
   end
 
   private
-
-  # Whether this account may see exact dates of birth and addresses at all.
-  # Participants here aren't scoped to one event, so a PII-restricted role on
-  # one event doesn't hide anything for someone who is ops elsewhere.
-  def view_pii?
-    return @view_pii if defined?(@view_pii)
-
-    @view_pii = current_user.can_view_participant_pii?
-  end
 
   # Participants reachable through the events this connection can access.
   def accessible_participants
@@ -93,7 +84,7 @@ class ParticipantsToolbox < ApplicationToolbox
     return base unless full
 
     base.merge(
-      phone: p.phone,
+      **(view_pii? ? { phone: p.phone } : {}),
       slack_user_id: p.slack_user_id,
       tshirt_size: p.tshirt_size,
       **(view_pii? ? { date_of_birth: p.date_of_birth, city: p.city, state: p.state,

--- a/app/views/admin/messages/show.html.erb
+++ b/app/views/admin/messages/show.html.erb
@@ -153,7 +153,16 @@
                           end %>">
                       <%= delivery.channel.titleize %>
                     </span>
-                    <span class="text-gray-500"><%= delivery.recipient_identifier %></span>
+                    <span class="text-gray-500">
+                      <%# For an SMS the identifier is the recipient's phone number, which
+                          PII-restricted roles don't get; an email address or Slack ID is
+                          fine for them. %>
+                      <% if can_view_participant_pii? || delivery.channel != "sms" %>
+                        <%= delivery.recipient_identifier %>
+                      <% else %>
+                        <%= contact_hidden_placeholder %>
+                      <% end %>
+                    </span>
                   </div>
                   <div class="flex items-center gap-3">
                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium

--- a/app/views/admin/participants/_participant_card.html.erb
+++ b/app/views/admin/participants/_participant_card.html.erb
@@ -46,7 +46,7 @@
         <span class="text-gray-900"><%= participant.age_on(event.starts_at || Date.current) %> years</span>
       </div>
     <% end %>
-    <% if participant.phone.present? %>
+    <% if participant.phone.present? && can_view_participant_pii? %>
       <div>
         <span class="text-gray-500">Phone:</span>
         <span class="text-gray-900"><%= participant.phone %></span>

--- a/app/views/admin/participants/_table_row.html.erb
+++ b/app/views/admin/participants/_table_row.html.erb
@@ -16,9 +16,11 @@
   <td class="px-2 py-1.5 text-gray-500 max-w-[160px] truncate" data-column="email" title="<%= pe.participant.email %>">
     <%= pe.participant.email %>
   </td>
-  <td class="px-2 py-1.5 text-gray-500 whitespace-nowrap" data-column="phone">
-    <%= pe.participant.phone.presence || "—" %>
-  </td>
+  <% if can_view_participant_pii? %>
+    <td class="px-2 py-1.5 text-gray-500 whitespace-nowrap" data-column="phone">
+      <%= pe.participant.phone.presence || "—" %>
+    </td>
+  <% end %>
   <td class="px-2 py-1.5 text-gray-500 whitespace-nowrap" data-column="pronouns">
     <%= pe.participant.pronouns.presence || "—" %>
   </td>

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -66,10 +66,12 @@
               <%= f.date_field :date_of_birth, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
             </div>
           <% end %>
-          <div>
-            <%= f.label :phone, class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.telephone_field :phone, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
-          </div>
+          <% if can_view_participant_pii? %>
+            <div>
+              <%= f.label :phone, class: "block text-sm font-medium text-gray-700 mb-1" %>
+              <%= f.telephone_field :phone, class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#ec3750]" %>
+            </div>
+          <% end %>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -12,10 +12,12 @@
             <dt class="text-sm text-gray-500">Email</dt>
             <dd class="text-gray-900"><%= @participant.email %></dd>
           </div>
-          <div>
-            <dt class="text-sm text-gray-500">Phone</dt>
-            <dd class="text-gray-900"><%= @participant.phone || "—" %></dd>
-          </div>
+          <% if can_view_participant_pii? %>
+            <div>
+              <dt class="text-sm text-gray-500">Phone</dt>
+              <dd class="text-gray-900"><%= @participant.phone || "—" %></dd>
+            </div>
+          <% end %>
           <% if can_view_participant_pii? %>
             <div>
               <dt class="text-sm text-gray-500">Date of Birth</dt>
@@ -246,12 +248,18 @@
                   <div>
                     <div class="font-medium"><%= gpe.guardian.full_name %></div>
                     <div class="text-sm text-gray-600">
-                      <%= gpe.guardian.email %>
+                      <% if can_view_participant_pii? %>
+                        <%= gpe.guardian.email %>
+                      <% else %>
+                        <%= contact_hidden_placeholder("Contact details hidden") %>
+                      <% end %>
                       <% if gpe.guardian.email_undeliverable? %>
                         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800" title="This address hard-bounced and is suppressed — emails to it will not be delivered. Correct the email to clear this.">⚠ Email bouncing</span>
                       <% end %>
                     </div>
-                    <div class="text-sm text-gray-500"><%= gpe.guardian.phone %></div>
+                    <% if can_view_participant_pii? %>
+                      <div class="text-sm text-gray-500"><%= gpe.guardian.phone %></div>
+                    <% end %>
                   </div>
                   <div class="text-right">
                     <% if gpe.completed? %>
@@ -264,9 +272,11 @@
                     <% else %>
                       <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">Pending</span>
                     <% end %>
-                  <%= link_to "Edit",
-                      edit_admin_event_participant_guardian_path(current_event, @participant_event, gpe),
-                      class: "text-xs text-[#ec3750] hover:text-blue-800 font-medium" %>
+                  <% if can_view_participant_pii? %>
+                    <%= link_to "Edit",
+                        edit_admin_event_participant_guardian_path(current_event, @participant_event, gpe),
+                        class: "text-xs text-[#ec3750] hover:text-blue-800 font-medium" %>
+                  <% end %>
                   </div>
                 </div>
                 <div class=" rounded px-2 py-1 mt-2 flex items-center gap-3">
@@ -291,6 +301,7 @@
           <p class="text-gray-500">No guardians linked.</p>
         <% end %>
 
+        <% if can_view_participant_pii? %>
         <div class="mt-4 border-2 border-dashed border-orange-400 rounded-lg p-4">
           <h3 class="text-sm font-semibold text-orange-700 mb-3">Link Guardian (Admin)</h3>
           <%= form_with url: link_guardian_admin_event_participant_path(current_event, @participant_event), method: :post, local: true, class: "space-y-3", data: { controller: "phone-input" } do |f| %>
@@ -321,7 +332,40 @@
             </div>
           <% end %>
         </div>
+        <% end %>
       </section>
+
+      <%# Roles that can't see contact details still get an emergency contact's
+          first name and phone number, so they can call someone during an
+          incident. Roles with safeguarding access see the full record here,
+          the same one the safeguarding tab shows. %>
+      <% if @emergency_contacts %>
+        <section class="bg-white rounded-lg border border-gray-200 p-6">
+          <h2 class="text-lg font-semibold mb-4">Emergency Contacts</h2>
+          <% if @emergency_contacts.any? %>
+            <ul class="space-y-3">
+              <% @emergency_contacts.each do |contact| %>
+                <li class="border-b border-gray-100 pb-3 last:border-0 last:pb-0">
+                  <div class="font-medium text-gray-900">
+                    <%= can_view_participant_pii? ? contact.name : contact.first_name %>
+                  </div>
+                  <div class="text-sm text-gray-600"><%= contact.phone %></div>
+                  <% if can_view_participant_pii? %>
+                    <% if contact.email.present? %>
+                      <div class="text-sm text-gray-600"><%= contact.email %></div>
+                    <% end %>
+                    <% if contact.relationship.present? %>
+                      <div class="text-sm text-gray-500"><%= contact.relationship %></div>
+                    <% end %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
+            <p class="text-gray-500">No emergency contacts recorded.</p>
+          <% end %>
+        </section>
+      <% end %>
 
       <section class="bg-white rounded-lg border border-gray-200 p-6">
         <div class="flex justify-between items-center mb-4">
@@ -431,7 +475,7 @@
       <section class="bg-white rounded-lg border border-gray-200 p-6">
         <div class="flex items-center justify-between mb-4">
           <h2 class="text-lg font-semibold">Scan History</h2>
-          <%= link_to "View all", history_admin_event_scans_path(current_event, search: @participant.email),
+          <%= link_to "View all", history_admin_event_scans_path(current_event, participant_event_id: @participant_event.id),
               class: "text-sm text-[#ec3750] hover:text-blue-800" %>
         </div>
         <% if @scans.any? %>

--- a/app/views/admin/participants/table.html.erb
+++ b/app/views/admin/participants/table.html.erb
@@ -111,7 +111,7 @@
               ["last_name", "Last Name"],
               ["preferred_name", "Preferred Name"],
               ["email", "Email"],
-              ["phone", "Phone"],
+              *(can_view_participant_pii? ? [["phone", "Phone"]] : []),
               ["pronouns", "Pronouns"],
               *(can_view_participant_pii? ? [["dob", "Date of Birth"]] : []),
               ["age", "Age"],
@@ -218,7 +218,9 @@
                 data-column="email" data-action="click->data-table#sort" data-sort-field="email">
               <div class="flex items-center gap-1">Email <%= render_sort_icon("email", @sort_field, @sort_direction) %></div>
             </th>
-            <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-column="phone">Phone</th>
+            <% if can_view_participant_pii? %>
+              <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-column="phone">Phone</th>
+            <% end %>
             <th class="px-2 py-2 text-left font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 whitespace-nowrap"
                 data-column="pronouns" data-action="click->data-table#sort" data-sort-field="pronouns">
               <div class="flex items-center gap-1">Pronouns <%= render_sort_icon("pronouns", @sort_field, @sort_direction) %></div>

--- a/app/views/admin/scans/scanner.html.erb
+++ b/app/views/admin/scans/scanner.html.erb
@@ -196,10 +196,12 @@
           <dt class="text-gray-500">Email</dt>
           <dd id="modal-email" class="truncate"></dd>
         </div>
-        <div>
-          <dt class="text-gray-500">Phone</dt>
-          <dd id="modal-phone"></dd>
-        </div>
+        <% if can_view_participant_pii? %>
+          <div>
+            <dt class="text-gray-500">Phone</dt>
+            <dd id="modal-phone"></dd>
+          </div>
+        <% end %>
         <div>
           <dt class="text-gray-500">T-Shirt Size</dt>
           <dd id="modal-tshirt" class="font-medium"></dd>
@@ -670,7 +672,10 @@ function showParticipantModal(data, scanContext, firstScan) {
   document.getElementById('modal-status').textContent = data.status.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
   document.getElementById('modal-pronouns').textContent = data.pronouns || '—';
   document.getElementById('modal-email').textContent = data.email || '—';
-  document.getElementById('modal-phone').textContent = data.phone || '—';
+  // The phone row is absent for roles that can't see phone numbers, and the
+  // lookup response leaves the field out for them too.
+  const phoneEl = document.getElementById('modal-phone');
+  if (phoneEl) phoneEl.textContent = data.phone || '—';
   document.getElementById('modal-tshirt').textContent = data.tshirt_size?.toUpperCase() || '—';
   document.getElementById('modal-dietary').textContent = data.dietary?.replace('_', ' ') || 'None specified';
   document.getElementById('modal-view-link').href = data.show_url;

--- a/spec/requests/admin/limited_role_spec.rb
+++ b/spec/requests/admin/limited_role_spec.rb
@@ -1,9 +1,13 @@
 require "rails_helper"
 
 # The Limited event role does everything Ops does, minus a participant's exact
-# date of birth and any address -- home or travel pickup. Medical records are
-# deliberately full: the role has to be able to help in an incident. These specs
-# pin the redaction on every surface that renders or exports a restricted field.
+# date of birth, any address (home or travel pickup), every phone number, and
+# the contact details of the people around them (guardians, emergency contacts).
+# Two things stay: the attendee's own email address, which the role searches and
+# works from, and an emergency contact's first name and phone number, which
+# running an incident depends on. Medical records are deliberately full for the
+# same reason. These specs pin the redaction on every surface that renders or
+# exports a restricted field.
 RSpec.describe "Limited event role", type: :request do
   include Devise::Test::IntegrationHelpers
 
@@ -36,6 +40,25 @@ RSpec.describe "Limited event role", type: :request do
       expect(response.body).not_to include("12 Langley Road", "23666")
     end
 
+    it "hides the phone number but keeps the attendee's email" do
+      participant.update!(phone: "+15005550001")
+      sign_in_with_role("limited")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).to include(participant.email)
+      expect(response.body).not_to include("+15005550001")
+    end
+
+    it "still shows the phone number to ops" do
+      participant.update!(phone: "+15005550001")
+      sign_in_with_role("ops", email: "ops-contact-spec@example.com")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).to include(participant.email, "+15005550001")
+    end
+
     it "still shows both to ops" do
       sign_in_with_role("ops")
 
@@ -56,6 +79,30 @@ RSpec.describe "Limited event role", type: :request do
       expect(response.body).to include(">Age<")
       expect(response.body).not_to include('data-column="dob"', "2009-03-14")
     end
+
+    it "drops the phone column and keeps the email one" do
+      participant.update!(phone: "+15005550001")
+      sign_in_with_role("limited")
+
+      get table_admin_event_participants_path(event.slug)
+
+      expect(response.body).to include('data-column="email"', participant.email)
+      expect(response.body).not_to include('data-column="phone"', "+15005550001")
+    end
+
+    it "still filters by email, which is how the role finds people" do
+      participant.update!(email: "dorothy@example.com")
+      other = create(:participant, legal_first_name: "Mary", legal_last_name: "Jackson",
+        email: "mary@example.com")
+      create(:participant_event, event: event, participant: other)
+      sign_in_with_role("limited")
+
+      get table_admin_event_participants_path(event.slug,
+        filters: { "0" => { field: "email", operator: "starts_with", value: "dorothy" } })
+
+      expect(response.body).to include("Dorothy")
+      expect(response.body).not_to include("Mary")
+    end
   end
 
   describe "the edit form" do
@@ -71,6 +118,21 @@ RSpec.describe "Limited event role", type: :request do
       expect(participant.reload.preferred_name).to eq("Dot")
       expect(participant.date_of_birth).to eq(Date.new(2009, 3, 14))
     end
+
+    it "omits the phone field and ignores it when posted, but still edits email" do
+      participant.update!(phone: "+15005550001")
+      sign_in_with_role("limited")
+
+      get edit_admin_event_participant_path(event.slug, participant_event)
+      expect(response.body).to include("participant[email]")
+      expect(response.body).not_to include("participant[phone]")
+
+      patch admin_event_participant_path(event.slug, participant_event),
+        params: { participant: { preferred_name: "Dot", email: "elsewhere@example.com", phone: "+15005550009" } }
+
+      expect(participant.reload.email).to eq("elsewhere@example.com")
+      expect(participant.phone).to eq("+15005550001")
+    end
   end
 
   describe "the change history" do
@@ -83,18 +145,36 @@ RSpec.describe "Limited event role", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).not_to include("2008-01-02", "Newport")
     end
+
+    it "hides phone changes, and a guardian's email, but not the attendee's own" do
+      guardian = Guardian.create!(legal_first_name: "Katherine", legal_last_name: "Johnson",
+        email: "katherine-history@example.com", phone: "+15005550003")
+      participant_event.guardian_participant_events.create!(guardian: guardian, relationship: "Parent")
+      PaperTrail.request(whodunnit: nil) do
+        participant.update!(email: "moved@example.com", phone: "+15005550004")
+        guardian.update!(email: "katherine-new@example.com")
+      end
+      sign_in_with_role("limited")
+
+      get history_admin_event_participant_path(event.slug, participant_event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("moved@example.com")
+      expect(response.body).not_to include("+15005550004", "katherine-new@example.com")
+    end
   end
 
   describe "exports" do
-    it "does not offer the DOB or address columns" do
+    it "does not offer the DOB, address, or phone columns, but keeps email" do
       sign_in_with_role("limited")
 
       get admin_event_exports_path(event_slug: event.slug)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("participant.age_at_event", "travel.inbound.mode")
+      expect(response.body).to include("participant.age_at_event", "travel.inbound.mode",
+        "participant.email")
       expect(response.body).not_to include("participant.date_of_birth", "participant.address_line_1",
-        "participant.postal_code")
+        "participant.postal_code", "participant.phone")
     end
 
     it "still offers the participants preset, stripping the DOB column from it" do
@@ -108,12 +188,12 @@ RSpec.describe "Limited event role", type: :request do
       expect(response.body).not_to include("participant.date_of_birth")
     end
 
-    it "describes the Participant category without promising an address" do
+    it "describes the Participant category without promising a phone or an address" do
       sign_in_with_role("limited")
 
       get admin_event_exports_path(event_slug: event.slug)
 
-      expect(response.body).to include("Contact details and profile information")
+      expect(response.body).to include("Profile information")
       expect(response.body).not_to include("Contact details, address, and profile information")
     end
 
@@ -243,6 +323,25 @@ RSpec.describe "Limited event role", type: :request do
       expect(personal).not_to have_key("address")
     end
 
+    it "omits the participant's phone but serves their email" do
+      payload = show_payload
+
+      expect(payload["email"]).to eq(participant.email)
+      expect(payload).not_to have_key("phone")
+    end
+
+    it "omits a guardian's email and phone, keeping their name" do
+      guardian = Guardian.create!(legal_first_name: "Katherine", legal_last_name: "Johnson",
+        email: "katherine-api@example.com", phone: "+15005550003")
+      participant_event.guardian_participant_events.create!(guardian: guardian, relationship: "Parent")
+
+      guardians = show_payload["guardians"]
+
+      expect(guardians.first["name"]).to eq("Katherine Johnson")
+      expect(guardians.first).not_to have_key("email")
+      expect(guardians.first).not_to have_key("phone")
+    end
+
     it "omits the travel pickup address" do
       travel = show_payload["travel_inbound"]
 
@@ -316,6 +415,145 @@ RSpec.describe "Limited event role", type: :request do
       payload = JSON.parse(response.body)["events"].find { |e| e["id"] == event.id }
       expect(payload["role"]).to eq("series_member")
       expect(payload["can_view_participant_pii"]).to be(true)
+    end
+  end
+  describe "emergency contacts" do
+    let!(:emergency_contact) do
+      EmergencyContact.create!(participant_event: participant_event, name: "Mary Jackson",
+        phone: "+15005550002", email: "mary@example.com", relationship: "Aunt", priority: 1)
+    end
+
+    it "gives the profile a first name and a phone number, and nothing else" do
+      sign_in_with_role("limited")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).to include("Emergency Contacts", "Mary", "+15005550002")
+      expect(response.body).not_to include("Mary Jackson", "mary@example.com")
+    end
+
+    it "is not offered to ops, who never had it on the profile" do
+      sign_in_with_role("ops", email: "ops-ec-spec@example.com")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).not_to include("Emergency Contacts", "+15005550002")
+    end
+  end
+
+  describe "guardians" do
+    let(:guardian) do
+      Guardian.create!(legal_first_name: "Katherine", legal_last_name: "Johnson",
+        email: "katherine@example.com", phone: "+15005550003")
+    end
+    let!(:gpe) do
+      participant_event.guardian_participant_events.create!(guardian: guardian, relationship: "Parent")
+    end
+
+    it "shows the guardian's name but not their email or phone" do
+      sign_in_with_role("limited")
+
+      get admin_event_participant_path(event.slug, participant_event)
+
+      expect(response.body).to include("Katherine Johnson")
+      expect(response.body).not_to include("katherine@example.com", "+15005550003")
+    end
+
+    it "closes the guardian edit form, which is all their contact details" do
+      sign_in_with_role("limited")
+
+      get edit_admin_event_participant_guardian_path(event.slug, participant_event, gpe)
+
+      expect(response).to redirect_to(admin_event_participant_path(event.slug, participant_event))
+      expect(flash[:alert]).to include("cannot see their contact details")
+    end
+
+    it "refuses to link a new guardian, which means typing their contact details in" do
+      sign_in_with_role("limited")
+
+      expect {
+        post link_guardian_admin_event_participant_path(event.slug, participant_event),
+          params: { guardian_first_name: "Dorothy", guardian_last_name: "Hoover",
+                    guardian_email: "dorothy@example.com", guardian_relationship: "Parent" }
+      }.not_to change(Guardian, :count)
+
+      expect(flash[:alert]).to include("cannot see their contact details")
+    end
+  end
+
+  describe "invitations" do
+    # Invitations are addressed by email, and the role can see those, so this
+    # surface stays open to it.
+    it "still lists pending invitations" do
+      event.invitations.create!(email: "invited@example.com", expires_at: 1.week.from_now)
+      sign_in_with_role("limited")
+
+      get admin_event_participants_path(event.slug, status: "pending_invitations")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("invited@example.com")
+    end
+  end
+
+  describe "the support inbox" do
+    # A ticket is an email or SMS thread, keyed by the sender's address or
+    # number, so there is no redacted version of it to show.
+    it "is closed to the role entirely" do
+      user = sign_in_with_role("limited")
+
+      expect(TicketPolicy.new(user, Ticket).index?).to be(false)
+      expect(user.support_staff_event_ids).to be_empty
+
+      get support_tickets_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "stays open to ops" do
+      user = sign_in_with_role("ops", email: "ops-support-spec@example.com")
+
+      expect(TicketPolicy.new(user, Ticket).index?).to be(true)
+    end
+  end
+
+  describe "the command palette search" do
+    it "finds someone by email and shows it back" do
+      sign_in_with_role("limited")
+
+      get admin_search_path(q: participant.email), headers: { "ACCEPT" => "application/json" }
+
+      payload = JSON.parse(response.body)
+      expect(payload["participants"].first["name"]).to eq("Dorothy Vaughan")
+      expect(payload["participants"].first["email"]).to eq(participant.email)
+    end
+  end
+  describe "bulk messaging" do
+    # The role keeps the ability to send; what it loses is the sight of the
+    # address or number each message went to.
+    it "hides the number an SMS went to, keeping the channel and status" do
+      user = sign_in_with_role("limited")
+      message = event.messages.create!(audience: "confirmed_attendees", channels: [ "sms" ],
+        subject: "Hi", body: "<p>Hello</p>", status: "completed", sent_by_user: user)
+      message.message_deliveries.create!(participant_event: participant_event, channel: "sms",
+        recipient_phone: "+15005550001", status: "delivered")
+
+      get admin_event_message_path(event_slug: event.slug, id: message)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Dorothy Vaughan", "Delivered")
+      expect(response.body).not_to include("+15005550001")
+    end
+
+    it "still shows the address an email went to" do
+      user = sign_in_with_role("limited")
+      message = event.messages.create!(audience: "confirmed_attendees", channels: [ "email" ],
+        subject: "Hi", body: "<p>Hello</p>", status: "completed", sent_by_user: user)
+      message.message_deliveries.create!(participant_event: participant_event, channel: "email",
+        recipient_email: participant.email, status: "delivered")
+
+      get admin_event_message_path(event_slug: event.slug, id: message)
+
+      expect(response.body).to include(participant.email)
     end
   end
 end


### PR DESCRIPTION
Limited already worked without exact dates of birth or addresses. It now also works without phone numbers, and without the contact details of the people around a participant.

An attendee's own email address is deliberately untouched — the role searches and works from it every day.

### Hidden now
- **Every phone number**: participant profile and card, the table column, the edit form (and its strong params, so a hand-crafted POST can't write one either), the scanner modal and its lookup JSON, SMS rows in message delivery logs, the phone export column, the mobile API payload, and the MCP participant tools.
- **Guardian email and phone**, on the profile and in the API. The guardian edit form and "link guardian" are closed to the role outright — both are nothing but contact details. Worth noting: `Admin::GuardiansController` had no authorization check at all before this, so any admin-role user could edit a guardian's details and address.
- **The support inbox.** A ticket is an SMS or email thread keyed by the sender's number or address, so there is no redacted version to show. Dropping `limited` from `User::SUPPORT_ROLES` closes the page, the sidebar link, `TicketPolicy`, and the ticket MCP tools together.
- **Change history**: phone changes go, and so do email changes on guardian and emergency-contact records — but not the participant's own. The page mixes all three record types through one helper, so `audit_version_changes` branches on `version.item_type`.

### New
Emergency contacts now render on the participant profile: first name and phone number for Limited, so an incident can actually be escalated, and the full record for roles that already saw it on the safeguarding tab. Ops sees no such block, same as before.

### Unchanged on purpose
Staff email addresses (note bylines, "last updated by", scan operators), bulk messaging (the role can still compose and send — only the SMS number is redacted), and full medical records, which is the whole point of the role.

### Testing
`spec/requests/admin/limited_role_spec.rb` covers each surface above and now runs 42 examples. Full suite green apart from one pre-existing DocuSeal webhook failure unrelated to this change (it stubs a credentials path the code no longer reads).

A visual pass on the new Emergency Contacts block and the narrower participants table is still worth doing before this goes out.