### PR TITLE
Record the series key by id in audit metadata, not by name

### DIFF
--- a/app/controllers/api/v1/series/events_controller.rb
+++ b/app/controllers/api/v1/series/events_controller.rb
@@ -160,7 +160,7 @@ module Api
         end
 
         # API-key requests have no current_user, so the token's owner is the
-        # closest thing to an actor; the token name goes in the metadata either
+        # closest thing to an actor; the key's id goes in the metadata either
         # way so a series key's writes are attributable.
         def log_event_change(action)
           AuditLog.log!(
@@ -174,7 +174,11 @@ module Api
               user_agent: request.user_agent,
               source: "series_api",
               series_id: @series.id,
-              series_api_token_name: current_series_api_token&.name
+              # The key's id, not its name: audit_logs.metadata is stored in
+              # clear text, and an id is provably not a credential. It also
+              # outlives a rename or a rotation, and revoking a key keeps its
+              # row, so this always resolves to the key that acted.
+              series_api_token_id: current_series_api_token&.id
             }.compact
           )
         rescue StandardError => e

--- a/spec/requests/api/v1/series_events_spec.rb
+++ b/spec/requests/api/v1/series_events_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Api::V1::Series::Events", type: :request do
       expect(log.action).to eq("record_create")
       expect(log.actor).to eq(owner)
       expect(log.metadata["source"]).to eq("series_api")
-      expect(log.metadata["series_api_token_name"]).to eq("owner-series-events@ops")
+      expect(log.metadata["series_api_token_id"]).to eq(SeriesApiToken.last.id)
     end
 
     describe "non-series credentials" do


### PR DESCRIPTION
Follow-up to #106.

CodeQL flagged the Series API's audit write as clear-text storage of sensitive data (`rb/clear-text-storage-sensitive-data`, high). It traces the read of `name` off a series API token into `audit_logs.metadata`, which is a plain `jsonb` column. The alert appeared on #106 but CodeQL is not a required check, so auto-merge landed the PR before it was addressed.

The name was never a secret — it is the display label built from the creator's email local part, and the secret itself is only ever held as a SHA256 digest. So this is not a leak. But the metadata does not need the label, and storing the key's **id** instead:

- removes the flagged dataflow entirely, rather than dismissing the alert
- survives a rename or a rotation
- resolves to the key's name, creator and revocation state, since revoking keeps the row

Distinct from the ~14 pre-existing alerts under the same rule, which are the known Active Record `encrypts` blindness (CodeQL cannot see that `date_of_birth`, `medical_text` and friends are encrypted at rest). Those are genuine false positives; this one was better fixed than dismissed.

Spec updated to assert the id. 41 series specs green, rubocop clean.
